### PR TITLE
Daily ad cap

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "if-env": "^1.0.0",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.4",
+    "mockdate": "^2.0.2",
     "npm-run-all": "^4.0.2",
     "react-test-renderer": "^15.5.4",
     "relay-compiler": "^1.4.1",

--- a/web/src/js/ads/__mocks__/adsEnabledStatus.js
+++ b/web/src/js/ads/__mocks__/adsEnabledStatus.js
@@ -1,0 +1,3 @@
+/* eslint-env jest */
+
+export default jest.fn(() => false)

--- a/web/src/js/ads/__tests__/ads.test.js
+++ b/web/src/js/ads/__tests__/ads.test.js
@@ -1,28 +1,35 @@
 /* eslint-env jest */
 
-const mockAdsEnabledStatus = jest.fn()
-const mockPrebidModule = jest.fn()
-const mockPrebidConfig = jest.fn()
-jest.mock('../adsEnabledStatus', () => mockAdsEnabledStatus)
-jest.mock('../prebid/prebidModule', () => mockPrebidModule)
-jest.mock('../prebid/prebidConfig', () => mockPrebidConfig)
+jest.mock('../adsEnabledStatus')
+jest.mock('../prebid/prebidConfig')
+jest.mock('../prebid/prebidModule')
 
 beforeEach(() => {
   jest.resetModules()
 })
 
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
 describe('ads script', function () {
   it('does not call ads scripts dependencies when ads are not enabled', () => {
-    jest.mock('../adsEnabledStatus', () => false)
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    adsEnabledStatus.mockReturnValue(false)
+    const prebidConfig = require('../prebid/prebidConfig').default
+    const prebidModule = require('../prebid/prebidModule').default
     require('../ads')
-    expect(mockPrebidModule).not.toHaveBeenCalled()
-    expect(mockPrebidConfig).not.toHaveBeenCalled()
+    expect(prebidConfig).not.toHaveBeenCalled()
+    expect(prebidModule).not.toHaveBeenCalled()
   })
 
   it('calls ads scripts dependencies when ads are enabled', () => {
-    jest.mock('../adsEnabledStatus', () => true)
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    adsEnabledStatus.mockReturnValue(true)
+    const prebidConfig = require('../prebid/prebidConfig').default
+    const prebidModule = require('../prebid/prebidModule').default
     require('../ads')
-    expect(mockPrebidModule).toHaveBeenCalled()
-    expect(mockPrebidConfig).toHaveBeenCalled()
+    expect(prebidConfig).toHaveBeenCalled()
+    expect(prebidModule).toHaveBeenCalled()
   })
 })

--- a/web/src/js/ads/__tests__/adsEnabledStatus.test.js
+++ b/web/src/js/ads/__tests__/adsEnabledStatus.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+
+var adsEnabledEnv = process.env.ADS_ENABLED
+
+afterEach(() => {
+  process.env.ADS_ENABLED = adsEnabledEnv // Reset env var after tests
+})
+
+describe('ads enabled status', function () {
+  it('disables ads when ADS_ENABLED env var is not set', () => {
+    process.env.ADS_ENABLED = undefined
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    expect(adsEnabledStatus()).toBe(false)
+  })
+
+  it('disables ads when ADS_ENABLED env var is not "true"', () => {
+    process.env.ADS_ENABLED = 'false'
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    expect(adsEnabledStatus()).toBe(false)
+  })
+
+  it('enables ads when ADS_ENABLED env var is "true"', () => {
+    process.env.ADS_ENABLED = 'true'
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    expect(adsEnabledStatus()).toBe(true)
+  })
+})

--- a/web/src/js/ads/__tests__/adsEnabledStatus.test.js
+++ b/web/src/js/ads/__tests__/adsEnabledStatus.test.js
@@ -1,5 +1,9 @@
 /* eslint-env jest */
 
+import { getTabsOpenedToday } from 'utils/local-user-data-mgr'
+
+jest.mock('utils/local-user-data-mgr')
+
 var adsEnabledEnv = process.env.ADS_ENABLED
 
 afterEach(() => {
@@ -19,9 +23,24 @@ describe('ads enabled status', function () {
     expect(adsEnabledStatus()).toBe(false)
   })
 
-  it('enables ads when ADS_ENABLED env var is "true"', () => {
+  it('enables ads when ADS_ENABLED env var is "true" and the user has not opened any tabs today', () => {
     process.env.ADS_ENABLED = 'true'
+    getTabsOpenedToday.mockReturnValue(0)
     const adsEnabledStatus = require('../adsEnabledStatus').default
     expect(adsEnabledStatus()).toBe(true)
+  })
+
+  it('enables ads when ADS_ENABLED env var is "true" and the user has opened below the max number of tabs today', () => {
+    process.env.ADS_ENABLED = 'true'
+    getTabsOpenedToday.mockReturnValue(135)
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    expect(adsEnabledStatus()).toBe(true)
+  })
+
+  it('disables ads when the user has opened more than the max number of tabs today', () => {
+    process.env.ADS_ENABLED = 'true'
+    getTabsOpenedToday.mockReturnValue(150)
+    const adsEnabledStatus = require('../adsEnabledStatus').default
+    expect(adsEnabledStatus()).toBe(false)
   })
 })

--- a/web/src/js/ads/ads.js
+++ b/web/src/js/ads/ads.js
@@ -5,7 +5,7 @@ import prebidConfig from './prebid/prebidConfig'
 import amazonBidder from './amazon/amazonBidder'
 import handleAdsLoaded from './handleAdsLoaded'
 
-if (adsEnabled) {
+if (adsEnabled()) {
   handleAdsLoaded()
   amazonBidder()
   prebid()

--- a/web/src/js/ads/adsEnabledStatus.js
+++ b/web/src/js/ads/adsEnabledStatus.js
@@ -1,7 +1,16 @@
 
+import { getTabsOpenedToday } from 'utils/local-user-data-mgr'
+
+const MAX_TABS_WITH_ADS = 150
+
 export default () => {
   if (!(process.env.ADS_ENABLED === 'true')) {
     return false
   }
-  return true
+
+  // If the user has exceeded the daily tab maximum,
+  // do not show ads.
+  // https://github.com/gladly-team/tab/issues/202
+  const tabsOpenedToday = getTabsOpenedToday()
+  return tabsOpenedToday < MAX_TABS_WITH_ADS
 }

--- a/web/src/js/ads/adsEnabledStatus.js
+++ b/web/src/js/ads/adsEnabledStatus.js
@@ -1,2 +1,6 @@
 
-export default process.env.ADS_ENABLED === 'true'
+export default () => {
+  if (!(process.env.ADS_ENABLED === 'true')) {
+    return false
+  }
+}

--- a/web/src/js/ads/adsEnabledStatus.js
+++ b/web/src/js/ads/adsEnabledStatus.js
@@ -3,4 +3,5 @@ export default () => {
   if (!(process.env.ADS_ENABLED === 'true')) {
     return false
   }
+  return true
 }

--- a/web/src/js/ads/prebid/__mocks__/prebidConfig.js
+++ b/web/src/js/ads/prebid/__mocks__/prebidConfig.js
@@ -1,0 +1,3 @@
+/* eslint-env jest */
+
+export default jest.fn()

--- a/web/src/js/ads/prebid/__mocks__/prebidModule.js
+++ b/web/src/js/ads/prebid/__mocks__/prebidModule.js
@@ -1,0 +1,3 @@
+/* eslint-env jest */
+
+export default jest.fn()

--- a/web/src/js/components/Dashboard/LogTabComponent.js
+++ b/web/src/js/components/Dashboard/LogTabComponent.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import LogTabMutation from 'mutations/LogTabMutation'
 import PropTypes from 'prop-types'
+import { incrementTabsOpenedToday } from 'utils/local-user-data-mgr'
 
 class LogTabComponent extends React.Component {
   componentDidMount () {
@@ -15,6 +16,12 @@ class LogTabComponent extends React.Component {
         this.props.tabId
       )
     }, LOG_TAB_DELAY)
+
+    // Update today's tab count in localStorage.
+    // This is useful when making rendering decisions before
+    // we fetch user data from the server (e.g., whether we
+    // should show ads or not).
+    incrementTabsOpenedToday()
   }
 
   render () {

--- a/web/src/js/components/Dashboard/__tests__/LogTabComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogTabComponent.test.js
@@ -7,8 +7,10 @@ import {
 import toJson from 'enzyme-to-json'
 
 import LogTabMutation from 'mutations/LogTabMutation'
+import { incrementTabsOpenedToday } from 'utils/local-user-data-mgr'
 
 jest.mock('mutations/LogTabMutation')
+jest.mock('utils/local-user-data-mgr')
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -45,5 +47,21 @@ describe('LogTabComponent', function () {
     jest.advanceTimersByTime(1)
     expect(LogTabMutation).toHaveBeenCalledWith(mockRelayEnvironment,
       mockUserData.id, tabId)
+  })
+
+  it('updates today\'s tab count in localStorage', () => {
+    const LogTabComponent = require('../LogTabComponent').default
+    const mockRelayEnvironment = {}
+    const mockUserData = { id: 'abcdefghijklmno' }
+    const tabId = 'abc-123'
+    jest.useFakeTimers()
+    shallow(
+      <LogTabComponent
+        user={mockUserData}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(incrementTabsOpenedToday).toHaveBeenCalled()
   })
 })

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -18,5 +18,14 @@ export const STORAGE_BACKGROUND_OPTION = 'tab.user.background.option'
 export const STORAGE_BACKGROUND_CUSTOM_IMAGE = 'tab.user.background.customImage'
 export const STORAGE_BACKGROUND_COLOR = 'tab.user.background.color'
 export const STORAGE_BACKGROUND_IMAGE_URL = 'tab.user.background.imageURL'
+
+// An ISO timestamp: the time of the first tab opened in the
+// most recent day (UTC day) the user was active.
+export const STORAGE_TABS_LAST_TAB_OPENED_DATE = 'tab.user.lastTabDay.date'
+
+// The count of tabs opened in the most recent day the user was
+// active. It could be today (ongoing) or a day in the past.
+export const STORAGE_TABS_RECENT_DAY_COUNT = 'tab.user.lastTabDay.count'
+
 export const STORAGE_REFERRAL_DATA_REFERRING_USER = 'tab.referralData.referringUser'
 export const STORAGE_REFERRAL_DATA_REFERRING_CHANNEL = 'tab.referralData.referringChannel'

--- a/web/src/js/mutations/__mocks__/LogTabMutation.js
+++ b/web/src/js/mutations/__mocks__/LogTabMutation.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+
+var onCompletedCallback = () => {}
+var onErrorCallback = () => {}
+
+// Mock Relay data returns
+export const __runOnCompleted = (response = null) => {
+  // Default response for this mutation's mock
+  if (!response) {
+    response = {
+      logTab: {
+        user: {
+          id: 'abc',
+          heartsUntilNextLevel: 10,
+          level: 5,
+          tabs: 2,
+          vcCurrent: 45
+        }
+      }
+    }
+  }
+  onCompletedCallback(response)
+}
+
+export const __runOnError = (response) => {
+  onErrorCallback(response)
+}
+
+export default jest.fn((environment, userId, tabId, onCompleted = () => {}, onError = () => {}) => {
+  onCompletedCallback = onCompleted
+  onErrorCallback = onError
+})

--- a/web/src/js/utils/__mocks__/extension-messenger.js
+++ b/web/src/js/utils/__mocks__/extension-messenger.js
@@ -1,0 +1,5 @@
+/* eslint-env jest */
+
+const extensionMessenger = jest.genMockFromModule('../extension-messenger')
+
+module.exports = extensionMessenger

--- a/web/src/js/utils/__mocks__/localstorage-mgr.js
+++ b/web/src/js/utils/__mocks__/localstorage-mgr.js
@@ -11,7 +11,9 @@ export default {
     return mockStorage[key]
   }),
   setItem: jest.fn((key, val) => {
-    mockStorage[key] = val
+    if (val) {
+      mockStorage[key] = String(val)
+    }
   }),
   removeItem: jest.fn((key, val) => {
     delete (mockStorage[key])

--- a/web/src/js/utils/__mocks__/localstorage-mgr.js
+++ b/web/src/js/utils/__mocks__/localstorage-mgr.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+
+var mockStorage = {}
+
+export const __mockClear = () => {
+  mockStorage = {}
+}
+
+export default {
+  getItem: jest.fn((key) => {
+    return mockStorage[key]
+  }),
+  setItem: jest.fn((key, val) => {
+    mockStorage[key] = val
+  }),
+  removeItem: jest.fn((key, val) => {
+    delete (mockStorage[key])
+  })
+}

--- a/web/src/js/utils/__tests__/local-bkg-settings.test.js
+++ b/web/src/js/utils/__tests__/local-bkg-settings.test.js
@@ -1,44 +1,46 @@
 /* eslint-env jest */
 
-beforeEach(() => {
-  jest.resetModules()
-})
+import localStorageMgr from '../localstorage-mgr'
 
-const mockSetItem = jest.fn()
-jest.mock('../localstorage-mgr', () => {
-  return {
-    getItem: (key) => {
-      switch (key) {
-        case 'tab.user.background.option':
-          return 'photo'
-        case 'tab.user.background.color':
-          return '#FF0000'
-        case 'tab.user.background.imageURL':
-          return 'https://static.example.com/my-img.png'
-        case 'tab.user.background.customImage':
-          return 'https://static.foo.com/some-img.png'
-        default:
-          return undefined
-      }
-    },
-    setItem: mockSetItem
-  }
+jest.mock('../extension-messenger')
+jest.mock('../localstorage-mgr')
+
+afterEach(() => {
+  jest.clearAllMocks()
 })
 
 describe('localBkgStorageMgr', () => {
   it('loads the background option', () => {
+    // Mock localStorage values
+    localStorageMgr.setItem('tab.user.background.option', 'photo')
+    localStorageMgr.setItem('tab.user.background.color', '#FF0000')
+    localStorageMgr.setItem('tab.user.background.imageURL', 'https://static.example.com/my-img.png')
+    localStorageMgr.setItem('tab.user.background.customImage', 'https://static.foo.com/some-img.png')
+
     const getUserBackgroundOption = require('../local-bkg-settings')
       .getUserBackgroundOption
     expect(getUserBackgroundOption()).toEqual('photo')
   })
 
   it('loads the background color', () => {
+    // Mock localStorage values
+    localStorageMgr.setItem('tab.user.background.option', 'photo')
+    localStorageMgr.setItem('tab.user.background.color', '#FF0000')
+    localStorageMgr.setItem('tab.user.background.imageURL', 'https://static.example.com/my-img.png')
+    localStorageMgr.setItem('tab.user.background.customImage', 'https://static.foo.com/some-img.png')
+
     const getUserBackgroundColor = require('../local-bkg-settings')
       .getUserBackgroundColor
     expect(getUserBackgroundColor()).toEqual('#FF0000')
   })
 
   it('loads the background image URL', () => {
+    // Mock localStorage values
+    localStorageMgr.setItem('tab.user.background.option', 'photo')
+    localStorageMgr.setItem('tab.user.background.color', '#FF0000')
+    localStorageMgr.setItem('tab.user.background.imageURL', 'https://static.example.com/my-img.png')
+    localStorageMgr.setItem('tab.user.background.customImage', 'https://static.foo.com/some-img.png')
+
     const getUserBackgroundImageURL = require('../local-bkg-settings')
       .getUserBackgroundImageURL
     expect(getUserBackgroundImageURL())
@@ -46,6 +48,12 @@ describe('localBkgStorageMgr', () => {
   })
 
   it('loads the background custom image', () => {
+    // Mock localStorage values
+    localStorageMgr.setItem('tab.user.background.option', 'photo')
+    localStorageMgr.setItem('tab.user.background.color', '#FF0000')
+    localStorageMgr.setItem('tab.user.background.imageURL', 'https://static.example.com/my-img.png')
+    localStorageMgr.setItem('tab.user.background.customImage', 'https://static.foo.com/some-img.png')
+
     const getUserBackgroundCustomImage = require('../local-bkg-settings')
       .getUserBackgroundCustomImage
     expect(getUserBackgroundCustomImage())
@@ -57,7 +65,7 @@ describe('localBkgStorageMgr', () => {
     setBackgroundSettings('color', 'https://static.foo.com/blep.png',
       '#000000', 'https://static.example.com/my-img.png')
 
-    expect(mockSetItem.mock.calls).toEqual([
+    expect(localStorageMgr.setItem.mock.calls).toEqual([
       ['tab.user.background.option', 'color'],
       ['tab.user.background.customImage', 'https://static.foo.com/blep.png'],
       ['tab.user.background.color', '#000000'],

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -16,6 +16,7 @@ beforeAll(() => {
 
 afterEach(() => {
   __mockClear()
+  jest.clearAllMocks()
 })
 
 afterAll(() => {
@@ -23,6 +24,7 @@ afterAll(() => {
 })
 
 describe('local user data manager', () => {
+  // getTabsOpenedToday method
   it('returns tabs today when the user has opened tabs today', () => {
     localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-12T12:50:42.000').utc().toISOString())
     localStorageMgr.setItem('tab.user.lastTabDay.count', 14)
@@ -52,5 +54,51 @@ describe('local user data manager', () => {
     localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-12T12:50:42.000').utc().toISOString())
     const getTabsOpenedToday = require('../local-user-data-mgr').getTabsOpenedToday
     expect(getTabsOpenedToday()).toBe(0)
+  })
+
+  // incrementTabsOpenedToday method
+  it('increments the tabs today when the user has opened tabs today', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-12T12:50:42.000').utc().toISOString())
+    localStorageMgr.setItem('tab.user.lastTabDay.count', 14)
+    jest.clearAllMocks()
+    const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
+    incrementTabsOpenedToday()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 15)
+    expect(localStorageMgr.setItem).not.toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
+  })
+
+  it('resets the counter of tabs today when the user last opened tabs more than one day ago', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-11T08:05:10.000').utc().toISOString())
+    localStorageMgr.setItem('tab.user.lastTabDay.count', 14)
+    jest.clearAllMocks()
+    const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
+    incrementTabsOpenedToday()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 15)
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
+  })
+
+  it('resets the counter of tabs today when the last tab day values are not set in localStorage', () => {
+    const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
+    incrementTabsOpenedToday()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 1)
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
+  })
+
+  it('resets the counter of tabs today when the last tab date value is not set in localStorage', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.count', 6)
+    jest.clearAllMocks()
+    const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
+    incrementTabsOpenedToday()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 7)
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
+  })
+
+  it('resets the counter of tabs today when the last tab day count is not set in localStorage', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-12T12:50:42.000').utc().toISOString())
+    jest.clearAllMocks()
+    const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
+    incrementTabsOpenedToday()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 1)
+    expect(localStorageMgr.setItem).not.toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
   })
 })

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -1,0 +1,56 @@
+/* eslint-env jest */
+
+import moment from 'moment'
+import MockDate from 'mockdate'
+import localStorageMgr, {
+  __mockClear
+} from '../localstorage-mgr'
+
+jest.mock('../localstorage-mgr')
+
+const mockNow = '2018-04-12T10:30:00.000'
+
+beforeAll(() => {
+  MockDate.set(moment(mockNow))
+})
+
+afterEach(() => {
+  __mockClear()
+})
+
+afterAll(() => {
+  MockDate.reset()
+})
+
+describe('local user data manager', () => {
+  it('returns tabs today when the user has opened tabs today', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-12T12:50:42.000').utc().toISOString())
+    localStorageMgr.setItem('tab.user.lastTabDay.count', 14)
+    const getTabsOpenedToday = require('../local-user-data-mgr').getTabsOpenedToday
+    expect(getTabsOpenedToday()).toBe(14)
+  })
+
+  it('returns zero tabs today when the user last opened tabs more than one day ago', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-11T08:05:10.000').utc().toISOString())
+    localStorageMgr.setItem('tab.user.lastTabDay.count', 14)
+    const getTabsOpenedToday = require('../local-user-data-mgr').getTabsOpenedToday
+    expect(getTabsOpenedToday()).toBe(0)
+  })
+
+  it('returns zero tabs today when the last tab day values are not set in localStorage', () => {
+    const getTabsOpenedToday = require('../local-user-data-mgr').getTabsOpenedToday
+    expect(getTabsOpenedToday()).toBe(0)
+  })
+
+  it('returns zero tabs today when the last tab date value is not set in localStorage', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.count', 6)
+    const getTabsOpenedToday = require('../local-user-data-mgr').getTabsOpenedToday
+    expect(getTabsOpenedToday()).toBe(0)
+  })
+
+  it('returns zero tabs today when the last tab day count is not set in localStorage', () => {
+    localStorageMgr.setItem('tab.user.lastTabDay.date', moment('2018-04-12T12:50:42.000').utc().toISOString())
+    const getTabsOpenedToday = require('../local-user-data-mgr').getTabsOpenedToday
+    expect(getTabsOpenedToday()).toBe(0)
+  })
+})

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -73,7 +73,7 @@ describe('local user data manager', () => {
     jest.clearAllMocks()
     const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
     incrementTabsOpenedToday()
-    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 15)
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 1)
     expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
   })
 
@@ -89,7 +89,7 @@ describe('local user data manager', () => {
     jest.clearAllMocks()
     const incrementTabsOpenedToday = require('../local-user-data-mgr').incrementTabsOpenedToday
     incrementTabsOpenedToday()
-    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 7)
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 1)
     expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
   })
 

--- a/web/src/js/utils/__tests__/utils.test.js
+++ b/web/src/js/utils/__tests__/utils.test.js
@@ -1,27 +1,19 @@
 /* eslint-env jest */
 
-beforeEach(() => {
-  jest.resetModules()
+import localStorageMgr, {
+  __mockClear
+} from '../localstorage-mgr'
+
+jest.mock('../localstorage-mgr')
+
+afterEach(() => {
+  __mockClear()
 })
 
 describe('getting referral data', () => {
   it('works with all fields set', () => {
-    const mockSetItem = jest.fn()
-    jest.mock('../localstorage-mgr', () => {
-      return {
-        getItem: (key) => {
-          switch (key) {
-            case 'tab.referralData.referringUser':
-              return 'sandra'
-            case 'tab.referralData.referringChannel':
-              return '42'
-            default:
-              return undefined
-          }
-        },
-        setItem: mockSetItem
-      }
-    })
+    localStorageMgr.setItem('tab.referralData.referringUser', 'sandra')
+    localStorageMgr.setItem('tab.referralData.referringChannel', '42')
     const getReferralData = require('../utils').getReferralData
     expect(getReferralData()).toEqual({
       referringUser: 'sandra',
@@ -30,20 +22,8 @@ describe('getting referral data', () => {
   })
 
   it('works with only referring user', () => {
-    jest.mock('../localstorage-mgr', () => {
-      return {
-        getItem: (key) => {
-          switch (key) {
-            case 'tab.referralData.referringUser':
-              return 'bob'
-            case 'tab.referralData.referringChannel':
-              return undefined
-            default:
-              return undefined
-          }
-        }
-      }
-    })
+    localStorageMgr.setItem('tab.referralData.referringUser', 'bob')
+    localStorageMgr.setItem('tab.referralData.referringChannel', undefined)
     const getReferralData = require('../utils').getReferralData
     expect(getReferralData()).toEqual({
       referringUser: 'bob'
@@ -51,20 +31,8 @@ describe('getting referral data', () => {
   })
 
   it('works with only referring channel', () => {
-    jest.mock('../localstorage-mgr', () => {
-      return {
-        getItem: (key) => {
-          switch (key) {
-            case 'tab.referralData.referringUser':
-              return undefined
-            case 'tab.referralData.referringChannel':
-              return '33'
-            default:
-              return undefined
-          }
-        }
-      }
-    })
+    localStorageMgr.setItem('tab.referralData.referringUser', undefined)
+    localStorageMgr.setItem('tab.referralData.referringChannel', '33')
     const getReferralData = require('../utils').getReferralData
     expect(getReferralData()).toEqual({
       referringChannel: '33'

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -1,0 +1,45 @@
+
+import moment from 'moment'
+import localStorageMgr from 'utils/localstorage-mgr'
+import {
+  STORAGE_TABS_RECENT_DAY_COUNT,
+  STORAGE_TABS_LAST_TAB_OPENED_DATE
+} from '../constants'
+
+/**
+ * Get the count of tabs opened today (UTC day) from localStorage. If no
+ * value exists in storage, return zero.
+ * @returns {number} The user's tab count
+ */
+const getTabsOpenedTodayFromStorage = () => {
+  const tabCountStr = localStorageMgr.getItem(STORAGE_TABS_RECENT_DAY_COUNT)
+  const tabCountParsed = parseInt(tabCountStr, 10)
+  const tabCount = isNaN(tabCountParsed) ? 0 : tabCountParsed
+  return tabCount
+}
+
+/**
+ * Get the count of tabs opened today (UTC day) from localStorage. If no
+ * value exists in storage, return zero.
+ * @returns {number} The user's tab count
+ */
+export const getTabsOpenedToday = function () {
+  // An ISO timestamp
+  const tabCountDate = localStorageMgr.getItem(STORAGE_TABS_LAST_TAB_OPENED_DATE)
+
+  // If no current date, assume no tabs have been opened today.
+  if (!tabCountDate) {
+    return 0
+  }
+
+  // If the current date is the same as the most recent date a
+  // tab was opened, it is not the first tab today.
+  const isFirstTabToday = (
+    moment(tabCountDate).utc().format('LL') !==
+    moment().utc().format('LL')
+  )
+  if (isFirstTabToday) {
+    return 0
+  }
+  return getTabsOpenedTodayFromStorage()
+}

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -63,13 +63,13 @@ const setLastTabOpenedDateInLocalStorage = () => {
 }
 
 /**
- * Sets the localStorage value for today's tab count to one greater
- * than its current value.
+ * Sets the localStorage value for today's tab count to the value
+ * of `tabCount`.
+ * @param {number} tabCount - The number of tabs today
  * @returns {undefined}
  */
-const incrementTabsCountInLocalStorage = () => {
-  const currentTabCount = getTabsOpenedTodayFromStorage()
-  localStorageMgr.setItem(STORAGE_TABS_RECENT_DAY_COUNT, currentTabCount + 1)
+const setTabCountInLocalStorage = (tabCount) => {
+  localStorageMgr.setItem(STORAGE_TABS_RECENT_DAY_COUNT, tabCount)
 }
 
 /**
@@ -79,8 +79,13 @@ const incrementTabsCountInLocalStorage = () => {
  * @returns {undefined}
  */
 export const incrementTabsOpenedToday = function () {
-  if (!hasUserOpenedTabToday()) {
+  if (hasUserOpenedTabToday()) {
+    // Increment the tab count
+    const currentTabCount = getTabsOpenedTodayFromStorage()
+    setTabCountInLocalStorage(currentTabCount + 1)
+  } else {
+    // Reset the date and tab count
     setLastTabOpenedDateInLocalStorage()
+    setTabCountInLocalStorage(1)
   }
-  incrementTabsCountInLocalStorage()
 }

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -19,11 +19,11 @@ const getTabsOpenedTodayFromStorage = () => {
 }
 
 /**
- * Get the count of tabs opened today (UTC day) from localStorage. If no
- * value exists in storage, return zero.
- * @returns {number} The user's tab count
+ * Get whether the user has opened a tab today, according to the tab
+ * count in localStorage.
+ * @returns {boolean} Whether the user has opened a tab today
  */
-export const getTabsOpenedToday = function () {
+const hasUserOpenedTabToday = () => {
   // An ISO timestamp
   const tabCountDate = localStorageMgr.getItem(STORAGE_TABS_LAST_TAB_OPENED_DATE)
 
@@ -34,12 +34,53 @@ export const getTabsOpenedToday = function () {
 
   // If the current date is the same as the most recent date a
   // tab was opened, it is not the first tab today.
-  const isFirstTabToday = (
-    moment(tabCountDate).utc().format('LL') !==
+  const hasOpenedTabToday = (
+    moment(tabCountDate).utc().format('LL') ===
     moment().utc().format('LL')
   )
-  if (isFirstTabToday) {
+  return hasOpenedTabToday
+}
+
+/**
+ * Get the count of tabs opened today (UTC day) from localStorage. If no
+ * value exists in storage, return zero.
+ * @returns {number} The user's tab count
+ */
+export const getTabsOpenedToday = function () {
+  if (!hasUserOpenedTabToday()) {
     return 0
   }
   return getTabsOpenedTodayFromStorage()
+}
+
+/**
+ * Sets the localStorage value for the date of the last tab opened
+ * to an ISO timestamp of the current time.
+ * @returns {undefined}
+ */
+const setLastTabOpenedDateInLocalStorage = () => {
+  localStorageMgr.setItem(STORAGE_TABS_LAST_TAB_OPENED_DATE, moment.utc().toISOString())
+}
+
+/**
+ * Sets the localStorage value for today's tab count to one greater
+ * than its current value.
+ * @returns {undefined}
+ */
+const incrementTabsCountInLocalStorage = () => {
+  const currentTabCount = getTabsOpenedTodayFromStorage()
+  localStorageMgr.setItem(STORAGE_TABS_RECENT_DAY_COUNT, currentTabCount + 1)
+}
+
+/**
+ * Increment the count of tabs opened today (UTC day) in localStorage.
+ * If the most recent day of a tab opening is prior to today, reset
+ * the tab counter. If no values exist in localStorage, set them.
+ * @returns {undefined}
+ */
+export const incrementTabsOpenedToday = function () {
+  if (!hasUserOpenedTabToday()) {
+    setLastTabOpenedDateInLocalStorage()
+  }
+  incrementTabsCountInLocalStorage()
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6843,6 +6843,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdi
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+
 moment@^2.13.0, moment@^2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"


### PR DESCRIPTION
Stop showing ads after a user opens >=150 tabs in a single UTC day. Fixes part of #202.

* Track daily tabs opened in localStorage
* Check count of today's tabs opened in localStorage before loading ads