### PR TITLE
Fix undefined `widgets` props values in widgets settings

### DIFF
--- a/dynamodb/fixtures/UserWidgetsData.json
+++ b/dynamodb/fixtures/UserWidgetsData.json
@@ -1,6 +1,6 @@
 [
   {
-  	"userId": "45bbefbf-63d1-4d36-931e-212fbe2bc3d9",
+  	"userId": "abcdefghijklmno",
     "widgetId": "a8cfd733-639b-49d4-a822-116cc7e5c2e2",
     "enabled": true,
     "visible": false,

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsComponent.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsComponent.js
@@ -48,7 +48,7 @@ class WidgetsSettings extends React.Component {
               key={index}
               user={user}
               appWidget={edge.node}
-              widget={self.state.userWidgets[edge.node.name]}
+              widget={self.state.userWidgets[edge.node.name] || null}
               showError={showError} />)
           })}
         </div>


### PR DESCRIPTION
Fixes error: Expected prop `widget` to be supplied to `Relay(WidgetSettings)`, but got `undefined`.