### PR TITLE
Try IDP auth redirect instead of popup

### DIFF
--- a/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
+++ b/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
@@ -122,7 +122,7 @@ class FirebaseAuthenticationUI extends React.Component {
     // https://github.com/firebase/firebaseui-web#example-with-all-parameters-used
     this.uiConfig = {
       // Either 'popup' or 'redirect'
-      signInFlow: 'popup',
+      signInFlow: 'redirect',
       // Redirect path after successful sign in, or a callbacks.signInSuccess function
       signInSuccessUrl: dashboardURL,
       // Auth providers


### PR DESCRIPTION
There’s a bug with Google sign-in failing on Firefox.