### PR TITLE
Delete UserRevenueLog table

### DIFF
--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -63,15 +63,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      userRevenueLogTable:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # userRevenueLogTable:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
       backgroundImagesTable:
         read:
           minimum: 1
@@ -155,15 +155,15 @@ custom:
           minimum: 5
           maximum: 9001
           usage: 0.60
-      userRevenueLogTable:
-        read:
-          minimum: 1
-          maximum: 9001
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 9001
-          usage: 0.60
+      # userRevenueLogTable:
+      #   read:
+      #     minimum: 1
+      #     maximum: 9001
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 9001
+      #     usage: 0.60
       backgroundImagesTable:
         read:
           minimum: 5
@@ -250,15 +250,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.vcDonationLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.vcDonationLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.vcDonationLogTable.write.usage}
-    - table: userRevenueLogTable
-      read:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.read.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.read.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.read.usage}
-      write:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.usage}
+    # - table: userRevenueLogTable
+    #   read:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.read.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.read.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.read.usage}
+    #   write:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.usage}
     - table: backgroundImagesTable
       read:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.backgroundImagesTable.read.minimum}
@@ -389,23 +389,23 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    userRevenueLogTable:  
-      Type: AWS::DynamoDB::Table
-      Properties:  
-        TableName: UserRevenueLog-${self:provider.stage}
-        KeySchema:
-          - AttributeName: userId
-            KeyType: HASH
-          - AttributeName: timestamp
-            KeyType: RANGE
-        AttributeDefinitions:
-          - AttributeName: userId
-            AttributeType: S
-          - AttributeName: timestamp
-            AttributeType: S
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+    # userRevenueLogTable:  
+    #   Type: AWS::DynamoDB::Table
+    #   Properties:  
+    #     TableName: UserRevenueLog-${self:provider.stage}
+    #     KeySchema:
+    #       - AttributeName: userId
+    #         KeyType: HASH
+    #       - AttributeName: timestamp
+    #         KeyType: RANGE
+    #     AttributeDefinitions:
+    #       - AttributeName: userId
+    #         AttributeType: S
+    #       - AttributeName: timestamp
+    #         AttributeType: S
+    #     ProvisionedThroughput:
+    #       ReadCapacityUnits: 1
+    #       WriteCapacityUnits: 1
 
     backgroundImagesTable:  
       Type: AWS::DynamoDB::Table

--- a/graphql/database/userRevenue/__tests__/logRevenue.test.js
+++ b/graphql/database/userRevenue/__tests__/logRevenue.test.js
@@ -1,17 +1,17 @@
 /* eslint-env jest */
 
-import moment from 'moment'
-import UserRevenueModel from '../UserRevenueModel'
-import logRevenue from '../logRevenue'
+// import moment from 'moment'
+// import UserRevenueModel from '../UserRevenueModel'
+// import logRevenue from '../logRevenue'
 import {
-  addTimestampFieldsToItem,
-  getMockUserContext,
+  // addTimestampFieldsToItem,
+  // getMockUserContext,
   mockDate
 } from '../../test-utils'
 
 jest.mock('../../databaseClient')
 
-const userContext = getMockUserContext()
+// const userContext = getMockUserContext()
 const mockCurrentTime = '2017-06-22T01:13:28.000Z'
 
 beforeAll(() => {
@@ -25,34 +25,38 @@ afterAll(() => {
 })
 
 describe('logRevenue', () => {
-  test('calls DB to create item', async () => {
-    const userId = userContext.id
-    const userRevenueCreate = jest.spyOn(UserRevenueModel, 'create')
-    await logRevenue(userContext, userId, 0.0172, 2468)
-
-    expect(userRevenueCreate).toHaveBeenLastCalledWith(
-      userContext,
-      addTimestampFieldsToItem({
-        userId: userId,
-        timestamp: moment.utc().toISOString(),
-        revenue: 0.0172,
-        dfpAdvertiserId: 2468
-      })
-    )
+  test('foo', () => {
+    expect(true).toBe(true)
   })
 
-  test('dfpAdvertiserId is optional', async () => {
-    const userId = userContext.id
-    const userRevenueCreate = jest.spyOn(UserRevenueModel, 'create')
-    await logRevenue(userContext, userId, 0.0172)
+  // test('calls DB to create item', async () => {
+  //   const userId = userContext.id
+  //   const userRevenueCreate = jest.spyOn(UserRevenueModel, 'create')
+  //   await logRevenue(userContext, userId, 0.0172, 2468)
 
-    expect(userRevenueCreate).toHaveBeenLastCalledWith(
-      userContext,
-      addTimestampFieldsToItem({
-        userId: userId,
-        timestamp: moment.utc().toISOString(),
-        revenue: 0.0172
-      })
-    )
-  })
+  //   expect(userRevenueCreate).toHaveBeenLastCalledWith(
+  //     userContext,
+  //     addTimestampFieldsToItem({
+  //       userId: userId,
+  //       timestamp: moment.utc().toISOString(),
+  //       revenue: 0.0172,
+  //       dfpAdvertiserId: 2468
+  //     })
+  //   )
+  // })
+
+  // test('dfpAdvertiserId is optional', async () => {
+  //   const userId = userContext.id
+  //   const userRevenueCreate = jest.spyOn(UserRevenueModel, 'create')
+  //   await logRevenue(userContext, userId, 0.0172)
+
+  //   expect(userRevenueCreate).toHaveBeenLastCalledWith(
+  //     userContext,
+  //     addTimestampFieldsToItem({
+  //       userId: userId,
+  //       timestamp: moment.utc().toISOString(),
+  //       revenue: 0.0172
+  //     })
+  //   )
+  // })
 })

--- a/graphql/database/userRevenue/logRevenue.js
+++ b/graphql/database/userRevenue/logRevenue.js
@@ -1,6 +1,6 @@
 
-import moment from 'moment'
-import UserRevenueModel from './UserRevenueModel'
+// import moment from 'moment'
+// import UserRevenueModel from './UserRevenueModel'
 
 /**
  * Log revenue earned by a user.
@@ -12,16 +12,16 @@ import UserRevenueModel from './UserRevenueModel'
  * @return {null}
  */
 const logRevenue = async (userContext, userId, revenue, dfpAdvertiserId = null) => {
-  try {
-    await UserRevenueModel.create(userContext, {
-      userId: userId,
-      timestamp: moment.utc().toISOString(),
-      revenue: revenue,
-      ...dfpAdvertiserId && { dfpAdvertiserId: dfpAdvertiserId }
-    })
-  } catch (e) {
-    throw e
-  }
+  // try {
+  //   await UserRevenueModel.create(userContext, {
+  //     userId: userId,
+  //     timestamp: moment.utc().toISOString(),
+  //     revenue: revenue,
+  //     ...dfpAdvertiserId && { dfpAdvertiserId: dfpAdvertiserId }
+  //   })
+  // } catch (e) {
+  //   throw e
+  // }
   return { success: true }
 }
 


### PR DESCRIPTION
Will recreate and use string type instead of number type for `dfpAdvertiserId` field, because some IDs are >32 bits.