### PR TITLE
Improve user data consent logging

### DIFF
--- a/web/src/js/ads/__mocks__/consentManagement.js
+++ b/web/src/js/ads/__mocks__/consentManagement.js
@@ -10,4 +10,6 @@ consentMgmt.hasGlobalConsent = jest.fn(() => {
   return Promise.resolve(true)
 })
 
+consentMgmt.checkIfNewConsentNeedsToBeLogged = jest.fn(() => false)
+
 module.exports = consentMgmt

--- a/web/src/js/ads/consentManagement.js
+++ b/web/src/js/ads/consentManagement.js
@@ -67,11 +67,14 @@ export const displayConsentUI = () => {
  * @return {Promise<undefined>}
  */
 export const registerConsentCallback = async (cb) => {
-  // Note: this callback appears to be buggy as of 5/24/2018
-  // and is called every time the CMP loads outside of the EU.
-  // We should verify that consent data exists before acting
-  // upon the callback.
+  // Note: this callback appears to be buggy as of 5/29/2018.
+  // It's called every time the CMP loads, regardless of
+  // whether in the EU or not. We can't rely on it calling
+  // just once, nor can we rely on consent data existing.
+  // We reached out to Quantcast about this.
   window.__cmp('setConsentUiCallback', async () => {
+    // We should verify that consent data exists before acting
+    // upon the callback.
     const consentString = await getConsentString()
     const isGlobalConsent = await hasGlobalConsent()
     if (consentString) {

--- a/web/src/js/ads/consentManagement.js
+++ b/web/src/js/ads/consentManagement.js
@@ -62,7 +62,9 @@ export const displayConsentUI = () => {
 
 /**
  * Register a callback that will be triggered when a user
- * makes a choice in the consent UI.
+ * makes a choice in the consent UI. Quantcast Choice will
+ * only call the callback once, so the handler must re-register
+ * the callback if it wants to continue to be called.
  * @param {function} cb - The callback function
  * @return {Promise<undefined>}
  */

--- a/web/src/js/components/App/App.js
+++ b/web/src/js/components/App/App.js
@@ -3,14 +3,27 @@ import withPageviewTracking from 'analytics/withPageviewTracking'
 import { isInEuropeanUnion } from 'utils/client-location'
 import {
   registerConsentCallback,
-  saveConsentUpdateEventToLocalStorage
+  saveConsentUpdateEventToLocalStorage,
+  unregisterConsentCallback
 } from 'ads/consentManagement'
 
 class App extends React.Component {
-  async componentWillMount () {
+  constructor (props) {
+    super(props)
+    this.consentChangeCallback = null
+  }
+
+  async componentDidMount () {
     const isEU = await isInEuropeanUnion()
     if (isEU) {
-      registerConsentCallback(this.handleDataConsentDecision.bind(this))
+      this.consentChangeCallback = this.handleDataConsentDecision.bind(this)
+      registerConsentCallback(this.consentChangeCallback)
+    }
+  }
+
+  componentWillUnmount () {
+    if (this.consentChangeCallback) {
+      unregisterConsentCallback(this.consentChangeCallback)
     }
   }
 

--- a/web/src/js/components/App/__tests__/App.test.js
+++ b/web/src/js/components/App/__tests__/App.test.js
@@ -30,7 +30,7 @@ describe('App', () => {
     const wrapper = shallow(
       <App />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
     wrapper.update()
     const registerConsentCallback = require('ads/consentManagement').registerConsentCallback
     expect(registerConsentCallback).toHaveBeenCalled()
@@ -45,7 +45,7 @@ describe('App', () => {
     const wrapper = shallow(
       <App />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
     wrapper.update()
     const registerConsentCallback = require('ads/consentManagement').registerConsentCallback
     expect(registerConsentCallback).not.toHaveBeenCalled()
@@ -69,7 +69,7 @@ describe('App', () => {
     const wrapper = shallow(
       <App />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
     wrapper.update()
 
     // We should not have done anything yet

--- a/web/src/js/components/App/__tests__/App.test.js
+++ b/web/src/js/components/App/__tests__/App.test.js
@@ -79,4 +79,23 @@ describe('App', () => {
     cmpCallback('some-consent-string', true)
     expect(saveConsentUpdateEventToLocalStorage).toHaveBeenCalledTimes(1)
   })
+
+  it('unregisters its callback when unmounting', async () => {
+    expect.assertions(2)
+
+    // Mock that the client is in the EU
+    const isInEuropeanUnion = require('utils/client-location').isInEuropeanUnion
+    isInEuropeanUnion.mockResolvedValue(true)
+    const App = require('../App').default
+    const wrapper = shallow(
+      <App />
+    )
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    const unregisterConsentCallback = require('ads/consentManagement').unregisterConsentCallback
+    expect(unregisterConsentCallback).not.toHaveBeenCalled()
+    wrapper.unmount()
+    expect(unregisterConsentCallback).toHaveBeenCalled()
+  })
 })

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -60,6 +60,7 @@ class Authentication extends React.Component {
     }
   }
 
+  // TODO: change to componentDidMount
   async componentWillMount () {
     this.mounted = true
 

--- a/web/src/js/components/Authentication/AuthenticationView.js
+++ b/web/src/js/components/Authentication/AuthenticationView.js
@@ -21,6 +21,7 @@ class AuthenticationView extends React.Component {
     }
   }
 
+  // TODO: change to componentDidMount
   componentWillMount () {
     this.fetchUser()
   }

--- a/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
+++ b/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
@@ -12,6 +12,7 @@ import {
 } from 'analytics/logEvent'
 
 class FirebaseAuthenticationUI extends React.Component {
+  // TODO: change to componentDidMount
   componentWillMount () {
     this.configureFirebaseUI()
   }

--- a/web/src/js/components/Background/BackgroundImagePickerComponent.js
+++ b/web/src/js/components/Background/BackgroundImagePickerComponent.js
@@ -19,6 +19,8 @@ class BackgroundImagePicker extends React.Component {
     }
   }
 
+  // TODO: change to componentDidMount, or instead probably
+  // just put the logic in the constructor
   componentWillMount () {
     const { app, user } = this.props
     const selectedImage = user.backgroundImage

--- a/web/src/js/components/Campaign/StickerCampaignComponent.js
+++ b/web/src/js/components/Campaign/StickerCampaignComponent.js
@@ -48,6 +48,7 @@ class CountdownClock extends React.Component {
       ${duration.minutes()}m ${duration.seconds()}s`
   }
 
+  // TODO: change to componentDidMount
   componentWillMount () {
     const self = this
 

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -34,6 +34,7 @@ class Dashboard extends React.Component {
     }
   }
 
+  // TODO: move to constructor
   componentWillMount () {
     this.setTabId()
   }

--- a/web/src/js/components/Dashboard/LogConsentDataComponent.js
+++ b/web/src/js/components/Dashboard/LogConsentDataComponent.js
@@ -24,11 +24,11 @@ class LogConsentDataComponent extends React.Component {
     if (checkIfNewConsentNeedsToBeLogged()) {
       const consentString = await getConsentString()
       const isGlobalConsent = await hasGlobalConsent()
-      await this.handleDataConsentDecision(consentString, isGlobalConsent)
+      this.logDataConsentDecision(consentString, isGlobalConsent)
     }
   }
 
-  async handleDataConsentDecision (consentString, isGlobalConsent) {
+  handleDataConsentDecision (consentString, isGlobalConsent) {
     // Re-register the callback with Quantcast Choice so we can
     // handle any other consent changes on this same page view.
     // Quantcast Choice will not call this callback more than once.
@@ -42,7 +42,10 @@ class LogConsentDataComponent extends React.Component {
     if (!consentString) {
       return
     }
+    this.logDataConsentDecision(consentString, isGlobalConsent)
+  }
 
+  logDataConsentDecision (consentString, isGlobalConsent) {
     const { relay, user } = this.props
     const onCompleted = () => {
       markConsentDataAsLogged()

--- a/web/src/js/components/Dashboard/LogConsentDataComponent.js
+++ b/web/src/js/components/Dashboard/LogConsentDataComponent.js
@@ -36,7 +36,6 @@ class LogConsentDataComponent extends React.Component {
   }
 
   componentWillUnmount () {
-    // Unregister the consent callback on unmount.
     if (this.consentChangeCallback) {
       unregisterConsentCallback(this.consentChangeCallback)
     }

--- a/web/src/js/components/Dashboard/LogConsentDataComponent.js
+++ b/web/src/js/components/Dashboard/LogConsentDataComponent.js
@@ -29,6 +29,15 @@ class LogConsentDataComponent extends React.Component {
   }
 
   async handleDataConsentDecision (consentString, isGlobalConsent) {
+    // Re-register the callback with Quantcast Choice so we can
+    // handle any other consent changes on this same page view.
+    // Quantcast Choice will not call this callback more than once.
+    // "To invoke the callback every time the UI is shown, this
+    // operation will need to be made before each time the UI is
+    // brought up with __cmp('displayConsentUi')."
+    // https://quantcast.zendesk.com/hc/en-us/articles/360003814853-Technical-Implementation-Guide
+    registerConsentCallback(this.handleDataConsentDecision.bind(this))
+
     // If we're missing a consent string, don't log.
     if (!consentString) {
       return

--- a/web/src/js/components/Dashboard/LogConsentDataComponent.js
+++ b/web/src/js/components/Dashboard/LogConsentDataComponent.js
@@ -17,8 +17,7 @@ class LogConsentDataComponent extends React.Component {
     this.consentChangeCallback = null
   }
 
-  // TODO: change to componentDidMount, which is only called on the client
-  async componentWillMount () {
+  async componentDidMount () {
     // Register a callback for any new consent updates.
     const isEU = await isInEuropeanUnion()
     if (isEU) {

--- a/web/src/js/components/Dashboard/LogRevenueComponent.js
+++ b/web/src/js/components/Dashboard/LogRevenueComponent.js
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types'
 
 // Log revenue from ads
 class LogRevenueComponent extends React.Component {
+  // TODO: to avoid memory leak,
+  // - change to componentDidMount
+  // - unregister the pubads listener on unmount
   componentWillMount () {
     this.listenForSlotsLoadedEvent()
     this.logRevenueForAlreadyLoadedAds()

--- a/web/src/js/components/Dashboard/__tests__/LogConsentDataComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogConsentDataComponent.test.js
@@ -145,15 +145,8 @@ describe('LogConsentDataComponent', function () {
     expect(LogUserDataConsentMutation.mock.calls[0][2]).toEqual('this-is-my-string')
   })
 
-  it('re-registers the consent data callback when the callback is called', async () => {
+  it('unregisters its callback when unmounting', async () => {
     expect.assertions(2)
-
-    // Mock the callback registration so we can trigger it ourselves
-    var cmpCallback
-    const registerConsentCallback = require('ads/consentManagement').registerConsentCallback
-    registerConsentCallback.mockImplementation(cb => {
-      cmpCallback = cb
-    })
 
     // Mock that the client is in the EU
     const isInEuropeanUnion = require('utils/client-location').isInEuropeanUnion
@@ -168,13 +161,9 @@ describe('LogConsentDataComponent', function () {
     )
     await wrapper.instance().componentWillMount()
 
-    // The component should have registered a callback on mount.
-    expect(registerConsentCallback).toHaveBeenCalled()
-
-    // The component should register a new callback after the
-    // original callback is called.
-    jest.clearAllMocks()
-    await cmpCallback('some-consent-string', true)
-    expect(registerConsentCallback).toHaveBeenCalledTimes(1)
+    const unregisterConsentCallback = require('ads/consentManagement').unregisterConsentCallback
+    expect(unregisterConsentCallback).not.toHaveBeenCalled()
+    wrapper.unmount()
+    expect(unregisterConsentCallback).toHaveBeenCalled()
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/LogConsentDataComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogConsentDataComponent.test.js
@@ -40,7 +40,7 @@ describe('LogConsentDataComponent', function () {
         relay={{ environment: {} }}
       />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
     wrapper.update()
     const registerConsentCallback = require('ads/consentManagement').registerConsentCallback
     expect(registerConsentCallback).toHaveBeenCalled()
@@ -58,7 +58,7 @@ describe('LogConsentDataComponent', function () {
         relay={{ environment: {} }}
       />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
     wrapper.update()
     const registerConsentCallback = require('ads/consentManagement').registerConsentCallback
     expect(registerConsentCallback).not.toHaveBeenCalled()
@@ -85,7 +85,7 @@ describe('LogConsentDataComponent', function () {
         relay={{ environment: {} }}
       />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
     await cmpCallback('some-consent-string', true)
 
     // Check that it calls the mutation.
@@ -133,7 +133,7 @@ describe('LogConsentDataComponent', function () {
         relay={{ environment: {} }}
       />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
 
     // Flush all promises
     await new Promise(resolve => setImmediate(resolve))
@@ -159,7 +159,7 @@ describe('LogConsentDataComponent', function () {
         relay={{ environment: {} }}
       />
     )
-    await wrapper.instance().componentWillMount()
+    await wrapper.instance().componentDidMount()
 
     const unregisterConsentCallback = require('ads/consentManagement').unregisterConsentCallback
     expect(unregisterConsentCallback).not.toHaveBeenCalled()

--- a/web/src/js/components/Settings/Account/AccountComponent.js
+++ b/web/src/js/components/Settings/Account/AccountComponent.js
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
 import { isInEuropeanUnion } from 'utils/client-location'
 import { displayConsentUI } from 'ads/consentManagement'
+import LogConsentData from '../../Dashboard/LogConsentDataContainer'
 
 export const AccountItem = (props) => (
   <div style={{
@@ -81,6 +82,7 @@ class Account extends React.Component {
                   </Button>
                 }
               />
+              { user ? <LogConsentData user={user} /> : null }
             </span>
           )
           : null

--- a/web/src/js/components/Settings/Account/AccountContainer.js
+++ b/web/src/js/components/Settings/Account/AccountContainer.js
@@ -11,6 +11,7 @@ export default createFragmentContainer(Account, {
       id
       email
       username
+      ...LogConsentDataContainer_user
     }
   `
 })

--- a/web/src/js/components/Settings/Account/__tests__/AccountComponent.test.js
+++ b/web/src/js/components/Settings/Account/__tests__/AccountComponent.test.js
@@ -74,4 +74,39 @@ describe('Account component', () => {
     })
     expect(containsDataPrivacyOption).toBe(false)
   })
+
+  it('contains the LogConsentData component when the client is in the EU', async () => {
+    // Mock that the client is in the EU
+    const isInEuropeanUnion = require('utils/client-location').isInEuropeanUnion
+    isInEuropeanUnion.mockResolvedValue(true)
+
+    const AccountComponent = require('../AccountComponent').default
+    const wrapper = shallow(
+      <AccountComponent
+        user={getMockUserData()}
+      />
+    )
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    const LogConsentData = require('../../../Dashboard/LogConsentDataContainer').default
+    expect(wrapper.find(LogConsentData).length > 0).toBe(true)
+  })
+
+  it('does not contain the LogConsentData component when the client is not in the EU', async () => {
+    const isInEuropeanUnion = require('utils/client-location').isInEuropeanUnion
+    isInEuropeanUnion.mockResolvedValue(false)
+
+    const AccountComponent = require('../AccountComponent').default
+    const wrapper = shallow(
+      <AccountComponent
+        user={getMockUserData()}
+      />
+    )
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    const LogConsentData = require('../../../Dashboard/LogConsentDataContainer').default
+    expect(wrapper.find(LogConsentData).length > 0).toBe(false)
+  })
 })

--- a/web/src/js/components/Settings/Background/BackgroundSettingsComponent.js
+++ b/web/src/js/components/Settings/Background/BackgroundSettingsComponent.js
@@ -24,6 +24,7 @@ class BackgroundSettings extends React.Component {
     }
   }
 
+  // TODO: move to constructor
   componentWillMount () {
     const { user } = this.props
     this.setState({

--- a/web/src/js/components/User/UserBackgroundImageComponent.js
+++ b/web/src/js/components/User/UserBackgroundImageComponent.js
@@ -50,6 +50,7 @@ class UserBackgroundImage extends React.Component {
     }
   }
 
+  // TODO: change to componentDidMount
   componentWillMount () {
     // If the props contain valid settings for the background,
     // and they are different from what's already in state,


### PR DESCRIPTION
* Log consent data when it's updated on the accounts page
* Manage our own callback registration for listening for consent change from the the consent management platform, because Quantcast Choice's callback registration isn't ideal
* Add TODOs to stop using `componentWillMount`, which is deprecated and could cause memory leaks with server-side rendering