### PR TITLE
Fix sign-in error within iframe

### DIFF
--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -12,6 +12,7 @@ import {
 } from 'authentication/user'
 import {
   goTo,
+  authMessageURL,
   replaceUrl,
   verifyEmailURL,
   enterUsernameURL,
@@ -19,7 +20,10 @@ import {
   goToLogin
 } from 'navigation/navigation'
 import CreateNewUserMutation from 'mutations/CreateNewUserMutation'
-import { getReferralData } from 'web-utils'
+import {
+  getReferralData,
+  isInIframe
+} from 'web-utils'
 import { isEqual } from 'lodash/lang'
 import {
   accountCreated
@@ -103,7 +107,14 @@ class Authentication extends React.Component {
     const authTokenUser = await getCurrentUser()
     // If the user is not logged in, go to main authentication page.
     if (!authTokenUser) {
-      goToLogin()
+      // If the page is in an iframe (e.g. the user opened it via an iframed
+      // new tab), authentication may not work correctly. Show an intermediary
+      // page that will open a non-iframed auth page.
+      if (isInIframe()) {
+        goTo(authMessageURL)
+      } else {
+        goToLogin()
+      }
     // If the user's email is not verified, ask them to
     // check their email.
     } else if (!authTokenUser.emailVerified) {

--- a/web/src/js/components/Authentication/SignInIframeMessage.js
+++ b/web/src/js/components/Authentication/SignInIframeMessage.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Paper } from 'material-ui'
+import RaisedButton from 'material-ui/RaisedButton'
+import {
+  absoluteUrl,
+  loginURL
+} from 'navigation/navigation'
+
+// This view primarily exists as an intermediary to open
+// the authentication page outside of an iframe, because
+// authentication may not work properly within an iframe.
+// E.g., see: https://github.com/gladly-team/tab/issues/188
+// Most often, users will see this if they are not authenticated
+// and open a new tab; our browser extensions currently iframe
+// the page.
+class SignInIframeMessage extends React.Component {
+  openAuthOutsideIframe () {
+    window.open(absoluteUrl(loginURL), '_top')
+  }
+
+  render () {
+    var buttonLabel = 'SIGN IN'
+    return (
+      <Paper
+        zDepth={1}
+        style={{
+          padding: 24,
+          maxWidth: 400,
+          backgroundColor: '#FFF'
+        }}
+      >
+        <h3>Let's get started!</h3>
+        <p>Sign in to customize your new tab page and raise money for your favorite causes.</p>
+        <span
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            marginTop: 24
+          }}
+        >
+          <RaisedButton
+            label={buttonLabel}
+            primary
+            onClick={this.openAuthOutsideIframe.bind(this)}
+           />
+        </span>
+      </Paper>
+    )
+  }
+}
+
+export default SignInIframeMessage

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -26,6 +26,7 @@ export const dashboardURL = '/newtab/'
 export const loginURL = '/newtab/auth/'
 export const verifyEmailURL = '/newtab/auth/verify-email/'
 export const enterUsernameURL = '/newtab/auth/username/'
+export const authMessageURL = '/newtab/auth/welcome/'
 
 // Settings and profile
 export const settingsURL = '/newtab/settings/widgets/'

--- a/web/src/js/routes/Route.js
+++ b/web/src/js/routes/Route.js
@@ -10,6 +10,7 @@ import AuthenticationView from '../components/Authentication/AuthenticationView'
 import FirebaseAuthenticationUI from '../components/Authentication/FirebaseAuthenticationUI'
 import VerifyEmailMessage from '../components/Authentication/VerifyEmailMessage'
 import EnterUsernameForm from '../components/Authentication/EnterUsernameForm'
+import SignInIframeMessage from '../components/Authentication/SignInIframeMessage'
 import SettingsComponent from '../components/Settings/SettingsComponent'
 import BackgroundSettingsView from '../components/Settings/Background/BackgroundSettingsView'
 import WidgetsSettingsView from '../components/Settings/Widgets/WidgetsSettingsView'
@@ -39,6 +40,7 @@ export default (
         <Route path='action' component={FirebaseAuthenticationUI} />
         <Route path='verify-email' component={VerifyEmailMessage} />
         <Route path='username' component={EnterUsernameForm} />
+        <Route path='welcome' component={SignInIframeMessage} />
       </Route>
       <Redirect from='*' to='/newtab/' />
     </Route>

--- a/web/src/js/utils/__tests__/utils.test.js
+++ b/web/src/js/utils/__tests__/utils.test.js
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 
+import jsdom from 'jsdom'
+
 beforeEach(() => {
   jest.resetModules()
 })
@@ -69,5 +71,22 @@ describe('getting referral data', () => {
     expect(getReferralData()).toEqual({
       referringChannel: '33'
     })
+  })
+})
+
+describe('iframe utils', () => {
+  it('detects when not in iframe', () => {
+    const isInIframe = require('../utils').isInIframe
+    expect(isInIframe()).toBe(false)
+  })
+
+  it('detects when in iframe', () => {
+    // Fake that the top window is some other window
+    jsdom.reconfigureWindow(window, { top: { some: 'other-window' } })
+    const isInIframe = require('../utils').isInIframe
+    expect(isInIframe()).toBe(true)
+
+    // Reset the top window
+    jsdom.reconfigureWindow(window, { top: window.self })
   })
 })

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -112,3 +112,15 @@ export const currencyFormatted = (amount) => {
   s = minus + s
   return s
 }
+
+/**
+ * Determine if the page is currently iframed.
+ * @return {boolean} Whether the page is in an iframe.
+ */
+export const isInIframe = () => {
+  try {
+    return window.self !== window.top
+  } catch (e) {
+    return true
+  }
+}


### PR DESCRIPTION
Fixes #188 

When the app is rendered within an iframe (e.g. within an extension's new tab page) and the user is unauthenticated, show an intermediary view with a button to open the sign-in page outside of the iframe.