### PR TITLE
Update Quantcast Choice options

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -178,6 +178,8 @@ src="https://www.facebook.com/tr?id=1813501258922708&ev=PageView&noscript=1"
     'Publisher Purpose IDs': [],
     'Min Days Between UI Displays': 30,
     'Non-Consent Display Frequency': 90,
+    // If true, displays a floating link on all pages
+    'Display Persistent Consent Link': false,
     // Initial screen
     'Initial Screen Title Text': 'We value your privacy',
     'Initial Screen Body Text': 'We and our partners use technology such as cookies on our site to personalise content and ads, provide social media features, and analyse our traffic. Click below to consent to the use of this technology on Tab for a Cause. You can change your mind at any time by visiting your settings page.',


### PR DESCRIPTION
Disable "Display Persistent Consent Link" because we handle the persistent link ourselves.