### PR TITLE
Change "account created" analytics event trigger

### DIFF
--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -26,9 +26,6 @@ import {
   isInIframe
 } from 'web-utils'
 import { isEqual } from 'lodash/lang'
-import {
-  accountCreated
-} from 'analytics/logEvent'
 
 // Handle the authentication flow:
 //   check if current user is fully authenticated and redirect
@@ -171,12 +168,6 @@ class Authentication extends React.Component {
     // Get or create the user
     return this.createNewUser(currentUser.uid, currentUser.email)
       .then((createdOrFetchedUser) => {
-        // Log the sign-up to analytics, but only if the user
-        // was just created. Do not log for returning users.
-        if (createdOrFetchedUser.justCreated) {
-          accountCreated()
-        }
-
         // Check if the user has verified their email.
         // Note: later versions of firebaseui-web might support mandatory
         // email verification:
@@ -217,8 +208,6 @@ class Authentication extends React.Component {
    *   email argument
    * @returns {string|null} user.username - The user's username, if already
    *   set; or null, if not yet set
-   * @returns {boolean} user.justCreated - Whether the user item was created
-   *   in this request; false if the user already existed
    */
   createNewUser (userId, email) {
     const referralData = getReferralData()

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -24,12 +24,8 @@ import {
   getReferralData,
   isInIframe
 } from 'web-utils'
-import {
-  accountCreated
-} from 'analytics/logEvent'
 import CreateNewUserMutation from 'mutations/CreateNewUserMutation'
 
-jest.mock('analytics/logEvent')
 jest.mock('authentication/user')
 jest.mock('authentication/firebaseConfig') // mock the Firebase app initialization
 jest.mock('mutations/CreateNewUserMutation')
@@ -401,108 +397,6 @@ describe('Authentication.js tests', function () {
     component.onSignInSuccess(mockFirebaseUserInstance,
       mockFirebaseCredential, mockFirebaseDefaultRedirectURL)
     expect(goTo).toHaveBeenCalledWith(missingEmailMessageURL)
-  })
-
-  it('after sign-in and creating a brand new user, calls analytics "account created" event', async () => {
-    expect.assertions(1)
-    const Authentication = require('../Authentication').default
-
-    // Args for onSignInSuccess
-    const mockFirebaseUserInstance = {
-      displayName: '',
-      email: 'foo@bar.com',
-      emailVerified: true,
-      isAnonymous: false,
-      metadata: {},
-      phoneNumber: null,
-      photoURL: null,
-      providerData: {},
-      providerId: 'some-id',
-      refreshToken: 'xyzxyz',
-      uid: 'abc123'
-    }
-    const mockFirebaseCredential = {}
-    const mockFirebaseDefaultRedirectURL = ''
-
-    const wrapper = shallow(
-      <Authentication
-        location={mockLocationData}
-        user={mockUserData}
-        fetchUser={jest.fn()}
-        />
-    )
-    const component = wrapper.instance()
-
-    // Mock a response from new user creation
-    CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, onCompleted, onError) => {
-        onCompleted({
-          createNewUser: {
-            id: 'abc123',
-            email: 'foo@bar.com',
-            username: 'fooismyname',
-            justCreated: true
-          }
-        })
-      }
-    )
-
-    // Mock a call from FirebaseUI after user signs in
-    await component.onSignInSuccess(mockFirebaseUserInstance,
-      mockFirebaseCredential, mockFirebaseDefaultRedirectURL)
-
-    expect(accountCreated).toHaveBeenCalledTimes(1)
-  })
-
-  it('after sign-in for a *returning* user, we do *not* call the analytics "account created" event', async () => {
-    expect.assertions(1)
-    const Authentication = require('../Authentication').default
-
-    // Args for onSignInSuccess
-    const mockFirebaseUserInstance = {
-      displayName: '',
-      email: 'foo@bar.com',
-      emailVerified: true,
-      isAnonymous: false,
-      metadata: {},
-      phoneNumber: null,
-      photoURL: null,
-      providerData: {},
-      providerId: 'some-id',
-      refreshToken: 'xyzxyz',
-      uid: 'abc123'
-    }
-    const mockFirebaseCredential = {}
-    const mockFirebaseDefaultRedirectURL = ''
-
-    const wrapper = shallow(
-      <Authentication
-        location={mockLocationData}
-        user={mockUserData}
-        fetchUser={jest.fn()}
-        />
-    )
-    const component = wrapper.instance()
-
-    // Mock a response from new user creation
-    CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, onCompleted, onError) => {
-        onCompleted({
-          createNewUser: {
-            id: 'abc123',
-            email: 'foo@bar.com',
-            username: 'fooismyname',
-            justCreated: false // Note that the user already existed
-          }
-        })
-      }
-    )
-
-    // Mock a call from FirebaseUI after user signs in
-    await component.onSignInSuccess(mockFirebaseUserInstance,
-      mockFirebaseCredential, mockFirebaseDefaultRedirectURL)
-
-    expect(accountCreated).not.toHaveBeenCalled()
   })
 
   it('after sign-in, send email verification if email is not verified', async () => {

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -8,6 +8,7 @@ import WidgetsContainer from '../Widget/WidgetsContainer'
 import CampaignBaseContainer from '../Campaign/CampaignBaseContainer'
 import Ad from '../Ad/Ad'
 import LogTab from './LogTabContainer'
+import LogAccountCreation from './LogAccountCreationContainer'
 import CircleIcon from 'material-ui/svg-icons/image/lens'
 import {
   dashboardIconInactiveColor,
@@ -135,6 +136,7 @@ class Dashboard extends React.Component {
             display: 'block'
           }} />
         { user ? <LogTab user={user} /> : null }
+        { user ? <LogAccountCreation user={user} /> : null }
         { errorMessage
           ? <ErrorMessage message={errorMessage}
             onRequestClose={this.clearError.bind(this)} />

--- a/web/src/js/components/Dashboard/DashboardContainer.js
+++ b/web/src/js/components/Dashboard/DashboardContainer.js
@@ -20,6 +20,7 @@ export default createFragmentContainer(Dashboard, {
       ...UserBackgroundImageContainer_user
       ...UserMenuContainer_user
       ...LogTabContainer_user
+      ...LogAccountCreationContainer_user
       ...CampaignBaseContainer_user
     }
   `

--- a/web/src/js/components/Dashboard/LogAccountCreationComponent.js
+++ b/web/src/js/components/Dashboard/LogAccountCreationComponent.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import {
+  accountCreated
+} from 'analytics/logEvent'
+
+class LogAccountCreation extends React.Component {
+  componentDidMount () {
+    const { user } = this.props
+
+    // If this is the user's first tab, log the "accountCreated"
+    // analytics event. It's a little inefficient to fetch the user's
+    // lifetime tabs count just for this purpose, so we may eventually
+    // want to move this analytics event to another trigger.
+    if (user.tabs === 0) {
+      accountCreated()
+    }
+  }
+
+  render () {
+    return null
+  }
+}
+
+LogAccountCreation.propTypes = {
+  user: PropTypes.shape({
+    tabs: PropTypes.number.isRequired
+  }).isRequired
+}
+
+export default LogAccountCreation

--- a/web/src/js/components/Dashboard/LogAccountCreationContainer.js
+++ b/web/src/js/components/Dashboard/LogAccountCreationContainer.js
@@ -1,0 +1,14 @@
+import {
+  createFragmentContainer,
+  graphql
+} from 'react-relay/compat'
+
+import LogAccountCreation from './LogAccountCreationComponent'
+
+export default createFragmentContainer(LogAccountCreation, {
+  user: graphql`
+    fragment LogAccountCreationContainer_user on User {
+      tabs
+    }
+  `
+})

--- a/web/src/js/components/Dashboard/__tests__/LogAccountCreationComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogAccountCreationComponent.test.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+
+import React from 'react'
+import {
+  shallow
+} from 'enzyme'
+
+import {
+  accountCreated
+} from 'analytics/logEvent'
+
+jest.mock('analytics/logEvent')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('LogAccountCreation component', function () {
+  it('logs the "account creation" analytics event when this is the user\'s first tab', function () {
+    const LogAccountCreationComponent = require('../LogAccountCreationComponent').default
+    const mockUserData = {
+      tabs: 0
+    }
+    shallow(
+      <LogAccountCreationComponent
+        user={mockUserData}
+        />
+    )
+    expect(accountCreated).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not log the "account creation" analytics event when this is not the user\'s first tab', function () {
+    const LogAccountCreationComponent = require('../LogAccountCreationComponent').default
+    const mockUserData = {
+      tabs: 1
+    }
+    shallow(
+      <LogAccountCreationComponent
+        user={mockUserData}
+        />
+    )
+    expect(accountCreated).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/js/mutations/CreateNewUserMutation.js
+++ b/web/src/js/mutations/CreateNewUserMutation.js
@@ -10,7 +10,6 @@ const mutation = graphql`
         id
         email
         username
-        justCreated
       }
     }
   }


### PR DESCRIPTION
Fire the "account created" event when a user opens their first tab. Previously, we fired this after account creation.