### PR TITLE
Format MomentJS for 24 Hour Time

### DIFF
--- a/web/src/js/components/Widget/Widgets/Clock/ClockWidgetComponent.js
+++ b/web/src/js/components/Widget/Widgets/Clock/ClockWidgetComponent.js
@@ -45,7 +45,7 @@ class ClockWidget extends React.Component {
     var date = moment().format('dddd, MMMM D')
     var time
     if (format24) {
-      time = moment().format('k:mm')
+      time = moment().format('H:mm')
     } else {
       time = moment().format('h:mm')
     }


### PR DESCRIPTION
Previously the Clock widget used `"k:mm"` to format 24 hour time but the correct format-code is `H`, not `k`. Changed moment format to `"H:mm"` for 24 hour time (starts at 0).

Fixes #152 