### PR TITLE
Accurate analytics "account created" event

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -193,6 +193,16 @@ const userType = new GraphQLObjectType({
       type: GraphQLString,
       description: 'ISO datetime string of when the user joined'
     },
+    justCreated: {
+      type: GraphQLBoolean,
+      description: 'Whether or not the user was created during this request;' /
+        'helpful for a "get or create" mutation',
+      resolve: (user, _) => {
+        // The user will only have the 'justCreated' field when it's a
+        // brand new user item
+        return !!user.justCreated
+      }
+    },
     vcCurrent: {
       type: GraphQLInt,
       description: 'User\'s current VC'

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -46,6 +46,7 @@ class User extends BaseModel {
       email: types.string().email().required(),
       username: types.string(),
       joined: types.string().isoDate().required(),
+      justCreated: types.boolean().forbidden(), // only set in app code
       vcCurrent: types.number().integer().default(self.fieldDefaults.vcCurrent),
       vcAllTime: types.number().integer().default(self.fieldDefaults.vcAllTime),
       level: types.number().integer().default(self.fieldDefaults.level),

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -167,6 +167,10 @@ describe('createUser when user does not exist', () => {
 
     const createdItem = await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
+
+    // The user was just created, so set the 'justCreated' field to true
+    expectedUser.justCreated = true
+
     expect(createdItem).toEqual(expectedUser)
   })
 
@@ -216,6 +220,10 @@ describe('createUser when user does not exist', () => {
       userInfo.email, referralData)
     const dbParams = dbQueryMock.mock.calls[0][0]
     expect(dbParams).toEqual(expectedParams)
+
+    // The user was just created, so set the 'justCreated' field to true
+    expectedUser.justCreated = true
+
     expect(createdItem).toEqual(expectedUser)
   })
 })

--- a/graphql/database/users/createUser.js
+++ b/graphql/database/users/createUser.js
@@ -85,6 +85,10 @@ const createUser = async (userContext, userId, email, referralData = null) => {
       }
     }
   }
+
+  // Add the 'justCreated' field so the client can know it's
+  // a brand new user
+  returnedUser.justCreated = true
   return returnedUser
 }
 

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -339,6 +339,7 @@ type User implements Node {
 
   # ISO datetime string of when the user joined
   joined: String
+  justCreated: Boolean
 
   # User's current VC
   vcCurrent: Int

--- a/web/src/js/mutations/CreateNewUserMutation.js
+++ b/web/src/js/mutations/CreateNewUserMutation.js
@@ -10,6 +10,7 @@ const mutation = graphql`
         id
         email
         username
+        justCreated
       }
     }
   }


### PR DESCRIPTION
Previously, we fired the analytics "account created" event every time a user signed in, regardless of whether they were truly a brand new user or were just a returning user. This should only fire the event for brand new users.