### PR TITLE
Log revenue on ad render

### DIFF
--- a/web/src/js/components/Dashboard/LogRevenueComponent.js
+++ b/web/src/js/components/Dashboard/LogRevenueComponent.js
@@ -141,7 +141,7 @@ class LogRevenueComponent extends React.Component {
   logRevenueForAlreadyLoadedAds () {
     try {
       // This may be set earlier by ads code (outside of core app code)
-      const slotsLoadedObj = window.tabforacause.ads.slotsViewable
+      const slotsLoadedObj = window.tabforacause.ads.slotsRendered
       if (Object.keys(slotsLoadedObj).length) {
         const self = this
         Object.keys(slotsLoadedObj).forEach((slotId) => {
@@ -158,10 +158,13 @@ class LogRevenueComponent extends React.Component {
     const googletag = window.googletag || {}
     googletag.cmd = googletag.cmd || []
     googletag.cmd.push(() => {
-      // When a slot's becomes viewable, log its revenue
-      googletag.pubads().addEventListener('impressionViewable', (event) => {
+      // When a slot renders (before creative loads), log its revenue
+      googletag.pubads().addEventListener('slotRenderEnded', (event) => {
         try {
           const slotId = event.slot.getSlotElementId()
+
+          // Store rendered slot data
+          window.tabforacause.ads.slotsRendered[slotId] = event
           this.logRevenueForSlotId(slotId)
         } catch (e) {
           console.error('Could not log revenue for ad slot', e)

--- a/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
@@ -8,7 +8,6 @@ import toJson from 'enzyme-to-json'
 import {
   getDefaultTabGlobal,
   mockAmazonBidResponse,
-  mockGoogleTagImpressionViewableData,
   mockGoogleTagSlotRenderEndedData
 } from 'utils/test-utils'
 

--- a/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
@@ -200,10 +200,9 @@ describe('LogRevenueComponent', function () {
       0.000123456789012, '9876543', null, null)
   })
 
-  it('after mount, logs revenue when GPT fires a "slot loaded" event', () => {
+  it('after mount, logs revenue when GPT fires a "slot rendered" event', () => {
     const slotId = 'xyz-987'
-    window.tabforacause.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
-      slotId, { advertiserId: 159260 })
+    window.tabforacause.ads.slotsRendered = {}
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -243,8 +242,10 @@ describe('LogRevenueComponent', function () {
     window.googletag.cmd.forEach((cmd) => cmd())
 
     // Fake the GPT event callback
-    const eventCallback = googleEventListenerCalls['impressionViewable'][0][1]
-    eventCallback(mockGoogleTagImpressionViewableData(slotId))
+    const eventCallback = googleEventListenerCalls['slotRenderEnded'][0][1]
+    eventCallback(
+      mockGoogleTagSlotRenderEndedData(slotId, { advertiserId: 159260 })
+    )
 
     // Should have logged revenue after the slot loaded
     expect(LogUserRevenueMutation).toHaveBeenCalledWith(mockRelayEnvironment,
@@ -253,14 +254,7 @@ describe('LogRevenueComponent', function () {
 
   it('defaults to 99 (Google Adsense) DFP Advertiser ID when the advertiser ID does not exist', () => {
     const slotId = 'xyz-987'
-    window.tabforacause.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
-      slotId,
-      {
-        advertiserId: null,
-        campaignId: null,
-        creativeId: null
-      }
-    )
+    window.tabforacause.ads.slotsRendered = {}
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -300,8 +294,17 @@ describe('LogRevenueComponent', function () {
     window.googletag.cmd.forEach((cmd) => cmd())
 
     // Fake the GPT event callback
-    const eventCallback = googleEventListenerCalls['impressionViewable'][0][1]
-    eventCallback(mockGoogleTagImpressionViewableData(slotId))
+    const eventCallback = googleEventListenerCalls['slotRenderEnded'][0][1]
+    eventCallback(
+      mockGoogleTagSlotRenderEndedData(
+        slotId,
+        {
+          advertiserId: null,
+          campaignId: null,
+          creativeId: null
+        }
+      )
+    )
 
     // Should have logged revenue after the slot loaded
     expect(LogUserRevenueMutation).toHaveBeenCalledWith(mockRelayEnvironment,


### PR DESCRIPTION
Switch away from logging revenue when an ad is viewable and back to logging when the ad slot has finished rendering.