### PR TITLE
Fix relay compile

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -10,9 +10,9 @@
     "dotenv-extended": "^1.0.4",
     "enzyme": "^2.8.0",
     "if-env": "^1.0.0",
-    "relay-compiler": "dev",
     "lodash": "^4.17.4",
-    "react-addons-test-utils": "^15.4.2"
+    "react-addons-test-utils": "^15.4.2",
+    "relay-compiler": "1.0.0-rc.2"
   },
   "dependencies": {
     "autoprefixer": "6.5.1",

--- a/web/package.json
+++ b/web/package.json
@@ -79,9 +79,10 @@
     "whatwg-fetch": "2.0.2"
   },
   "scripts": {
-    "start": "node scripts/start.js & yarn run relay",
+    "start":  "yarn run relay && nodemon --watch data/schema.graphql scripts/start.js & yarn run relay:watch",
     "build": "node scripts/build.js",
-    "relay": "relay-compiler --src ./src/ --schema ./data/schema.graphql --watch",
+    "relay": "relay-compiler --src ./src/ --schema ./data/schema.graphql",
+    "relay:watch": "nodemon --watch src/ --watch data/schema.graphql --ignore **/__generated__/**/* --exec \"yarn run relay\"",
     "test": "jest --env=jsdom --coverage && if-env NODE_ENV=test && codecov || echo 'Skipping test coverage logging.'",
     "test:watch": "jest --env=jsdom --watch"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -79,11 +79,11 @@
     "whatwg-fetch": "2.0.2"
   },
   "scripts": {
-    "start": "nodemon --watch data/schema.graphql scripts/start.js",
+    "start": "node scripts/start.js & yarn run relay",
     "build": "node scripts/build.js",
+    "relay": "relay-compiler --src ./src/ --schema ./data/schema.graphql --watch",
     "test": "jest --env=jsdom --coverage && if-env NODE_ENV=test && codecov || echo 'Skipping test coverage logging.'",
-    "test:watch": "jest --env=jsdom --watch",
-    "relay": "relay-compiler --src ./src/ --schema ./data/schema.graphql"
+    "test:watch": "jest --env=jsdom --watch"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/web/scripts/start.js
+++ b/web/scripts/start.js
@@ -275,31 +275,11 @@ function runDevServer(host, port, protocol) {
   });
 }
 
-function runRelayCompiler(callback) {
-  // Compile the relay app.
-  exec('yarn run relay', (error, stdout) => {
-    console.log(stdout);
-    
-    if(error) {
-      console.log('Relay Compiler Failed with; ', error);
-    }
-    
-    function handleTaskDone() {
-      if (callback) {
-        callback();
-      }
-    }
-    handleTaskDone();
-  });
-}
-
 function run(port) {
   var protocol = process.env.HTTPS === 'true' ? "https" : "http";
   var host = process.env.WEB_HOST || 'localhost';
   setupCompiler(host, port, protocol);
-  runRelayCompiler(() => {
-    runDevServer(host, port, protocol);
-  });
+  runDevServer(host, port, protocol);
 }
 
 run(DEFAULT_PORT);

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5969,9 +5969,9 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
-relay-compiler@dev:
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-1.0.0-rc.1.tgz#b5a7194ded2875a7d4d374970753d5d61bf9982b"
+relay-compiler@1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-1.0.0-rc.2.tgz#f9ff5254bfb04c7a2320ad3bd5bd9ee1931028c0"
   dependencies:
     babel-generator "6.24.0"
     babel-runtime "^6.23.0"
@@ -5982,13 +5982,20 @@ relay-compiler@dev:
     fbjs "^0.8.1"
     graphql "^0.9.1"
     immutable "^3.8.1"
-    relay-runtime "1.0.0-rc.1"
+    relay-runtime "1.0.0-rc.2"
     signedsource "^1.0.0"
     yargs "^7.0.2"
 
 relay-runtime@1.0.0-rc.1:
   version "1.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-1.0.0-rc.1.tgz#fc6deb348ec816ca333e6ddf8b2dfb6e2a3ae472"
+  dependencies:
+    babel-runtime "^6.23.0"
+    fbjs "^0.8.1"
+
+relay-runtime@1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-1.0.0-rc.2.tgz#3a90c5912aca3c40cd976e689fda5001f8241827"
   dependencies:
     babel-runtime "^6.23.0"
     fbjs "^0.8.1"


### PR DESCRIPTION
Make `relay-compiler` recompile automatically when the source JS or schema changes. When source JS changes, recompile and let Webpack handle hot reload; when schema changes, just restart the server and recompile (server restart needed for `babel-plugin-relay`).

We're not using Relay compiler's built-in `--watch` because it doesn't watch schema by default.