### PR TITLE
Max daily Hearts from opening tabs

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -217,6 +217,10 @@ const userType = new GraphQLObjectType({
       type: GraphQLInt,
       description: 'User\'s all time tab count'
     },
+    tabsToday: {
+      type: GraphQLInt,
+      description: 'User\'s tab count for today'
+    },
     maxTabsDay: {
       type: maxTabsDayType,
       description: 'Info about the user\'s day of most opened tabs',

--- a/graphql/database/base/BaseModel.js
+++ b/graphql/database/base/BaseModel.js
@@ -26,15 +26,15 @@ class BaseModel {
       ['created', 'updated'])
     const customDeserializers = this.constructor.fieldDeserializers
     const fieldDefaults = this.constructor.fieldDefaults
+
+    // Set properties for each field on the model.
+    // * If `obj[fieldName]` exists, use the value of `obj[fieldName]`.
+    // * Else, if `obj[fieldName]` does not exist, use the default value of
+    //   the field if one exists.
+    // * If both the value and default value are nil, do not set
+    //   the property.
     fieldNames.forEach((fieldName) => {
-      // Set properties for each field on the model.
-      // * If `obj[fieldName]` exists, use the value of `obj[fieldName]`.
-      // * Else, if `obj[fieldName]` does not exist, use the default value of
-      //   the field if one exists.
-      // * If a custom deserializer exists for that field, call it.
-      // * If the final value is null or undefined, do not set
-      //   the property.
-      var val = null
+      let val = null
       if (has(obj, fieldName)) {
         val = obj[fieldName]
       } else if (has(fieldDefaults, fieldName)) {
@@ -45,12 +45,27 @@ class BaseModel {
           val = fieldDefault
         }
       }
+      if (!isNil(val)) {
+        obj[fieldName] = val
+      }
+    })
+
+    // Call any custom deserializers on the fields.
+    // * If a custom deserializer exists for that field, call it.
+    // * If the returned value is null or undefined, do not set
+    //   the property.
+    const self = this
+    fieldNames.forEach((fieldName) => {
+      var val = null
+      if (has(obj, fieldName)) {
+        val = obj[fieldName]
+      }
       if (isFunction(get(customDeserializers, fieldName, false))) {
         let deserializeFunc = customDeserializers[fieldName]
         val = deserializeFunc(val, obj)
       }
       if (!isNil(val)) {
-        this[fieldName] = val
+        self[fieldName] = val
       }
     })
   }

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -12,6 +12,7 @@ import {
   permissionAuthorizers
 } from '../../utils/authorization-helpers'
 import config from '../../config'
+import { getTodayTabCount } from './user-utils'
 
 const mediaRoot = config.MEDIA_ENDPOINT
 
@@ -51,6 +52,7 @@ class User extends BaseModel {
       vcAllTime: types.number().integer().default(self.fieldDefaults.vcAllTime),
       level: types.number().integer().default(self.fieldDefaults.level),
       tabs: types.number().integer().default(self.fieldDefaults.tabs),
+      tabsToday: types.number().integer().forbidden(), // only set in deserializer
       validTabs: types.number().integer().default(self.fieldDefaults.tabs),
       maxTabsDay: types.object({
         // The count of tabs for the day on which the user opened
@@ -125,6 +127,10 @@ class User extends BaseModel {
 
   static get fieldDeserializers () {
     return {
+      tabsToday: (tabsToday, userObj) => {
+        // Calculate tabsToday based on the maxTabsDay value
+        return getTodayTabCount(userObj)
+      },
       backgroundImage: (backgroundImage, userObj) => {
         return Object.assign({}, backgroundImage, {
           imageURL: `${mediaRoot}/img/backgrounds/${backgroundImage.image}`,

--- a/graphql/database/users/__tests__/UserModel.test.js
+++ b/graphql/database/users/__tests__/UserModel.test.js
@@ -144,6 +144,7 @@ describe('UserModel', () => {
       vcAllTime: 0,
       level: 0,
       tabs: 0,
+      tabsToday: 0,
       maxTabsDay: {
         maxDay: {
           date: moment.utc().toISOString(),
@@ -167,6 +168,28 @@ describe('UserModel', () => {
         timestamp: moment.utc().toISOString()
       },
       backgroundOption: 'photo'
+    })
+  })
+
+  it('constructs with the expected "tabsToday" value', () => {
+    const item = Object.assign({}, new User({
+      id: 'bb5082cc-151a-4a9a-9289-06906670fd4e',
+      email: 'foo@bar.com',
+      username: 'Foo Bar',
+      maxTabsDay: {
+        maxDay: {
+          date: moment.utc().toISOString(),
+          numTabs: 300
+        },
+        recentDay: {
+          date: moment.utc().toISOString(),
+          numTabs: 47
+        }
+      }
+    }))
+    expect(item).toMatchObject({
+      id: 'bb5082cc-151a-4a9a-9289-06906670fd4e',
+      tabsToday: 47
     })
   })
 })

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -206,6 +206,7 @@ describe('createUser when user does not exist', () => {
     // Remove dynamic fields (won't be passed during creation)
     delete expectedParamsUser.backgroundImage.imageURL
     delete expectedParamsUser.backgroundImage.thumbnailURL
+    delete expectedParamsUser.tabsToday
 
     const expectedParams = {
       ConditionExpression: '(#id <> :id)',

--- a/graphql/database/users/__tests__/logTab.test.js
+++ b/graphql/database/users/__tests__/logTab.test.js
@@ -133,7 +133,7 @@ describe('logTab', () => {
     )
   })
 
-  test('when an invalid tab, it does not increment VC or valid tab counts', async () => {
+  test('an invalid tab (because of too-quickly-opened tabs) does not increment VC or valid tab counts', async () => {
     const userId = userContext.id
 
     // Mock fetching the user.
@@ -173,26 +173,6 @@ describe('logTab', () => {
       }
     })
     expect(returnedUser).not.toBeNull()
-  })
-
-  test('when an invalid tab, it does not log the tab for analytics', async () => {
-    const userId = userContext.id
-
-    // Mock fetching the user.
-    const mockUser = getMockUserInstance({
-      lastTabTimestamp: '2017-06-22T01:13:26.000Z'
-    })
-    setMockDBResponse(
-      DatabaseOperation.GET,
-      {
-        Item: mockUser
-      }
-    )
-    const userTabsLogCreate = jest.spyOn(UserTabsLogModel, 'create')
-    await logTab(userContext, userId)
-
-    // It should create an item in UserTabsLog.
-    expect(userTabsLogCreate).not.toHaveBeenCalled()
   })
 
   test('for the first tab logged today, it resets the date for today\'s tab counter', async () => {

--- a/graphql/database/users/__tests__/logTab.test.js
+++ b/graphql/database/users/__tests__/logTab.test.js
@@ -115,6 +115,32 @@ describe('logTab', () => {
     )
   })
 
+  test('an invalid tab still logs the tab for analytics', async () => {
+    const userId = userContext.id
+
+    // Mock fetching the user.
+    const mockUser = getMockUserInstance({
+      lastTabTimestamp: '2017-06-22T01:13:28.000Z'
+    })
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: mockUser
+      }
+    )
+    const userTabsLogCreate = jest.spyOn(UserTabsLogModel, 'create')
+    await logTab(userContext, userId)
+
+    // It should create an item in UserTabsLog.
+    expect(userTabsLogCreate).toHaveBeenLastCalledWith(
+      userContext,
+      addTimestampFieldsToItem({
+        userId: userId,
+        timestamp: moment.utc().toISOString()
+      })
+    )
+  })
+
   test('it logs the tab ID when given', async () => {
     const userId = userContext.id
 

--- a/graphql/database/users/__tests__/user-utils.test.js
+++ b/graphql/database/users/__tests__/user-utils.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+
+import moment from 'moment'
+import {
+  getMockUserInstance,
+  mockDate
+} from '../../test-utils'
+
+const mockCurrentTime = '2017-06-22T01:13:28.000Z'
+
+beforeAll(() => {
+  mockDate.on(mockCurrentTime, {
+    mockCurrentTimeOnly: true
+  })
+})
+
+afterAll(() => {
+  mockDate.off()
+})
+
+describe('user utils', () => {
+  test('getTodayTabCount calculates the correct amount when maxTabsDay has a recentDay of today', () => {
+    const mockUser = getMockUserInstance({
+      maxTabsDay: {
+        maxDay: {
+          date: moment.utc().toISOString(),
+          numTabs: 400
+        },
+        recentDay: {
+          date: moment.utc().toISOString(),
+          numTabs: 148
+        }
+      }
+    })
+    const getTodayTabCount = require('../user-utils').getTodayTabCount
+    expect(getTodayTabCount(mockUser)).toBe(148)
+  })
+
+  test('getTodayTabCount calculates the correct amount when maxTabsDay has a recentDay of prior to today', () => {
+    const mockUser = getMockUserInstance({
+      maxTabsDay: {
+        maxDay: {
+          date: moment.utc().toISOString(),
+          numTabs: 400
+        },
+        recentDay: {
+          date: '2017-06-18T01:13:28.000Z', // not today
+          numTabs: 14
+        }
+      }
+    })
+    const getTodayTabCount = require('../user-utils').getTodayTabCount
+    expect(getTodayTabCount(mockUser)).toBe(0)
+  })
+})

--- a/graphql/database/users/logTab.js
+++ b/graphql/database/users/logTab.js
@@ -28,6 +28,24 @@ const isTabValid = (userContext, lastTabTimestampStr) => {
 }
 
 /**
+ * Return the count of tabs opened today (UTC day).
+ * @param {object} user - The user object from our DB
+ * @return {number} The number of tabs opened today.
+ */
+const getTodayTabCount = (user) => {
+  const isFirstTabToday = (
+    moment(user.maxTabsDay.recentDay.date).utc().format('LL') !==
+    moment().utc().format('LL')
+  )
+  const todayTabCount = (
+    isFirstTabToday
+    ? 1
+    : user.maxTabsDay.recentDay.numTabs + 1
+  )
+  return todayTabCount
+}
+
+/**
  * Change the user's tab and VC stats accordingly when the
  * user opens a tab.
  * This only increments the VC if the tab is "valid",
@@ -52,15 +70,7 @@ const logTab = async (userContext, userId, tabId = null) => {
   // for the user's "current day" tab count.
   // If today is also the day of all time max tabs,
   // update the max tabs day value.
-  const isFirstTabToday = (
-    moment(user.maxTabsDay.recentDay.date).utc().format('LL') !==
-    moment().utc().format('LL')
-  )
-  const todayTabCount = (
-    isFirstTabToday
-    ? 1
-    : user.maxTabsDay.recentDay.numTabs + 1
-  )
+  const todayTabCount = getTodayTabCount(user)
   const isTodayMax = todayTabCount >= user.maxTabsDay.maxDay.numTabs
   const maxTabsDayVal = {
     maxDay: {

--- a/graphql/database/users/logTab.js
+++ b/graphql/database/users/logTab.js
@@ -3,6 +3,7 @@ import moment from 'moment'
 import UserModel from './UserModel'
 import UserTabsLogModel from './UserTabsLogModel'
 import addVc from './addVc'
+import { getTodayTabCount } from './user-utils'
 
 /**
  * Return whether a tab opened now is "valid" for this user;
@@ -43,24 +44,6 @@ const isTabValid = (tabsOpenedToday, lastTabTimestampStr) => {
 }
 
 /**
- * Return the count of tabs opened today (UTC day).
- * @param {object} user - The user object from our DB
- * @return {number} The number of tabs opened today.
- */
-const getTodayTabCount = (user) => {
-  const isFirstTabToday = (
-    moment(user.maxTabsDay.recentDay.date).utc().format('LL') !==
-    moment().utc().format('LL')
-  )
-  const todayTabCount = (
-    isFirstTabToday
-    ? 1
-    : user.maxTabsDay.recentDay.numTabs + 1
-  )
-  return todayTabCount
-}
-
-/**
  * Change the user's tab and VC stats accordingly when the
  * user opens a tab.
  * This only increments the VC if the tab is "valid",
@@ -78,7 +61,7 @@ const logTab = async (userContext, userId, tabId = null) => {
   } catch (e) {
     throw e
   }
-  const todayTabCount = getTodayTabCount(user)
+  const todayTabCount = getTodayTabCount(user) + 1
   const isValid = isTabValid(todayTabCount, user.lastTabTimestamp)
 
   // Update the user's counter for max tabs in a day.

--- a/graphql/database/users/user-utils.js
+++ b/graphql/database/users/user-utils.js
@@ -1,0 +1,20 @@
+
+import moment from 'moment'
+
+/**
+ * Return the count of tabs opened today (UTC day).
+ * @param {object} user - The user object from our DB
+ * @return {number} The number of tabs opened today.
+ */
+export const getTodayTabCount = (user) => {
+  const isFirstTabToday = (
+    moment(user.maxTabsDay.recentDay.date).utc().format('LL') !==
+    moment().utc().format('LL')
+  )
+  const todayTabCount = (
+    isFirstTabToday
+    ? 0
+    : user.maxTabsDay.recentDay.numTabs
+  )
+  return todayTabCount
+}

--- a/graphql/migration/__tests__/createUserHandler.test.js
+++ b/graphql/migration/__tests__/createUserHandler.test.js
@@ -45,6 +45,10 @@ const exampleUser = {
     maxDay: {
       date: '2017-11-18T20:39:15.088Z',
       numTabs: 11
+    },
+    recentDay: {
+      date: '2017-11-18T20:39:15.088Z',
+      numTabs: 11
     }
   },
   heartsUntilNextLevel: 12,

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -386,6 +386,9 @@ type User implements Node {
   # User's all time tab count
   tabs: Int
 
+  # User's tab count for today
+  tabsToday: Int
+
   # Info about the user's day of most opened tabs
   maxTabsDay: MaxTabsDay
 

--- a/web/src/js/components/User/UserMenuComponent.js
+++ b/web/src/js/components/User/UserMenuComponent.js
@@ -13,6 +13,7 @@ import SettingsIcon from 'material-ui/svg-icons/action/settings'
 import HelpIcon from 'material-ui/svg-icons/action/help'
 import PersonAddIcon from 'material-ui/svg-icons/social/person-add'
 import ChartIcon from 'material-ui/svg-icons/editor/insert-chart'
+import CheckmarkIcon from 'material-ui/svg-icons/action/done'
 import ExitToAppIcon from 'material-ui/svg-icons/action/exit-to-app'
 import {
   goToInviteFriends,
@@ -217,10 +218,9 @@ class UserMenu extends React.Component {
       width: 22
     }
 
-    // TODO
     // Used to let the user know they aren't earning any more
     // Hearts from tabs today.
-    // const reachedMaxDailyHearts = user.tabsToday >= MAX_DAILY_HEARTS_FROM_TABS
+    const reachedMaxDailyHearts = user.tabsToday >= MAX_DAILY_HEARTS_FROM_TABS
 
     // TODO: add level bar
     return (
@@ -233,11 +233,23 @@ class UserMenu extends React.Component {
           onClick={this.onHeartsClick.bind(this)}
         >
           <span>{commaFormatted(user.vcCurrent)}</span>
-          <HeartBorderIcon
-            style={{ marginLeft: 2, height: 24, width: 24, paddingBottom: 0 }}
-            color={dashboardIconInactiveColor}
-            hoverColor={dashboardIconActiveColor}
-          />
+          <span style={{ position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <HeartBorderIcon
+              style={{ marginLeft: 2, height: 24, width: 24, paddingBottom: 0 }}
+              color={dashboardIconInactiveColor}
+              hoverColor={dashboardIconActiveColor}
+            />
+            { reachedMaxDailyHearts
+              ? (
+                <CheckmarkIcon
+                  style={{ height: 16, width: 16, position: 'absolute', paddingLeft: 4, paddingBottom: 2 }}
+                  color={dashboardIconInactiveColor}
+                  hoverColor={dashboardIconActiveColor}
+                />
+              )
+              : null
+            }
+          </span>
         </div>
         <DashboardPopover
           open={this.state.heartsPopoverOpen}

--- a/web/src/js/components/User/UserMenuComponent.js
+++ b/web/src/js/components/User/UserMenuComponent.js
@@ -38,7 +38,11 @@ class UserMenu extends React.Component {
       heartsHover: false,
       heartsPopoverOpen: false,
       menuIconHover: false,
-      menuOpen: false
+      menuOpen: false,
+      // refs
+      heartsPopoverAnchorElem: null,
+      heartsHoverPopoverAnchorElem: null,
+      menuPopoverAnchorElem: null
     }
   }
 
@@ -54,9 +58,10 @@ class UserMenu extends React.Component {
     }
   }
 
-  onHeartsHover (hovering) {
+  onHeartsHover (hovering, event) {
     this.setState({
-      heartsHover: hovering
+      heartsHover: hovering,
+      heartsHoverPopoverAnchorElem: event.currentTarget
     })
   }
 
@@ -233,7 +238,10 @@ class UserMenu extends React.Component {
           onClick={this.onHeartsClick.bind(this)}
         >
           <span>{commaFormatted(user.vcCurrent)}</span>
-          <span style={{ position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <span
+            style={{ position: 'relative', display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+            ref={(ref) => { this.heartIconContainer = ref }}
+          >
             <HeartBorderIcon
               style={{ marginLeft: 2, height: 24, width: 24, paddingBottom: 0 }}
               color={dashboardIconInactiveColor}
@@ -246,6 +254,21 @@ class UserMenu extends React.Component {
                   color={dashboardIconInactiveColor}
                   hoverColor={dashboardIconActiveColor}
                 />
+              )
+              : null
+            }
+            { reachedMaxDailyHearts
+              ? (
+                <DashboardPopover
+                  open={this.state.heartsHover && !this.state.heartsPopoverOpen}
+                  anchorEl={this.state.heartsHoverPopoverAnchorElem}
+                  style={heartsPopoverStyle}
+                >
+                  <div style={{ padding: 10 }}>
+                    You've earned the maximum Hearts from opening tabs today! You'll
+                    be able to earn more Hearts in a few hours.
+                  </div>
+                </DashboardPopover>
               )
               : null
             }

--- a/web/src/js/components/User/UserMenuComponent.js
+++ b/web/src/js/components/User/UserMenuComponent.js
@@ -28,6 +28,7 @@ import appTheme, {
   dividerColor
 } from 'theme/default'
 import { commaFormatted } from 'utils/utils'
+import { MAX_DAILY_HEARTS_FROM_TABS } from '../../constants'
 
 class UserMenu extends React.Component {
   constructor (props) {
@@ -216,6 +217,11 @@ class UserMenu extends React.Component {
       width: 22
     }
 
+    // TODO
+    // Used to let the user know they aren't earning any more
+    // Hearts from tabs today.
+    // const reachedMaxDailyHearts = user.tabsToday >= MAX_DAILY_HEARTS_FROM_TABS
+
     // TODO: add level bar
     return (
       <div
@@ -400,7 +406,9 @@ UserMenu.propTypes = {
     vcCurrent: PropTypes.number.isRequired,
     level: PropTypes.number.isRequired,
     heartsUntilNextLevel: PropTypes.number.isRequired,
-    vcDonatedAllTime: PropTypes.number.isRequired
+    vcDonatedAllTime: PropTypes.number.isRequired,
+    numUsersRecruited: PropTypes.number.isRequired,
+    tabsToday: PropTypes.number.isRequired
   }),
   style: PropTypes.object
 }

--- a/web/src/js/components/User/UserMenuContainer.js
+++ b/web/src/js/components/User/UserMenuContainer.js
@@ -19,6 +19,7 @@ export default createFragmentContainer(UserMenu, {
       heartsUntilNextLevel 
       vcDonatedAllTime
       numUsersRecruited
+      tabsToday
     }
   `
 })

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -1,4 +1,10 @@
 
+// Configuration
+
+export const MAX_DAILY_HEARTS_FROM_TABS = 150
+
+// Strings passed from server-side. Do not change.
+
 export const WIDGET_TYPE_BOOKMARKS = 'bookmarks'
 export const WIDGET_TYPE_CLOCK = 'clock'
 export const WIDGET_TYPE_NOTES = 'notes'


### PR DESCRIPTION
Set a maximum of 150 Hearts that a user can earn from opening tabs within a single UTC day.

* Analytics change: log all tabs, even those that we consider "invalid" and do not earn any Hearts
* Add "tabsToday" field to user model
* Adjust BaseModel class to set all field defaults before running deserializers
* Show a message to users when they reach maximum Hearts so they understand why their Hearts aren't increasing