### PR TITLE
Handle missing user

### DIFF
--- a/graphql/database/base/BaseModel.js
+++ b/graphql/database/base/BaseModel.js
@@ -6,6 +6,7 @@ import { isObject, isFunction, isNil } from 'lodash/lang'
 import dynogels from './dynogels-promisified'
 import types from '../fieldTypes'
 import {
+  DatabaseItemDoesNotExistException,
   NotImplementedException,
   UnauthorizedQueryException
 } from '../../utils/exceptions'
@@ -226,7 +227,7 @@ class BaseModel {
     return this.dynogelsModel.getAsync(...keys)
       .then(data => {
         if (isNil(data)) {
-          throw new Error(`Could not get item with hash key ${hashKey}.`)
+          throw new DatabaseItemDoesNotExistException()
         }
         return self.deserialize(data)
       })

--- a/graphql/database/base/__tests__/BaseModel-queries.test.js
+++ b/graphql/database/base/__tests__/BaseModel-queries.test.js
@@ -15,6 +15,7 @@ import {
   setModelPermissions
 } from '../../test-utils'
 import {
+  DatabaseItemDoesNotExistException,
   UnauthorizedQueryException
 } from '../../../utils/exceptions'
 
@@ -108,7 +109,7 @@ describe('BaseModel queries', () => {
     expect(response).toEqual(itemToGet)
   })
 
-  it('correctly handles a `get` that returns no item', async () => {
+  it('throws an error when a `get` returns no item', async () => {
     setModelPermissions(ExampleModel, {
       get: () => true
     })
@@ -121,8 +122,9 @@ describe('BaseModel queries', () => {
         Item: null
       }
     )
-    const promise = ExampleModel.get(user, itemToGet.id)
-    await expect(promise).rejects.toBeDefined()
+
+    return expect(ExampleModel.get(user, itemToGet.id))
+      .rejects.toEqual(new DatabaseItemDoesNotExistException())
   })
 
   it('correctly uses `get` method for a model with a range key', async () => {

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -13,6 +13,10 @@ import {
 } from '../../utils/authorization-helpers'
 import config from '../../config'
 import { getTodayTabCount } from './user-utils'
+import {
+  DATABASE_ITEM_DOES_NOT_EXIST,
+  UserDoesNotExistException
+} from '../../utils/exceptions'
 
 const mediaRoot = config.MEDIA_ENDPOINT
 
@@ -136,6 +140,21 @@ class User extends BaseModel {
           imageURL: `${mediaRoot}/img/backgrounds/${backgroundImage.image}`,
           thumbnailURL: `${mediaRoot}/img/background-thumbnails/${backgroundImage.thumbnail}`
         })
+      }
+    }
+  }
+
+  // Extend the `get` method to throw a unique error when
+  // an item does not exist.
+  static async get (...args) {
+    try {
+      const response = await super.get(...args)
+      return response
+    } catch (e) {
+      if (e.code === DATABASE_ITEM_DOES_NOT_EXIST) {
+        throw new UserDoesNotExistException()
+      } else {
+        throw e
       }
     }
   }

--- a/graphql/database/users/__tests__/UserModel.test.js
+++ b/graphql/database/users/__tests__/UserModel.test.js
@@ -6,7 +6,10 @@ import { permissionAuthorizers } from '../../../utils/authorization-helpers'
 import User from '../UserModel'
 import config from '../../../config'
 import {
-  mockDate
+  DatabaseOperation,
+  mockDate,
+  getMockUserContext,
+  setMockDBResponse
 } from '../../test-utils'
 
 const mediaRoot = config.MEDIA_ENDPOINT
@@ -171,6 +174,41 @@ describe('UserModel', () => {
     const item = null
     expect(User.permissions.create(userContext, null, null, item))
       .toBe(false)
+  })
+
+  it('throws an error when a `get` returns no item', () => {
+    const userContext = getMockUserContext()
+    const mockItemId = userContext.id
+
+    // Set mock response from DB client.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: null
+      }
+    )
+
+    return expect(User.get(userContext, mockItemId))
+      .rejects.toThrow('The database does not contain an item with these keys')
+  })
+
+  it('does not throw an error when a `get` returns an item', () => {
+    const userContext = getMockUserContext()
+    const mockItemId = userContext.id
+
+    // Set mock response from DB client.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: {
+          // Actual item would have more properties
+          id: mockItemId
+        }
+      }
+    )
+
+    return expect(User.get(userContext, mockItemId))
+      .resolves.toBeDefined()
   })
 
   it('constructs as expected', () => {

--- a/graphql/database/users/__tests__/UserModel.test.js
+++ b/graphql/database/users/__tests__/UserModel.test.js
@@ -11,6 +11,10 @@ import {
   getMockUserContext,
   setMockDBResponse
 } from '../../test-utils'
+import {
+  UnauthorizedQueryException,
+  UserDoesNotExistException
+} from '../../../utils/exceptions'
 
 const mediaRoot = config.MEDIA_ENDPOINT
 
@@ -176,7 +180,7 @@ describe('UserModel', () => {
       .toBe(false)
   })
 
-  it('throws an error when a `get` returns no item', () => {
+  it('throws an UserDoesNotExistException error when a `get` returns no item', () => {
     const userContext = getMockUserContext()
     const mockItemId = userContext.id
 
@@ -187,9 +191,16 @@ describe('UserModel', () => {
         Item: null
       }
     )
-
     return expect(User.get(userContext, mockItemId))
-      .rejects.toThrow('The database does not contain an item with these keys')
+      .rejects.toEqual(new UserDoesNotExistException())
+  })
+
+  it('throws an error when `get` throws an error other than "item does not exist"', () => {
+    const userContext = getMockUserContext()
+
+    // Use an unauthorized request to get its error.
+    return expect(User.get(userContext, 'unauthorized-user-id-here'))
+      .rejects.toEqual(new UnauthorizedQueryException())
   })
 
   it('does not throw an error when a `get` returns an item', () => {

--- a/graphql/utils/__tests__/error-logging.test.js
+++ b/graphql/utils/__tests__/error-logging.test.js
@@ -6,7 +6,8 @@ import {
 } from '../error-logging'
 import {
   UNAUTHORIZED_QUERY,
-  UnauthorizedQueryException
+  UnauthorizedQueryException,
+  UserDoesNotExistException
 } from '../exceptions'
 import logger from '../logger'
 
@@ -64,9 +65,21 @@ describe('error-logging', () => {
     expect(formattedErr).toEqual(expectedFormattedErr)
   })
 
-  test('handleError logs the error', () => {
+  test('handleError logs a normal error', () => {
     const mockGraphQLErr = new MockGraphQLError(new Error('Yikes!'))
     handleError(mockGraphQLErr)
     expect(logger.error).toHaveBeenCalledWith(mockGraphQLErr)
+  })
+
+  test('handleError logs a custom error', () => {
+    const mockGraphQLErr = new MockGraphQLError(new UnauthorizedQueryException())
+    handleError(mockGraphQLErr)
+    expect(logger.error).toHaveBeenCalledWith(mockGraphQLErr)
+  })
+
+  test('handleError does not log an error that should not be logged', () => {
+    const mockGraphQLErr = new MockGraphQLError(new UserDoesNotExistException())
+    handleError(mockGraphQLErr)
+    expect(logger.error).not.toHaveBeenCalled()
   })
 })

--- a/graphql/utils/error-logging.js
+++ b/graphql/utils/error-logging.js
@@ -1,6 +1,9 @@
 
 import logger from './logger'
 import { get } from 'lodash/object'
+import {
+  USER_DOES_NOT_EXIST
+} from './exceptions'
 
 /*
  * Wrap a function and log all exceptions, then re-throw the
@@ -35,6 +38,20 @@ export const formatError = (graphQLError) => {
 }
 
 /*
+ * Determine whether we should log an error. Some errors are
+ * fairly expected and shouldn't be logged.
+ * @param {object} graphQLError - The GraphQL error.
+ * @return {Boolean} Whether we should log the error.
+ */
+const shouldLogError = graphQLError => {
+  const errorCodesToSkipLogging = [
+    USER_DOES_NOT_EXIST
+  ]
+  const errCode = get(graphQLError, 'originalError.code')
+  return errorCodesToSkipLogging.indexOf(errCode) === -1
+}
+
+/*
  * The handler for any GraphQL errors, primarily for logging and
  * formatting errors.
  * We will use this as the `formatError` function in graphQLHTTP.
@@ -42,7 +59,9 @@ export const formatError = (graphQLError) => {
  * @return {object} The error to send to the client (optionally formatted).
  */
 export const handleError = (graphQLError) => {
-  logger.error(graphQLError)
+  if (shouldLogError(graphQLError)) {
+    logger.error(graphQLError)
+  }
 
   // TODO: probably want to return different message
   // for some error types (e.g. UnauthorizedQueryException)

--- a/graphql/utils/error-logging.js
+++ b/graphql/utils/error-logging.js
@@ -1,6 +1,7 @@
 
 // import uuid from 'uuid'
 import logger from './logger'
+import { get } from 'lodash/object'
 
 /*
  * Wrap a function and log all exceptions, then re-throw the
@@ -29,7 +30,8 @@ export const formatError = (graphQLError) => {
   return {
     message: graphQLError.message,
     locations: graphQLError.locations,
-    path: graphQLError.path
+    path: graphQLError.path,
+    code: get(graphQLError, 'originalError.code', null)
   }
 }
 

--- a/graphql/utils/error-logging.js
+++ b/graphql/utils/error-logging.js
@@ -1,5 +1,4 @@
 
-// import uuid from 'uuid'
 import logger from './logger'
 import { get } from 'lodash/object'
 
@@ -43,13 +42,6 @@ export const formatError = (graphQLError) => {
  * @return {object} The error to send to the client (optionally formatted).
  */
 export const handleError = (graphQLError) => {
-  // FIXME: disabled because it's breaking some of the error messages.
-  // // Return masked error messages to the client side to
-  // // prevent leakage of any sensitive info.
-  // // Inspired by graphql-errors package:
-  // // https://github.com/kadirahq/graphql-errors/blob/master/lib/index.js#L29
-  // const errId = uuid.v4()
-  // logErrorWithId(graphQLError, errId)
   logger.error(graphQLError)
 
   // TODO: probably want to return different message

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -12,7 +12,7 @@ class ExtendableError extends Error {
 
 class NotImplementedException extends ExtendableError {
   constructor () {
-    super('Required method is not implmented.')
+    super('Required method is not implemented.')
   }
 }
 
@@ -24,7 +24,7 @@ class UnauthorizedQueryException extends ExtendableError {
 
 class UserReachedMaxLevelException extends ExtendableError {
   constructor () {
-    super('There are no more levels user at max level.')
+    super('There are no more levels. The user is at the max level.')
   }
 }
 
@@ -38,19 +38,11 @@ class EmptyOperationStackException extends MockDatabaseException {
   }
 }
 
-class OperationMissmatchException extends MockDatabaseException {
-  constructor (expectedOperation, receivedOperation) {
-    const message = `Expected <${expectedOperation}> operation but 
-              received <${receivedOperation}> operation instead.`
-
-    super(message)
-  }
-}
+//
 
 export {
   NotImplementedException,
   UnauthorizedQueryException,
   UserReachedMaxLevelException,
-  EmptyOperationStackException,
-  OperationMissmatchException
+  EmptyOperationStackException
 }

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -26,6 +26,14 @@ class UnauthorizedQueryException extends ExtendableError {
   }
 }
 
+export const DATABASE_ITEM_DOES_NOT_EXIST = 'DATABASE_ITEM_DOES_NOT_EXIST'
+class DatabaseItemDoesNotExistException extends ExtendableError {
+  constructor () {
+    super('The database does not contain an item with these keys.')
+    this.code = DATABASE_ITEM_DOES_NOT_EXIST
+  }
+}
+
 export const USER_REACHED_MAX_LEVEL = 'USER_REACHED_MAX_LEVEL'
 class UserReachedMaxLevelException extends ExtendableError {
   constructor () {
@@ -56,6 +64,7 @@ class EmptyOperationStackException extends MockDatabaseException {
 export {
   NotImplementedException,
   UnauthorizedQueryException,
+  DatabaseItemDoesNotExistException,
   UserReachedMaxLevelException,
   UserDoesNotExistException,
   EmptyOperationStackException

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -34,6 +34,14 @@ class UserReachedMaxLevelException extends ExtendableError {
   }
 }
 
+export const USER_DOES_NOT_EXIST = 'USER_DOES_NOT_EXIST'
+class UserDoesNotExistException extends ExtendableError {
+  constructor () {
+    super('No user exists with this ID.')
+    this.code = USER_DOES_NOT_EXIST
+  }
+}
+
 // For tests.
 class MockDatabaseException extends ExtendableError {}
 
@@ -45,12 +53,10 @@ class EmptyOperationStackException extends MockDatabaseException {
   }
 }
 
-// TODO:
-// USER_DOES_NOT_EXIST_ERROR
-
 export {
   NotImplementedException,
   UnauthorizedQueryException,
   UserReachedMaxLevelException,
+  UserDoesNotExistException,
   EmptyOperationStackException
 }

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -10,35 +10,43 @@ class ExtendableError extends Error {
   }
 }
 
+export const METHOD_NOT_IMPLEMENTED = 'METHOD_NOT_IMPLEMENTED'
 class NotImplementedException extends ExtendableError {
   constructor () {
     super('Required method is not implemented.')
+    this.code = UNAUTHORIZED_QUERY
   }
 }
 
+export const UNAUTHORIZED_QUERY = 'UNAUTHORIZED_QUERY'
 class UnauthorizedQueryException extends ExtendableError {
   constructor () {
     super('Query not authorized.')
+    this.code = UNAUTHORIZED_QUERY
   }
 }
 
+export const USER_REACHED_MAX_LEVEL = 'USER_REACHED_MAX_LEVEL'
 class UserReachedMaxLevelException extends ExtendableError {
   constructor () {
     super('There are no more levels. The user is at the max level.')
+    this.code = USER_REACHED_MAX_LEVEL
   }
 }
 
-class MockDatabaseException extends ExtendableError {
+// For tests.
+class MockDatabaseException extends ExtendableError {}
 
-}
-
+export const OPERATION_STACK_IS_EMPTY = 'OPERATION_STACK_IS_EMPTY'
 class EmptyOperationStackException extends MockDatabaseException {
   constructor () {
     super('Operation stack is empty. Check if you set your expected data in the test.')
+    this.code = OPERATION_STACK_IS_EMPTY
   }
 }
 
-//
+// TODO:
+// USER_DOES_NOT_EXIST_ERROR
 
 export {
   NotImplementedException,

--- a/web/__mocks__/react-relay.js
+++ b/web/__mocks__/react-relay.js
@@ -1,10 +1,74 @@
 /* eslint-env jest */
 import React from 'react'
+import PropTypes from 'prop-types'
 
 // A gist with mock for Relay Modern:
 // https://gist.github.com/robrichard/ad838e599d828a89978f54faaa2070a8
 
 const RelayMock = jest.genMockFromModule('react-relay')
+
+/*
+  Mock createFragmentContainer, createRefetchContainer, and
+  createPaginationContainer functionality.
+*/
+
+const relayChildContextTypes = {
+  relay: PropTypes.object
+}
+
+const relayEnvironment = {
+  lookup: jest.fn()
+}
+
+const relayContext = {
+  relay: {
+    environment: relayEnvironment,
+    variables: {}
+  }
+}
+
+const relayFragmentProps = {
+  relay: {
+    environment: relayEnvironment
+  }
+}
+
+const relayRefetchProps = {
+  relay: {
+    environment: relayEnvironment,
+    refetch: jest.fn()
+  }
+}
+
+const relayPaginationProps = {
+  relay: {
+    environment: relayEnvironment,
+    hasMore: jest.fn(),
+    loadMore: jest.fn(),
+    isLoading: jest.fn()
+  }
+}
+
+function makeRelayWrapper (relayProps) {
+  return function (Comp) {
+    class HOC extends React.Component {
+      getChildContext () {
+        return relayContext
+      }
+
+      render () {
+        return <Comp {...this.props} {...relayProps} />
+      }
+    }
+
+    HOC.childContextTypes = relayChildContextTypes
+    return HOC
+  }
+}
+
+RelayMock.createFragmentContainer = makeRelayWrapper(relayFragmentProps)
+RelayMock.createRefetchContainer = makeRelayWrapper(relayRefetchProps)
+RelayMock.createPaginationContainer = makeRelayWrapper(relayPaginationProps)
 
 /* Mock QueryRenderer functionality */
 

--- a/web/__mocks__/react-relay/compat.js
+++ b/web/__mocks__/react-relay/compat.js
@@ -1,10 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
 
-// A gist with mock for Relay Modern:
-// https://gist.github.com/robrichard/ad838e599d828a89978f54faaa2070a8
-
-const RelayMock = jest.genMockFromModule('react-relay')
+const RelayCompatMock = jest.genMockFromModule('react-relay/compat')
 
 /* Mock QueryRenderer functionality */
 
@@ -25,7 +22,7 @@ const MockComponent = props => {
 }
 MockComponent.displayName = 'QueryRenderer'
 
-RelayMock.QueryRenderer = MockComponent
+RelayCompatMock.QueryRenderer = MockComponent
 
 /**
  * Set the mock response value passed as an argument to the mock
@@ -41,8 +38,8 @@ RelayMock.QueryRenderer = MockComponent
  *   would retry the query.
  * @return {undefined}
  */
-RelayMock.QueryRenderer.__setQueryResponse = mockResponse => {
+RelayCompatMock.QueryRenderer.__setQueryResponse = mockResponse => {
   queryRendererResponse = mockResponse
 }
 
-module.exports = RelayMock
+module.exports = RelayCompatMock

--- a/web/__mocks__/react-relay/compat.js
+++ b/web/__mocks__/react-relay/compat.js
@@ -1,45 +1,5 @@
 /* eslint-env jest */
-import React from 'react'
+import RelayMock from '../react-relay'
 
-const RelayCompatMock = jest.genMockFromModule('react-relay/compat')
-
-/* Mock QueryRenderer functionality */
-
-// The default mock response used to call the QueryRenderer's
-// `render` prop.
-var queryRendererResponse = {
-  error: null,
-  props: null,
-  retry: jest.fn()
-}
-
-// The mock QueryRenderer component, which will call the
-// `render` prop on mount and render the response as child
-// elements.
-const MockComponent = props => {
-  const children = props.render ? props.render(queryRendererResponse) : null
-  return <span>{children}</span>
-}
-MockComponent.displayName = 'QueryRenderer'
-
-RelayCompatMock.QueryRenderer = MockComponent
-
-/**
- * Set the mock response value passed as an argument to the mock
- * QueryRenderer's `render` function prop. Set this before rendering
- * the component.
- * @param {Object} mockResponse
- * @param {Object|null} mockResponse.error - Any errors returned from
- *   the mock Relay query
- * @param {Object|null} mockResponse.props - Any props returned from
- *   the mock Relay query. These should match the form expected from
- *   the QueryRenderer's `query` prop.
- * @param {function} mockResponse.retry - A function that, if called,
- *   would retry the query.
- * @return {undefined}
- */
-RelayCompatMock.QueryRenderer.__setQueryResponse = mockResponse => {
-  queryRendererResponse = mockResponse
-}
-
-module.exports = RelayCompatMock
+// Just use our react-relay mock.
+module.exports = RelayMock

--- a/web/src/js/authentication/__tests__/helpers.test.js
+++ b/web/src/js/authentication/__tests__/helpers.test.js
@@ -12,12 +12,16 @@ import {
   getReferralData
 } from 'web-utils'
 import CreateNewUserMutation from 'mutations/CreateNewUserMutation'
+import {
+  getCurrentUser
+} from 'authentication/user'
 
 jest.mock('authentication/user')
 jest.mock('navigation/navigation')
 jest.mock('utils/localstorage-mgr')
 jest.mock('web-utils')
 jest.mock('mutations/CreateNewUserMutation')
+jest.mock('authentication/user')
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -106,8 +110,17 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
 describe('createNewUser tests', () => {
   it('returns the new user data', async () => {
     expect.assertions(1)
+
+    // Mock the authed user
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'somebody@example.com',
+      username: null,
+      isAnonymous: false,
+      emailVerified: false
+    })
+
     getReferralData.mockImplementationOnce(() => null)
-    const createNewUser = require('../helpers').createNewUser
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
@@ -123,7 +136,8 @@ describe('createNewUser tests', () => {
       }
     )
 
-    const newUser = await createNewUser('abc123', 'somebody@example.com')
+    const createNewUser = require('../helpers').createNewUser
+    const newUser = await createNewUser()
 
     expect(newUser).toEqual({
       id: 'abc123',
@@ -138,7 +152,15 @@ describe('createNewUser tests', () => {
     getReferralData.mockImplementationOnce(() => ({
       referringUser: 'asdf1234'
     }))
-    const createNewUser = require('../helpers').createNewUser
+
+    // Mock the authed user
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'somebody@example.com',
+      username: null,
+      isAnonymous: false,
+      emailVerified: false
+    })
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
@@ -154,6 +176,7 @@ describe('createNewUser tests', () => {
       }
     )
 
+    const createNewUser = require('../helpers').createNewUser
     await createNewUser('abc123', 'somebody@example.com')
 
     expect(CreateNewUserMutation.mock.calls[0][3]).toEqual({

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -44,6 +44,20 @@ const allowAnonymousUser = () => {
 export const checkAuthStateAndRedirectIfNeeded = (user, fetchedUsername = null) => {
   var redirected = true
 
+  // FIXME: need to handle a state where the user is authenticated
+  // but does not have a user on the server. This can happen if
+  // Firebase authentication succeeds but the request to our server
+  // fails (e.g., network error, or user navigates away).
+  // We may want to handle this in QueryRenderers:
+  // - In GraphQL, create a custom UserDoesNotExist error
+  // - UserModel extends BaseModel's `get` method; if the item
+  //   does not exist, throw UserDoesNotExist
+  // - In formatError, return error codes. Also filter out some
+  //   errors that we do not want to log because they're sometimes
+  //   expected, like UserDoesNotExist errors.
+  // - In QueryRenderers, if the error indicates that the user does
+  //   not exist, create the user and then re-query.
+
   // If the user is not fully logged in, redirect to the
   // appropriate auth page.
   // User is not logged in.

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -117,11 +117,11 @@ export const checkAuthStateAndRedirectIfNeeded = (user, fetchedUsername = null) 
 /**
  * Create a new user in our database, or get the user if they already
  * exist. This is idempotent and may be called when returning users sign in.
- * @returns {Promise<object>} user - A promise that resolves into an
- *   object with a few requested fields
+ * @returns {Promise<object>} user - A promise that resolves into a
+ *   user object
  * @returns {string} user.id - The user's ID, the same value as the
  *   userId argument
- * @returns {string} user.email - The user's email, the same value as the
+ * @returns {string|null} user.email - The user's email, the same value as the
  *   email argument
  * @returns {string|null} user.username - The user's username, if already
  *   set; or null, if not yet set

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import environment from '../../../relay-env'
 import {
   getCurrentUser,
   sendVerificationEmail
 } from 'authentication/user'
 import {
-  checkAuthStateAndRedirectIfNeeded
+  checkAuthStateAndRedirectIfNeeded,
+  createNewUser
 } from 'authentication/helpers'
 import {
   goTo,
@@ -14,10 +14,6 @@ import {
   verifyEmailURL,
   goToDashboard
 } from 'navigation/navigation'
-import CreateNewUserMutation from 'mutations/CreateNewUserMutation'
-import {
-  getReferralData
-} from 'web-utils'
 import { isEqual } from 'lodash/lang'
 import LogoWithText from '../Logo/LogoWithText'
 
@@ -135,7 +131,7 @@ class Authentication extends React.Component {
     }
 
     // Get or create the user
-    return this.createNewUser(currentUser.uid, currentUser.email)
+    return createNewUser(currentUser.uid, currentUser.email)
       .then((createdOrFetchedUser) => {
         // Check if the user has verified their email.
         // Note: later versions of firebaseui-web might support mandatory
@@ -162,39 +158,6 @@ class Authentication extends React.Component {
         // TODO: show error message to the user
         console.error(err)
       })
-  }
-
-  /**
-   * Create a new user in our database, or get the user if they already
-   * exist. This is idempotent and will be called when returning users sign in.
-   * @param {string} userId - The userId from Firebase
-   * @param {string} email - The user's email address from Firebase
-   * @returns {Promise<object>} user - A promise that resolves into an
-   *   object with a few requested fields
-   * @returns {string} user.id - The user's ID, the same value as the
-   *   userId argument
-   * @returns {string} user.email - The user's email, the same value as the
-   *   email argument
-   * @returns {string|null} user.username - The user's username, if already
-   *   set; or null, if not yet set
-   */
-  createNewUser (userId, email) {
-    const referralData = getReferralData()
-    return new Promise((resolve, reject) => {
-      CreateNewUserMutation(
-        environment,
-        userId,
-        email,
-        referralData,
-        (response) => {
-          resolve(response.createNewUser)
-        },
-        (err) => {
-          console.error('Error at createNewUser:', err)
-          reject(new Error('Could not create new user', err))
-        }
-      )
-    })
   }
 
   render () {

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -131,7 +131,7 @@ class Authentication extends React.Component {
     }
 
     // Get or create the user
-    return createNewUser(currentUser.uid, currentUser.email)
+    return createNewUser()
       .then((createdOrFetchedUser) => {
         // Check if the user has verified their email.
         // Note: later versions of firebaseui-web might support mandatory

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -480,7 +480,30 @@ describe('Authentication.js tests', function () {
 
   it('uses referral data when creating a new user', async () => {
     expect.assertions(1)
+
+    getReferralData.mockImplementationOnce(() => ({
+      referringUser: 'asdf1234'
+    }))
+
     const Authentication = require('../Authentication').default
+
+    // Args for onSignInSuccess
+    const mockFirebaseUserInstance = {
+      displayName: '',
+      email: 'foo@bar.com',
+      emailVerified: true,
+      isAnonymous: false,
+      metadata: {},
+      phoneNumber: null,
+      photoURL: null,
+      providerData: {},
+      providerId: 'some-id',
+      refreshToken: 'xyzxyz',
+      uid: 'abc123'
+    }
+    const mockFirebaseCredential = {}
+    const mockFirebaseDefaultRedirectURL = ''
+    const mockFetchUser = jest.fn()
 
     const wrapper = shallow(
       <Authentication
@@ -490,16 +513,25 @@ describe('Authentication.js tests', function () {
       />
     )
     const component = wrapper.instance()
+
+    // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
       (environment, userId, email, referralData, onCompleted, onError) => {
-        onCompleted({})
+        onCompleted({
+          createNewUser: {
+            id: 'abc123',
+            email: 'foo@bar.com',
+            username: 'fooismyname',
+            justCreated: true
+          }
+        })
       }
     )
-    getReferralData.mockImplementationOnce(() => ({
-      referringUser: 'asdf1234'
-    }))
 
-    await component.createNewUser('some-user-id', 'foo@bar.com')
+    // Mock a call from FirebaseUI after user signs in
+    component.onSignInSuccess(mockFirebaseUserInstance,
+      mockFirebaseCredential, mockFirebaseDefaultRedirectURL)
+
     expect(CreateNewUserMutation.mock.calls[0][3]).toEqual({
       referringUser: 'asdf1234'
     })

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -103,8 +103,8 @@ describe('Authentication.js tests', function () {
       username: null
     }
 
-    // Mock the Firebase user
-    getCurrentUser.mockReturnValueOnce({
+    // Mock the authed user
+    getCurrentUser.mockResolvedValue({
       id: 'abc123',
       email: 'foo@bar.com',
       username: 'foo',
@@ -133,7 +133,7 @@ describe('Authentication.js tests', function () {
     }
 
     // User is unauthed
-    getCurrentUser.mockReturnValueOnce(null)
+    getCurrentUser.mockResolvedValue(null)
 
     // Inside an iframe
     isInIframe.mockReturnValueOnce(true)
@@ -159,7 +159,7 @@ describe('Authentication.js tests', function () {
     }
 
     // User is unauthed
-    getCurrentUser.mockReturnValueOnce(null)
+    getCurrentUser.mockResolvedValue(null)
 
     // Inside an iframe
     isInIframe.mockReturnValueOnce(false)
@@ -184,7 +184,7 @@ describe('Authentication.js tests', function () {
       username: null
     }
 
-    getCurrentUser.mockReturnValueOnce({
+    getCurrentUser.mockResolvedValue({
       id: 'abc123',
       email: null,
       username: null,
@@ -213,7 +213,7 @@ describe('Authentication.js tests', function () {
       username: null
     }
 
-    getCurrentUser.mockReturnValueOnce({
+    getCurrentUser.mockResolvedValue({
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -242,7 +242,7 @@ describe('Authentication.js tests', function () {
       username: null
     }
 
-    getCurrentUser.mockReturnValueOnce({
+    getCurrentUser.mockResolvedValue({
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -271,7 +271,7 @@ describe('Authentication.js tests', function () {
       username: 'fooismyname'
     }
 
-    getCurrentUser.mockReturnValueOnce({
+    getCurrentUser.mockResolvedValue({
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -301,7 +301,7 @@ describe('Authentication.js tests', function () {
       username: null
     }
 
-    getCurrentUser.mockReturnValueOnce({
+    getCurrentUser.mockResolvedValue({
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -374,7 +374,6 @@ describe('Authentication.js tests', function () {
 
   it('after sign-in, send email verification if email is not verified', async () => {
     expect.assertions(2)
-    const Authentication = require('../Authentication').default
 
     // Args for onSignInSuccess
     const mockFirebaseUserInstance = {
@@ -393,6 +392,32 @@ describe('Authentication.js tests', function () {
     const mockFirebaseCredential = {}
     const mockFirebaseDefaultRedirectURL = ''
 
+    // Mock the authed user
+    // getCurrentUser.mockResolvedValue({
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'foo@bar.com',
+      username: null,
+      isAnonymous: false,
+      emailVerified: false // Note that email is unverified
+    })
+
+    // Mock a response from new user creation
+    CreateNewUserMutation.mockImplementationOnce(
+      (environment, userId, email, referralData, onCompleted, onError) => {
+        onCompleted({
+          createNewUser: {
+            id: 'abc123',
+            email: 'foo@bar.com',
+            username: null
+          }
+        })
+      }
+    )
+
+    sendVerificationEmail.mockImplementationOnce(() => Promise.resolve(true))
+
+    const Authentication = require('../Authentication').default
     const wrapper = shallow(
       <Authentication
         location={mockLocationData}
@@ -402,22 +427,6 @@ describe('Authentication.js tests', function () {
     )
     const component = wrapper.instance()
 
-    // Mock a response from new user creation
-    CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, onCompleted, onError) => {
-        onCompleted({
-          createNewUser: {
-            id: 'abc123',
-            email: 'foo@bar.com',
-            username: 'fooismyname',
-            justCreated: true
-          }
-        })
-      }
-    )
-
-    sendVerificationEmail.mockImplementationOnce(() => Promise.resolve(true))
-
     // Mock a call from FirebaseUI after user signs in
     await component.onSignInSuccess(mockFirebaseUserInstance,
       mockFirebaseCredential, mockFirebaseDefaultRedirectURL)
@@ -426,9 +435,8 @@ describe('Authentication.js tests', function () {
     expect(goTo).toHaveBeenCalledWith(verifyEmailURL)
   })
 
-  it('after sign-in, refetch the user', async () => {
+  it('refetches the user after sign-in', async () => {
     expect.assertions(1)
-    const Authentication = require('../Authentication').default
 
     // Args for onSignInSuccess
     const mockFirebaseUserInstance = {
@@ -448,6 +456,30 @@ describe('Authentication.js tests', function () {
     const mockFirebaseDefaultRedirectURL = ''
     const mockFetchUser = jest.fn()
 
+    // Mock a response from new user creation
+    CreateNewUserMutation.mockImplementationOnce(
+      (environment, userId, email, referralData, onCompleted, onError) => {
+        onCompleted({
+          createNewUser: {
+            id: 'abc123',
+            email: 'foo@bar.com',
+            username: null,
+            justCreated: true
+          }
+        })
+      }
+    )
+
+    // Mock the authed user
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'foo@bar.com',
+      username: null,
+      isAnonymous: false,
+      emailVerified: true
+    })
+
+    const Authentication = require('../Authentication').default
     const wrapper = shallow(
       <Authentication
         location={mockLocationData}
@@ -456,20 +488,6 @@ describe('Authentication.js tests', function () {
       />
     )
     const component = wrapper.instance()
-
-    // Mock a response from new user creation
-    CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, onCompleted, onError) => {
-        onCompleted({
-          createNewUser: {
-            id: 'abc123',
-            email: 'foo@bar.com',
-            username: 'fooismyname',
-            justCreated: true
-          }
-        })
-      }
-    )
 
     // Mock a call from FirebaseUI after user signs in
     await component.onSignInSuccess(mockFirebaseUserInstance,
@@ -485,8 +503,6 @@ describe('Authentication.js tests', function () {
       referringUser: 'asdf1234'
     }))
 
-    const Authentication = require('../Authentication').default
-
     // Args for onSignInSuccess
     const mockFirebaseUserInstance = {
       displayName: '',
@@ -505,15 +521,6 @@ describe('Authentication.js tests', function () {
     const mockFirebaseDefaultRedirectURL = ''
     const mockFetchUser = jest.fn()
 
-    const wrapper = shallow(
-      <Authentication
-        location={mockLocationData}
-        user={mockUserData}
-        fetchUser={mockFetchUser}
-      />
-    )
-    const component = wrapper.instance()
-
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
       (environment, userId, email, referralData, onCompleted, onError) => {
@@ -528,8 +535,27 @@ describe('Authentication.js tests', function () {
       }
     )
 
+    // Mock the authed user
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'foo@bar.com',
+      username: null,
+      isAnonymous: false,
+      emailVerified: true
+    })
+
+    const Authentication = require('../Authentication').default
+    const wrapper = shallow(
+      <Authentication
+        location={mockLocationData}
+        user={mockUserData}
+        fetchUser={mockFetchUser}
+      />
+    )
+    const component = wrapper.instance()
+
     // Mock a call from FirebaseUI after user signs in
-    component.onSignInSuccess(mockFirebaseUserInstance,
+    await component.onSignInSuccess(mockFirebaseUserInstance,
       mockFirebaseCredential, mockFirebaseDefaultRedirectURL)
 
     expect(CreateNewUserMutation.mock.calls[0][3]).toEqual({

--- a/web/src/js/components/Dashboard/DashboardView.js
+++ b/web/src/js/components/Dashboard/DashboardView.js
@@ -1,7 +1,7 @@
 /* global graphql */
 
 import React from 'react'
-import {QueryRenderer} from 'react-relay/compat'
+import { QueryRenderer } from 'react-relay/compat'
 import environment from '../../../relay-env'
 
 import AuthUserComponent from 'general/AuthUserComponent'

--- a/web/src/js/components/Dashboard/DashboardView.js
+++ b/web/src/js/components/Dashboard/DashboardView.js
@@ -8,6 +8,14 @@ import AuthUserComponent from 'general/AuthUserComponent'
 import ErrorMessage from 'general/ErrorMessage'
 
 import DashboardContainer from './DashboardContainer'
+import { createNewUser } from 'authentication/helpers'
+import {
+  goTo,
+  loginURL
+} from 'navigation/navigation'
+import {
+  ERROR_USER_DOES_NOT_EXIST
+} from '../../constants'
 
 class DashboardView extends React.Component {
   render () {
@@ -25,11 +33,28 @@ class DashboardView extends React.Component {
               }
             }
           `}
-          render={({error, props}) => {
+          render={({ error, props, retry }) => {
+            // TODO: add tests
             if (error) {
-              console.error(error, error.source)
-              const errMsg = 'We had a problem loading your dashboard :('
-              return <ErrorMessage message={errMsg} />
+              // If any of the errors is because the user does not exist
+              // on the server side, create the user and re-query if
+              // possible. If it's not possible to create a new user,
+              // redirect to the authentication page.
+              const userDoesNotExistError = error.source.errors
+                .some(err => err.code === ERROR_USER_DOES_NOT_EXIST)
+
+              if (userDoesNotExistError) {
+                createNewUser()
+                  .then(user => {
+                    retry()
+                  })
+                  .catch(e => {
+                    goTo(loginURL)
+                  })
+              } else {
+                const errMsg = 'We had a problem loading your dashboard :('
+                return <ErrorMessage message={errMsg} />
+              }
             }
             if (!props) {
               props = {}

--- a/web/src/js/components/Dashboard/DashboardView.js
+++ b/web/src/js/components/Dashboard/DashboardView.js
@@ -34,7 +34,6 @@ class DashboardView extends React.Component {
             }
           `}
           render={({ error, props, retry }) => {
-            // TODO: add tests
             if (error) {
               // If any of the errors is because the user does not exist
               // on the server side, create the user and re-query if

--- a/web/src/js/components/Dashboard/__mocks__/DashboardContainer.js
+++ b/web/src/js/components/Dashboard/__mocks__/DashboardContainer.js
@@ -1,0 +1,6 @@
+
+import {
+  createMockReactComponent
+} from 'utils/test-utils'
+
+export default createMockReactComponent('DashboardContainer')

--- a/web/src/js/components/Dashboard/__tests__/DashboardView.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardView.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+
+import React from 'react'
+import {
+  mount,
+  shallow
+} from 'enzyme'
+import DashboardView from '../DashboardView'
+import AuthUserComponent from 'general/AuthUserComponent'
+import {
+  QueryRenderer
+} from 'react-relay/compat'
+import DashboardContainer from '../DashboardContainer'
+
+jest.mock('general/AuthUserComponent')
+jest.mock('analytics/logEvent')
+jest.mock('react-relay/compat')
+jest.mock('../DashboardContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('DashboardView', () => {
+  it('renders without error', () => {
+    shallow(
+      <DashboardView />
+    )
+  })
+
+  it('includes AuthUserComponent', () => {
+    const wrapper = shallow(
+      <DashboardView />
+    )
+    expect(wrapper.find(AuthUserComponent).length).toBe(1)
+  })
+
+  it('includes QueryRenderer', () => {
+    const wrapper = shallow(
+      <DashboardView />
+    )
+    expect(wrapper.find(QueryRenderer).length).toBe(1)
+  })
+
+  it('renders DashboardContainer before receiving a query response', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn()
+    })
+
+    const wrapper = mount(
+      <DashboardView />
+    )
+    expect(wrapper.find(DashboardContainer).length).toBe(1)
+  })
+})

--- a/web/src/js/components/Dashboard/__tests__/DashboardView.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardView.test.js
@@ -11,11 +11,23 @@ import {
   QueryRenderer
 } from 'react-relay/compat'
 import DashboardContainer from '../DashboardContainer'
+import ErrorMessage from 'general/ErrorMessage'
+import { createNewUser } from 'authentication/helpers'
+import {
+  goTo,
+  loginURL
+} from 'navigation/navigation'
+import {
+  ERROR_USER_DOES_NOT_EXIST
+} from '../../../constants'
 
 jest.mock('general/AuthUserComponent')
+jest.mock('general/ErrorMessage')
 jest.mock('analytics/logEvent')
 jest.mock('react-relay/compat')
 jest.mock('../DashboardContainer')
+jest.mock('authentication/helpers')
+jest.mock('navigation/navigation')
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -33,6 +45,11 @@ describe('DashboardView', () => {
       <DashboardView />
     )
     expect(wrapper.find(AuthUserComponent).length).toBe(1)
+
+    // Make sure AuthUserComponent is the top-level component.
+    // We're not using Enzyme's .type() here because the
+    // component is mocked.
+    expect(wrapper.name()).toEqual('AuthUserComponent')
   })
 
   it('includes QueryRenderer', () => {
@@ -40,6 +57,15 @@ describe('DashboardView', () => {
       <DashboardView />
     )
     expect(wrapper.find(QueryRenderer).length).toBe(1)
+  })
+
+  it('QueryRenderer receives the "variables" prop', () => {
+    const wrapper = mount(
+      <DashboardView />
+    )
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'abc123xyz456' // default value in AuthUser mock
+    })
   })
 
   it('renders DashboardContainer before receiving a query response', () => {
@@ -53,5 +79,154 @@ describe('DashboardView', () => {
       <DashboardView />
     )
     expect(wrapper.find(DashboardContainer).length).toBe(1)
+  })
+
+  it('passes "app" and "user" props to the DashboardContainer when they exist', () => {
+    const fakeProps = {
+      app: {
+        some: 'value'
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233
+      }
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeProps,
+      retry: jest.fn()
+    })
+
+    const wrapper = mount(
+      <DashboardView />
+    )
+    const dashboardContainer = wrapper.find(DashboardContainer)
+    expect(dashboardContainer.prop('app')).toEqual(fakeProps.app)
+    expect(dashboardContainer.prop('user')).toEqual(fakeProps.user)
+  })
+
+  it('renders an ErrorMessage if unexpected errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [{
+                line: 8,
+                column: 3
+              }],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR'
+            }
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' }
+        }
+      },
+      props: null,
+      retry: jest.fn()
+    })
+
+    const wrapper = mount(
+      <DashboardView />
+    )
+
+    // Dashboard should not render.
+    expect(wrapper.find(DashboardContainer).length).toBe(0)
+
+    // Make sure the ErrorMessage exists and has the expected message.
+    expect(wrapper.find(ErrorMessage).length).toBe(1)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading your dashboard :(')
+  })
+
+  it('attempts to create a new user and refetch when there is a "user does not exist" error', async () => {
+    expect.assertions(2)
+
+    const mockRetryFn = jest.fn()
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'No user exists with this ID.',
+              locations: [{
+                line: 8,
+                column: 3
+              }],
+              path: ['user'],
+              code: ERROR_USER_DOES_NOT_EXIST
+            }
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' }
+        }
+      },
+      props: null,
+      retry: mockRetryFn
+    })
+
+    createNewUser.mockResolvedValue({
+      id: 'abc123xyz456',
+      username: null,
+      email: null
+    })
+
+    mount(<DashboardView />)
+
+    // Flush all promises
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(createNewUser).toHaveBeenCalledTimes(1)
+    expect(mockRetryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('redirects to the login page if it cannot create the user after a "user does not exist" error', async () => {
+    expect.assertions(3)
+
+    const mockRetryFn = jest.fn()
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'No user exists with this ID.',
+              locations: [{
+                line: 8,
+                column: 3
+              }],
+              path: ['user'],
+              code: ERROR_USER_DOES_NOT_EXIST
+            }
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' }
+        }
+      },
+      props: null,
+      retry: mockRetryFn
+    })
+
+    // Failed to createa  new user.
+    createNewUser.mockRejectedValue(new Error('Failure'))
+
+    mount(<DashboardView />)
+
+    // Flush all promises
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(createNewUser).toHaveBeenCalledTimes(1)
+    expect(mockRetryFn).not.toHaveBeenCalled()
+    expect(goTo).toHaveBeenCalledWith(loginURL)
   })
 })

--- a/web/src/js/components/General/__mocks__/AuthUserComponent.js
+++ b/web/src/js/components/General/__mocks__/AuthUserComponent.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+
+import {
+  createMockReactComponent
+} from 'utils/test-utils'
+
+export default createMockReactComponent('AuthUserComponent', {
+  variables: {
+    userId: 'abc123xyz456'
+  }
+})

--- a/web/src/js/components/General/__mocks__/ErrorMessage.js
+++ b/web/src/js/components/General/__mocks__/ErrorMessage.js
@@ -1,0 +1,6 @@
+
+import {
+  createMockReactComponent
+} from 'utils/test-utils'
+
+export default createMockReactComponent('ErrorMessage')

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -57,3 +57,9 @@ export const STORAGE_NEW_CONSENT_DATA_EXISTS = 'tab.consentData.newConsentDataEx
 //   data we need for unauthenticated users or temporary data we
 //   don't want to store server-side. Stored client-side only.
 export const STORAGE_NEW_USER_HAS_COMPLETED_TOUR = 'tab.newUser.hasCompletedTour'
+
+/**
+  Error codes passed from server-side.
+**/
+
+export const ERROR_USER_DOES_NOT_EXIST = 'USER_DOES_NOT_EXIST'

--- a/web/src/js/utils/test-utils.js
+++ b/web/src/js/utils/test-utils.js
@@ -158,12 +158,15 @@ export const getDefaultTabGlobal = (properties = {}) => {
  */
 export const createMockReactComponent = (componentName, childProps = null) => {
   const MockComponent = props => {
-    const children = childProps ? (
-      React.Children.map(
-        props.children,
-        (child) => React.cloneElement(child, childProps)
-      )
-    ) : props.children
+    var children
+    if (props) {
+      children = childProps ? (
+        React.Children.map(
+          props.children,
+          (child) => React.cloneElement(child, childProps)
+        )
+      ) : props.children
+    }
     return (
       <span>{children}</span>
     )

--- a/web/src/js/utils/test-utils.js
+++ b/web/src/js/utils/test-utils.js
@@ -1,4 +1,6 @@
 
+import React from 'react'
+
 // Like Enzyme's `find` method, but polling to wait for
 // elements to mount.
 export const enzymeFindAsync = async (rootComponent, selector, maxTimeMs = 4000, intervalMs = 50) => {
@@ -143,4 +145,29 @@ export const getDefaultTabGlobal = (properties = {}) => {
     },
     featureFlags: {}
   }
+}
+
+/**
+ * Create a mock React component for testing. The component will render
+ * any React.children.
+ * @param {String} componentName - The value of the component's displayName;
+ *   typically should be the name of the component class or file name.
+ * @param {Object|null} childProps - Any props that should be passed on to
+ *   all children. If provided, children will be cloned with these props.
+ * @return {function} The mock component
+ */
+export const createMockReactComponent = (componentName, childProps = null) => {
+  const MockComponent = props => {
+    const children = childProps ? (
+      React.Children.map(
+        props.children,
+        (child) => React.cloneElement(child, childProps)
+      )
+    ) : props.children
+    return (
+      <span>{children}</span>
+    )
+  }
+  MockComponent.displayName = componentName || 'MyMockComponent'
+  return MockComponent
 }


### PR DESCRIPTION
Handle the case when a user is authenticated but does not have a user on the server side. This may happen if Firebase authentication succeeds but the request to our server fails (e.g., network error, or user navigates away). Currently, a user would be stuck in this broken state. Now, we try to create the user on the server side and refetch data (when on the dashboard view).

* Add a "code" field to our returned GraphQL error
* Throw a custom UserDoesNotExist error when querying for a User item that does not exist
* Don't log UserDoesNotExist errors
* Move the logic to create a new user into its own module
* Add some missing tests