### PR TITLE
Redirect the user from newtab page if they’re missing an email

### DIFF
--- a/web/src/js/components/General/AuthUserComponent.js
+++ b/web/src/js/components/General/AuthUserComponent.js
@@ -6,6 +6,7 @@ import {
 } from 'authentication/user'
 import {
   replaceUrl,
+  missingEmailMessageURL,
   verifyEmailURL,
   enterUsernameURL,
   goToLogin
@@ -63,6 +64,10 @@ class AuthUserComponent extends React.Component {
     // User is not logged in.
     if (!user || !user.id) {
       goToLogin()
+    // If the user does not have an email address, show a message
+    // asking them to sign in with a different method.
+    } else if (!user.email) {
+      replaceUrl(missingEmailMessageURL)
     // User is logged in but their email is not verified.
     } else if (!user.emailVerified) {
       replaceUrl(verifyEmailURL)


### PR DESCRIPTION
Due to #151, some users might not have an email address and will see errors on the new tab page. Redirect them to restart the authentication flow.