### PR TITLE
Reward referrers when their referred users verify their email address

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -43,6 +43,7 @@ import {
 import UserModel from '../database/users/UserModel'
 import createUser from '../database/users/createUser'
 import setUsername from '../database/users/setUsername'
+import logEmailVerified from '../database/users/logEmailVerified'
 import logTab from '../database/users/logTab'
 import logRevenue from '../database/userRevenue/logRevenue'
 import logUserDataConsent from '../database/userDataConsent/logUserDataConsent'
@@ -904,6 +905,25 @@ const mergeIntoExistingUserMutation = mutationWithClientMutationId({
 })
 
 /**
+ * Log when a user verifies their email on the client side.
+ */
+const logEmailVerifiedMutation = mutationWithClientMutationId({
+  name: 'LogEmailVerifiedMutation',
+  inputFields: {
+    // Note that this is the raw user ID (not the Relay global).
+    userId: { type: new GraphQLNonNull(GraphQLString) }
+  },
+  outputFields: {
+    user: {
+      type: userType
+    }
+  },
+  mutateAndGetPayload: ({ userId }, context) => {
+    return logEmailVerified(context.user, userId)
+  }
+})
+
+/**
  * Log a data consent action (e.g. for GDPR).
  */
 const logUserDataConsentMutation = mutationWithClientMutationId({
@@ -959,6 +979,7 @@ const mutationType = new GraphQLObjectType({
     logUserDataConsent: logUserDataConsentMutation,
     donateVc: donateVcMutation,
     mergeIntoExistingUser: mergeIntoExistingUserMutation,
+    logEmailVerified: logEmailVerifiedMutation,
 
     setUserBkgImage: setUserBkgImageMutation,
     setUserBkgColor: setUserBkgColorMutation,

--- a/graphql/database/referrals/ReferralDataModel.js
+++ b/graphql/database/referrals/ReferralDataModel.js
@@ -44,6 +44,7 @@ class ReferralData extends BaseModel {
 
   static get permissions () {
     return {
+      get: permissionAuthorizers.userIdMatchesHashKey,
       create: permissionAuthorizers.userIdMatchesHashKey,
       indexPermissions: {
         ReferralsByReferrer: {

--- a/graphql/database/referrals/__tests__/ReferralDataModel.test.js
+++ b/graphql/database/referrals/__tests__/ReferralDataModel.test.js
@@ -22,7 +22,9 @@ describe('ReferralDataModel', () => {
   })
 
   it('has the correct get permission', () => {
-    expect(ReferralDataModel.permissions.get).toBeUndefined()
+    expect(ReferralDataModel.permissions.get).toBe(
+      permissionAuthorizers.userIdMatchesHashKey
+    )
   })
 
   it('has the correct getAll permission', () => {

--- a/graphql/database/test-utils.js
+++ b/graphql/database/test-utils.js
@@ -51,6 +51,16 @@ export const setMockDBResponse = function (operation, returnVal = null, error = 
 }
 
 /**
+ * Clear all mock implementations for database operations.
+ * @return {undefined}
+ */
+export const clearAllMockDBResponses = () => {
+  availableOperations.forEach(operation => {
+    databaseClient[operation].mockReset()
+  })
+}
+
+/**
  * Set the `permissions` getter value for a model class.
  * @param {Object} modelClass - The model class (extended from BaseModel)
  * @param {Object} permissions - The permissions object

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -95,7 +95,9 @@ class User extends BaseModel {
       customImage: types.string(),
       activeWidget: types.string(),
       lastTabTimestamp: types.string().isoDate(),
-      mergedIntoExistingUser: types.boolean()
+      mergedIntoExistingUser: types.boolean(),
+      emailVerified: types.boolean(),
+      referrerRewarded: types.boolean()
     }
   }
 

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -7,7 +7,6 @@ import UserModel from '../UserModel'
 import createUser from '../createUser'
 import logReferralData from '../../referrals/logReferralData'
 import getUserByUsername from '../getUserByUsername'
-import rewardReferringUser from '../rewardReferringUser'
 import setUpWidgetsForNewUser from '../../widgets/setUpWidgetsForNewUser'
 import {
   addTimestampFieldsToItem,
@@ -23,7 +22,6 @@ import {
 jest.mock('../../databaseClient')
 
 jest.mock('../../referrals/logReferralData')
-jest.mock('../rewardReferringUser')
 jest.mock('../logEmailVerified')
 jest.mock('../getUserByUsername')
 jest.mock('../../widgets/setUpWidgetsForNewUser')
@@ -55,7 +53,7 @@ function getExpectedCreateItemFromUserInfo (userInfo) {
 
 describe('createUser when user does not exist', () => {
   it('works as expected without referralData', async () => {
-    expect.assertions(3)
+    expect.assertions(2)
 
     // Mock database responses.
     const userInfo = getMockUserInfo()
@@ -79,11 +77,10 @@ describe('createUser when user does not exist', () => {
     expect(getOrCreateMethod)
       .toHaveBeenCalledWith(userContext, expectedCreateItem)
     expect(logReferralData).not.toHaveBeenCalled()
-    expect(rewardReferringUser).not.toHaveBeenCalled()
   })
 
   it('works as expected with empty object referralData', async () => {
-    expect.assertions(3)
+    expect.assertions(2)
 
     // Mock database responses.
     const userInfo = getMockUserInfo()
@@ -107,7 +104,6 @@ describe('createUser when user does not exist', () => {
     expect(getOrCreateMethod)
       .toHaveBeenCalledWith(userContext, expectedCreateItem)
     expect(logReferralData).not.toHaveBeenCalled()
-    expect(rewardReferringUser).not.toHaveBeenCalled()
   })
 
   it('works as expected without an email address', async () => {
@@ -194,8 +190,8 @@ describe('createUser when user does not exist', () => {
       .toHaveBeenCalledWith(userContext, userInfo.id)
   })
 
-  it('logs referral data and rewards referring user', async () => {
-    expect.assertions(3)
+  it('logs referral data', async () => {
+    expect.assertions(2)
 
     // Mock database responses.
     const userInfo = getMockUserInfo()
@@ -229,12 +225,10 @@ describe('createUser when user does not exist', () => {
       .toHaveBeenCalledWith(userContext, expectedCreateItem)
     expect(logReferralData)
       .toHaveBeenCalledWith(userContext, userInfo.id, referringUserId, null)
-    expect(rewardReferringUser)
-      .toHaveBeenCalledWith(referringUserId)
   })
 
   it('works when referring user does not exist', async () => {
-    expect.assertions(3)
+    expect.assertions(2)
 
     // Mock database responses.
     const userInfo = getMockUserInfo()
@@ -265,7 +259,6 @@ describe('createUser when user does not exist', () => {
       .toHaveBeenCalledWith(userContext, expectedCreateItem)
     expect(logReferralData)
       .toHaveBeenCalledWith(userContext, userInfo.id, null, null)
-    expect(rewardReferringUser).not.toHaveBeenCalled()
   })
 
   it('returns the user even if there is an error logging referral data', async () => {
@@ -416,8 +409,8 @@ describe('createUser when user already exists (should be idempotent)', () => {
        .not.toHaveBeenCalled()
   })
 
-  it('does not log referral data or reward referring user', async () => {
-    expect.assertions(2)
+  it('does not log referral data', async () => {
+    expect.assertions(1)
 
     // Mock that the user already exists.
     setMockDBResponse(
@@ -450,8 +443,6 @@ describe('createUser when user already exists (should be idempotent)', () => {
       userInfo.email, referralData)
 
     expect(logReferralData)
-      .not.toHaveBeenCalled()
-    expect(rewardReferringUser)
       .not.toHaveBeenCalled()
   })
 

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -16,17 +16,19 @@ import {
   getMockUserInfo,
   getMockUserInstance,
   mockDate,
-  setMockDBResponse
+  setMockDBResponse,
+  clearAllMockDBResponses
 } from '../../test-utils'
 
 jest.mock('../../databaseClient')
 
 jest.mock('../../referrals/logReferralData')
 jest.mock('../rewardReferringUser')
+jest.mock('../logEmailVerified')
 jest.mock('../getUserByUsername')
 jest.mock('../../widgets/setUpWidgetsForNewUser')
 
-const userContext = getMockUserContext()
+const defaultUserContext = getMockUserContext()
 
 beforeAll(() => {
   mockDate.on()
@@ -38,6 +40,7 @@ afterAll(() => {
 
 afterEach(() => {
   jest.clearAllMocks()
+  clearAllMockDBResponses()
 })
 
 function getExpectedCreateItemFromUserInfo (userInfo) {
@@ -52,9 +55,23 @@ function getExpectedCreateItemFromUserInfo (userInfo) {
 
 describe('createUser when user does not exist', () => {
   it('works as expected without referralData', async () => {
-    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    expect.assertions(3)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
     const referralData = null
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
+
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
 
@@ -66,9 +83,23 @@ describe('createUser when user does not exist', () => {
   })
 
   it('works as expected with empty object referralData', async () => {
-    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    expect.assertions(3)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
     const referralData = {}
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
+
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
 
@@ -80,15 +111,26 @@ describe('createUser when user does not exist', () => {
   })
 
   it('works as expected without an email address', async () => {
-    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    expect.assertions(1)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
 
     // Remove the email info from the user context.
-    const newUserContext = cloneDeep(userContext)
-    delete newUserContext.email
-    delete newUserContext.emailVerified
+    const userContext = cloneDeep(defaultUserContext)
+    delete userContext.email
+    delete userContext.emailVerified
 
-    await createUser(newUserContext, userInfo.id, null, null)
+    await createUser(userContext, userInfo.id, null, null)
 
     // The expected item to create will have no email.
     const expectedCreateItem = getExpectedCreateItemFromUserInfo({
@@ -96,30 +138,56 @@ describe('createUser when user does not exist', () => {
       email: null
     })
     expect(getOrCreateMethod)
-      .toHaveBeenCalledWith(newUserContext, expectedCreateItem)
+      .toHaveBeenCalledWith(userContext, expectedCreateItem)
   })
 
   it('uses the email address from the context (user claims), not the provided value', async () => {
-    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    expect.assertions(1)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
 
     // Remove the email info from the user context.
-    const newUserContext = cloneDeep(userContext)
-    newUserContext.email = 'someotheremail@example.com'
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
+    userContext.email = 'someotheremail@example.com'
 
-    await createUser(newUserContext, userInfo.id, 'notthesame@example.com', null)
+    await createUser(userContext, userInfo.id, 'notthesame@example.com', null)
 
     const expectedCreateItem = getExpectedCreateItemFromUserInfo({
       id: userInfo.id,
       email: 'someotheremail@example.com'
     })
     expect(getOrCreateMethod)
-      .toHaveBeenCalledWith(newUserContext, expectedCreateItem)
+      .toHaveBeenCalledWith(userContext, expectedCreateItem)
   })
 
   it('calls to set up initial widgets', async () => {
+    expect.assertions(1)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
     const referralData = null
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
+
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
     expect(setUpWidgetsForNewUser)
@@ -127,19 +195,31 @@ describe('createUser when user does not exist', () => {
   })
 
   it('logs referral data and rewards referring user', async () => {
-    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    expect.assertions(3)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
     const referralData = {
       referringUser: 'FriendOfMine'
     }
 
     // Mock fetching the referring user.
     const referringUserId = 'ppooiiuu-151a-4a9a-9289-06906670fd4e'
-    getUserByUsername.mockImplementationOnce(() => {
-      return {
-        id: referringUserId
-      }
+    getUserByUsername.mockResolvedValueOnce({
+      id: referringUserId
     })
+
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
 
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
@@ -154,16 +234,28 @@ describe('createUser when user does not exist', () => {
   })
 
   it('works when referring user does not exist', async () => {
-    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    expect.assertions(3)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
     const referralData = {
       referringUser: 'FriendOfMine'
     }
 
     // Mock fetching the referring user.
-    getUserByUsername.mockImplementationOnce(() => {
-      return null
-    })
+    getUserByUsername.mockResolvedValueOnce(null)
+
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
 
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
@@ -177,51 +269,70 @@ describe('createUser when user does not exist', () => {
   })
 
   it('returns the user even if there is an error logging referral data', async () => {
+    expect.assertions(1)
+
+    // Mock database responses.
+    const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
     // Hide expected error output
     jest.spyOn(console, 'error')
       .mockImplementationOnce(() => {})
 
-    const userInfo = getMockUserInfo()
     const referralData = {
       referringChannel: '42'
     }
 
-    // Mock the response for getting the user.
-    const expectedUser = getMockUserInstance(userInfo)
-    setMockDBResponse(
-      DatabaseOperation.GET,
-      {
-        Item: expectedUser
-      }
-    )
+    // Mock fetching the referring user.
+    const referringUserId = 'ppooiiuu-151a-4a9a-9289-06906670fd4e'
+    getUserByUsername.mockResolvedValueOnce({
+      id: referringUserId
+    })
 
     // Some unexpected error in logging referral data.
     logReferralData.mockImplementationOnce(() => {
       throw new Error('Bad thing happened!')
     })
 
-    await createUser(userContext, userInfo.id,
-      userInfo.email, referralData)
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
 
     const createdItem = await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
 
-    // The user was just created, so set the 'justCreated' field to true
-    expectedUser.justCreated = true
-
-    expect(createdItem).toEqual(expectedUser)
+    // The user was just created, so we expect the 'justCreated' field to be true.
+    userReturnedFromCreate.justCreated = true
+    expect(createdItem).toEqual(userReturnedFromCreate)
   })
 
   it('logs "referringChannel" referral data', async () => {
+    expect.assertions(1)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
     const referralData = {
       referringChannel: '42'
     }
 
     // No referring user.
-    getUserByUsername.mockImplementationOnce(() => {
-      return null
-    })
+    getUserByUsername.mockResolvedValueOnce(null)
+
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
 
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
@@ -230,16 +341,20 @@ describe('createUser when user does not exist', () => {
   })
 
   it('calls the database as expected', async () => {
+    expect.assertions(2)
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
-    const referralData = null
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
     const dbQueryMock = setMockDBResponse(
       DatabaseOperation.CREATE,
       {
-        Attributes: {}
+        Attributes: userReturnedFromCreate
       }
     )
-    const expectedUser = getMockUserInstance(userInfo)
-    const expectedParamsUser = cloneDeep(expectedUser)
+
+    const referralData = null
+    const expectedParamsUser = cloneDeep(userReturnedFromCreate)
 
     // Remove dynamic fields (won't be passed during creation)
     delete expectedParamsUser.backgroundImage.imageURL
@@ -255,28 +370,46 @@ describe('createUser when user does not exist', () => {
       Item: expectedParamsUser,
       TableName: UserModel.tableName
     }
+
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
+
     const createdItem = await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
     const dbParams = dbQueryMock.mock.calls[0][0]
     expect(dbParams).toEqual(expectedParams)
 
-    // The user was just created, so set the 'justCreated' field to true
-    expectedUser.justCreated = true
+    // The user was just created, so we expect the 'justCreated' field to be true.
+    userReturnedFromCreate.justCreated = true
 
-    expect(createdItem).toEqual(expectedUser)
+    expect(createdItem).toEqual(userReturnedFromCreate)
   })
 })
 
 describe('createUser when user already exists (should be idempotent)', () => {
   it('does not call to set up initial widgets', async () => {
+    expect.assertions(1)
+
     // Mock that the user already exists.
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
       { code: 'ConditionalCheckFailedException' } // simple mock error
     )
+
+    // Mock database responses.
     const userInfo = getMockUserInfo()
+    const existingUser = getMockUserInstance(Object.assign({}, userInfo, { emailVerified: true }))
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: existingUser
+      }
+    )
+
     const referralData = null
+    const userContext = cloneDeep(defaultUserContext)
+
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
     expect(setUpWidgetsForNewUser)
@@ -284,6 +417,8 @@ describe('createUser when user already exists (should be idempotent)', () => {
   })
 
   it('does not log referral data or reward referring user', async () => {
+    expect.assertions(2)
+
     // Mock that the user already exists.
     setMockDBResponse(
       DatabaseOperation.CREATE,
@@ -295,14 +430,22 @@ describe('createUser when user already exists (should be idempotent)', () => {
       referringUser: 'FriendOfMine'
     }
 
+    // Mock database responses.
+    const existingUser = getMockUserInstance(Object.assign({}, userInfo, { emailVerified: true }))
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: existingUser
+      }
+    )
+
     // Mock fetching the referring user.
     const referringUserId = 'ppooiiuu-151a-4a9a-9289-06906670fd4e'
-    getUserByUsername.mockImplementationOnce(() => {
-      return {
-        id: referringUserId
-      }
+    getUserByUsername.mockResolvedValueOnce({
+      id: referringUserId
     })
 
+    const userContext = cloneDeep(defaultUserContext)
     await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
 
@@ -313,6 +456,8 @@ describe('createUser when user already exists (should be idempotent)', () => {
   })
 
   it('returns the existing user', async () => {
+    expect.assertions(1)
+
     const userInfo = getMockUserInfo()
     const referralData = null
 
@@ -323,20 +468,24 @@ describe('createUser when user already exists (should be idempotent)', () => {
       { code: 'ConditionalCheckFailedException' } // simple mock error
     )
 
-    // Mock the response for getting the user.
-    const expectedUser = getMockUserInstance(userInfo)
+    // Mock database responses.
+    const existingUser = getMockUserInstance(Object.assign({}, userInfo, { emailVerified: true }))
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: expectedUser
+        Item: existingUser
       }
     )
+
+    const userContext = cloneDeep(defaultUserContext)
     const createdItem = await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
-    expect(createdItem).toEqual(expectedUser)
+    expect(createdItem).toEqual(existingUser)
   })
 
   it('updates the existing user\'s email address if it is different from the user claims', async () => {
+    expect.assertions(2)
+
     const userInfo = getMockUserInfo()
     const referralData = null
 
@@ -347,19 +496,18 @@ describe('createUser when user already exists (should be idempotent)', () => {
       { code: 'ConditionalCheckFailedException' } // simple mock error
     )
 
-    // Set the email in the user context.
-    const newUserContext = cloneDeep(userContext)
-    newUserContext.email = 'myemail@example.com'
-
-    // Mock the response for getting the user.
-    const expectedUser = getMockUserInstance(userInfo)
-    expectedUser.email = 'someotheremail@example.com'
+    // Mock database responses.
+    const existingUser = getMockUserInstance(Object.assign({}, userInfo, { emailVerified: true }))
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: expectedUser
+        Item: existingUser
       }
     )
+
+    // Set the email in the user context.
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.email = 'myemail@example.com'
 
     // Mock the response for updating the email address.
     setMockDBResponse(
@@ -367,13 +515,96 @@ describe('createUser when user already exists (should be idempotent)', () => {
       {
         // Like original user but with modified email.
         Attributes: Object.assign({},
-          expectedUser,
-          { email: newUserContext.email })
+          existingUser,
+          { email: userContext.email })
       }
     )
 
-    const createdItem = await createUser(newUserContext, userInfo.id,
+    const updateMethod = jest.spyOn(UserModel, 'update')
+
+    const returnedUser = await createUser(userContext, userInfo.id,
       userInfo.email, referralData)
-    expect(createdItem.email).toEqual('myemail@example.com')
+
+    expect(updateMethod)
+      .toHaveBeenCalledWith(userContext, {
+        id: userInfo.id,
+        email: 'myemail@example.com',
+        updated: moment.utc().toISOString()
+      })
+    expect(returnedUser.email).toEqual('myemail@example.com')
+  })
+
+  it('updates the existing user\'s emailVerified property if it is different from the value in user claims', async () => {
+    expect.assertions(2)
+
+    const userInfo = getMockUserInfo()
+    const referralData = null
+
+    // Mock that the user already exists.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      { code: 'ConditionalCheckFailedException' } // simple mock error
+    )
+
+    // Mock database responses.
+    const existingUser = getMockUserInstance(Object.assign({}, userInfo, { emailVerified: false }))
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: existingUser
+      }
+    )
+
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = true // Different from the existing user's value
+
+    // Mock the response from updating the emailVerified value.
+    const updatedUser = Object.assign({}, existingUser, { emailVerified: true })
+    const logEmailVerified = require('../logEmailVerified').default
+    logEmailVerified.mockResolvedValue(updatedUser)
+
+    const returnedUser = await createUser(userContext, userInfo.id,
+      userInfo.email, referralData)
+
+    expect(logEmailVerified)
+      .toHaveBeenCalledWith(userContext, userInfo.id)
+    expect(returnedUser.emailVerified).toBe(true)
+  })
+
+  it('does not update the existing user\'s emailVerified property if it is the same as the value in user claims', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const referralData = null
+
+    // Mock that the user already exists.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      { code: 'ConditionalCheckFailedException' } // simple mock error
+    )
+
+    // Mock database responses.
+    const existingUser = getMockUserInstance(Object.assign({}, userInfo, { emailVerified: true }))
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: existingUser
+      }
+    )
+
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = true // Same as the existing user's value
+
+    // Mock the response from updating the emailVerified value.
+    const logEmailVerified = require('../logEmailVerified').default
+    logEmailVerified.mockResolvedValue(existingUser)
+
+    await createUser(userContext, userInfo.id,
+      userInfo.email, referralData)
+
+    expect(logEmailVerified)
+      .not.toHaveBeenCalledWith(userContext, userInfo.id)
   })
 })

--- a/graphql/database/users/__tests__/logEmailVerified.test.js
+++ b/graphql/database/users/__tests__/logEmailVerified.test.js
@@ -1,0 +1,94 @@
+/* eslint-env jest */
+
+import moment from 'moment'
+import { cloneDeep } from 'lodash/lang'
+import {
+  DatabaseOperation,
+  getMockUserContext,
+  getMockUserInstance,
+  mockDate,
+  setMockDBResponse
+} from '../../test-utils'
+
+jest.mock('../../databaseClient')
+const userContext = getMockUserContext()
+
+beforeAll(() => {
+  mockDate.on()
+})
+
+afterAll(() => {
+  mockDate.off()
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('logEmailVerified', () => {
+  it('sets emailVerified=true when it is true', async () => {
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const modifiedUserContext = cloneDeep(userContext)
+    modifiedUserContext.emailVerified = true
+
+    const logEmailVerified = require('../logEmailVerified').default
+    await logEmailVerified(modifiedUserContext, modifiedUserContext.id)
+    expect(updateQuery).toHaveBeenCalledWith(modifiedUserContext, {
+      id: modifiedUserContext.id,
+      emailVerified: true,
+      updated: moment.utc().toISOString()
+    })
+  })
+
+  it('sets emailVerified=false when it is false', async () => {
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const modifiedUserContext = cloneDeep(userContext)
+    modifiedUserContext.emailVerified = false
+
+    const logEmailVerified = require('../logEmailVerified').default
+    await logEmailVerified(modifiedUserContext, modifiedUserContext.id)
+    expect(updateQuery).toHaveBeenCalledWith(modifiedUserContext, {
+      id: modifiedUserContext.id,
+      emailVerified: false,
+      updated: moment.utc().toISOString()
+    })
+  })
+
+  it('sets emailVerified=true with the default mock user context', async () => {
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const logEmailVerified = require('../logEmailVerified').default
+    await logEmailVerified(userContext, userContext.id)
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      emailVerified: true,
+      updated: moment.utc().toISOString()
+    })
+  })
+
+  it('returns the user object', async () => {
+    // Mock DB response.
+    const expectedReturnedUser = Object.assign(
+      {},
+      getMockUserInstance(),
+      {
+        emailVerified: true
+      }
+    )
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: expectedReturnedUser
+      }
+    )
+
+    const logEmailVerified = require('../logEmailVerified').default
+    const returnedUser = await logEmailVerified(userContext, userContext.id)
+    expect(returnedUser).toEqual(expectedReturnedUser)
+  })
+})

--- a/graphql/database/users/__tests__/logEmailVerified.test.js
+++ b/graphql/database/users/__tests__/logEmailVerified.test.js
@@ -9,8 +9,11 @@ import {
   mockDate,
   setMockDBResponse
 } from '../../test-utils'
+import rewardReferringUser from '../rewardReferringUser'
 
 jest.mock('../../databaseClient')
+jest.mock('../rewardReferringUser')
+
 const userContext = getMockUserContext()
 
 beforeAll(() => {
@@ -27,6 +30,8 @@ beforeEach(() => {
 
 describe('logEmailVerified', () => {
   it('sets emailVerified=true when it is true', async () => {
+    expect.assertions(1)
+
     const UserModel = require('../UserModel').default
     const updateQuery = jest.spyOn(UserModel, 'update')
 
@@ -43,6 +48,8 @@ describe('logEmailVerified', () => {
   })
 
   it('sets emailVerified=false when it is false', async () => {
+    expect.assertions(1)
+
     const UserModel = require('../UserModel').default
     const updateQuery = jest.spyOn(UserModel, 'update')
 
@@ -59,6 +66,8 @@ describe('logEmailVerified', () => {
   })
 
   it('sets emailVerified=true with the default mock user context', async () => {
+    expect.assertions(1)
+
     const UserModel = require('../UserModel').default
     const updateQuery = jest.spyOn(UserModel, 'update')
 
@@ -72,6 +81,8 @@ describe('logEmailVerified', () => {
   })
 
   it('returns the user object', async () => {
+    expect.assertions(1)
+
     // Mock DB response.
     const expectedReturnedUser = Object.assign(
       {},
@@ -90,5 +101,28 @@ describe('logEmailVerified', () => {
     const logEmailVerified = require('../logEmailVerified').default
     const returnedUser = await logEmailVerified(userContext, userContext.id)
     expect(returnedUser).toEqual(expectedReturnedUser)
+  })
+
+  it('calls to reward the referring user when the email is verified', async () => {
+    expect.assertions(1)
+
+    const modifiedUserContext = cloneDeep(userContext)
+    modifiedUserContext.emailVerified = true
+
+    const logEmailVerified = require('../logEmailVerified').default
+    await logEmailVerified(modifiedUserContext, modifiedUserContext.id)
+    expect(rewardReferringUser)
+      .toHaveBeenCalledWith(modifiedUserContext, modifiedUserContext.id)
+  })
+
+  it('does not call to reward the referring user when the email is not verified', async () => {
+    expect.assertions(1)
+
+    const modifiedUserContext = cloneDeep(userContext)
+    modifiedUserContext.emailVerified = false
+
+    const logEmailVerified = require('../logEmailVerified').default
+    await logEmailVerified(modifiedUserContext, modifiedUserContext.id)
+    expect(rewardReferringUser).not.toHaveBeenCalled()
   })
 })

--- a/graphql/database/users/__tests__/rewardReferringUser.test.js
+++ b/graphql/database/users/__tests__/rewardReferringUser.test.js
@@ -22,6 +22,9 @@ afterEach(() => {
   clearAllMockDBResponses()
 })
 
+const timeBeforeEmailVerifyFeatureChange = '2018-09-14T02:10:13.000Z'
+const timeAfterEmailVerifyFeatureChange = '2018-09-28T08:00:30.000Z'
+
 describe('rewardReferringUser', () => {
   it('gives the referring user VC as expected', async () => {
     expect.assertions(3)
@@ -48,7 +51,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -92,7 +98,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -134,7 +143,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -170,7 +182,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -212,7 +227,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -256,7 +274,10 @@ describe('rewardReferringUser', () => {
       DatabaseOperation.GET,
       {
         // Note that the referrer was already rewarded.
-        Item: Object.assign({}, mockUser, { referrerRewarded: true })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: true,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -272,6 +293,94 @@ describe('rewardReferringUser', () => {
     expect(response).toBe(false)
     expect(addVc).not.toHaveBeenCalled()
     expect(addUsersRecruited).not.toHaveBeenCalled()
+  })
+
+  it('does not reward a referrer if the referred user joined before we changed the email verification feature', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeBeforeEmailVerifyFeatureChange // before feature change
+        })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    const response = await rewardReferringUser(userContext, userId)
+    expect(response).toBe(false)
+  })
+
+  it('does not reward a referrer if the referred user does not have a "joined" time (which should never happen)', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: undefined // missing datetime
+        })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    const response = await rewardReferringUser(userContext, userId)
+    expect(response).toBe(false)
   })
 
   it('throws if there is an error when getting the referral data', async () => {
@@ -293,7 +402,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -374,7 +486,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -414,7 +529,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 
@@ -458,7 +576,10 @@ describe('rewardReferringUser', () => {
     setMockDBResponse(
       DatabaseOperation.GET,
       {
-        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+        Item: Object.assign({}, mockUser, {
+          referrerRewarded: false,
+          joined: timeAfterEmailVerifyFeatureChange
+        })
       }
     )
 

--- a/graphql/database/users/__tests__/rewardReferringUser.test.js
+++ b/graphql/database/users/__tests__/rewardReferringUser.test.js
@@ -1,25 +1,66 @@
 /* eslint-env jest */
 
-import UserModel from '../UserModel'
+import ReferralDataModel from '../../referrals/ReferralDataModel'
 import rewardReferringUser from '../rewardReferringUser'
 import addVc from '../addVc'
 import addUsersRecruited from '../addUsersRecruited'
+import {
+  DatabaseOperation,
+  getMockUserContext,
+  getMockUserInfo,
+  getMockUserInstance,
+  setMockDBResponse,
+  clearAllMockDBResponses
+} from '../../test-utils'
 
 jest.mock('../../databaseClient')
 jest.mock('../addVc')
 jest.mock('../addUsersRecruited')
 
-// Mock addVc method
-UserModel.addVc = jest.fn()
-
 afterEach(() => {
   jest.clearAllMocks()
+  clearAllMockDBResponses()
 })
 
 describe('rewardReferringUser', () => {
   it('gives the referring user VC as expected', async () => {
-    const referringUserId = 'some-id-123'
-    await rewardReferringUser(referringUserId)
+    expect.assertions(3)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    await rewardReferringUser(userContext, userId)
     const addVcCallParams = addVc.mock.calls[0]
     expect(addVcCallParams[0]).toMatch(/REWARD_REFERRER_OVERRIDE_CONFIRMED_[0-9]{5}$/)
     expect(addVcCallParams[1]).toBe(referringUserId)
@@ -27,9 +68,412 @@ describe('rewardReferringUser', () => {
   })
 
   it('calls to increment the referring user\'s number of recruited users', async () => {
-    const referringUserId = 'some-id-123'
-    await rewardReferringUser(referringUserId)
+    expect.assertions(2)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    await rewardReferringUser(userContext, userId)
     expect(addUsersRecruited).toHaveBeenCalledWith(referringUserId, 1)
     expect(addUsersRecruited).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns true when the referrer was rewarded', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    const response = await rewardReferringUser(userContext, userId)
+    expect(response).toBe(true)
+  })
+
+  it('does not reward a referrer if no referral data exists', async () => {
+    expect.assertions(3)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: null // no referral data exists
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    const response = await rewardReferringUser(userContext, userId)
+    expect(response).toBe(false)
+    expect(addVc).not.toHaveBeenCalled()
+    expect(addUsersRecruited).not.toHaveBeenCalled()
+  })
+
+  it('does not reward a referrer if the referral data does not include a user referrer', async () => {
+    expect.assertions(3)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: null, // no referring user
+          referringChannel: 'some-channel'
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    const response = await rewardReferringUser(userContext, userId)
+    expect(response).toBe(false)
+    expect(addVc).not.toHaveBeenCalled()
+    expect(addUsersRecruited).not.toHaveBeenCalled()
+  })
+
+  it('does not reward a referrer if the referrer was already rewarded', async () => {
+    expect.assertions(3)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        // Note that the referrer was already rewarded.
+        Item: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    const response = await rewardReferringUser(userContext, userId)
+    expect(response).toBe(false)
+    expect(addVc).not.toHaveBeenCalled()
+    expect(addUsersRecruited).not.toHaveBeenCalled()
+  })
+
+  it('throws if there is an error when getting the referral data', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      null,
+      { code: 'SomeFakeError' } // simple mock error
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    return expect(rewardReferringUser(userContext, userId))
+      .rejects.toThrow()
+  })
+
+  it('throws if there is an error when getting the user', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      null,
+      { code: 'SomeFakeError' } // simple mock error
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    return expect(rewardReferringUser(userContext, userId))
+      .rejects.toThrow()
+  })
+
+  it('throws if there is an error when updating the user to mark its referrer as rewarded', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'SomeFakeError' } // simple mock error
+    )
+
+    return expect(rewardReferringUser(userContext, userId))
+      .rejects.toThrow()
+  })
+
+  it('throws if there is an error when rewarding the user with VC', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    // Mock an error when adding VC.
+    addVc.mockImplementationOnce(() => Promise.reject(new Error('Darn.')))
+
+    await expect(rewardReferringUser(userContext, userId))
+      .rejects.toThrow('Darn.')
+  })
+
+  it('throws if there is an error when increasing the referrer\'s count of referred users', async () => {
+    expect.assertions(1)
+
+    const userContext = getMockUserContext()
+    const userInfo = getMockUserInfo()
+    const userId = userInfo.id
+    const mockUser = getMockUserInstance(Object.assign({}, userInfo))
+    const referringUserId = 'referring-user-id-123'
+
+    // Mock getting the ReferralData.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, new ReferralDataModel({
+          userId: userId,
+          referringUser: referringUserId,
+          referringChannel: null
+        }))
+      }
+    )
+
+    // Mock getting the user to check if its referral has been rewarded.
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: Object.assign({}, mockUser, { referrerRewarded: false })
+      }
+    )
+
+    // Mock updating the user to mark the user as referred.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: Object.assign({}, mockUser, { referrerRewarded: true })
+      }
+    )
+
+    // Mock an error when adding VC.
+    addUsersRecruited.mockImplementationOnce(() => Promise.reject(new Error('Whoops.')))
+
+    await expect(rewardReferringUser(userContext, userId))
+      .rejects.toThrow('Whoops.')
   })
 })

--- a/graphql/database/users/createUser.js
+++ b/graphql/database/users/createUser.js
@@ -4,7 +4,6 @@ import { get } from 'lodash/object'
 import moment from 'moment'
 import UserModel from './UserModel'
 import logReferralData from '../referrals/logReferralData'
-import rewardReferringUser from './rewardReferringUser'
 import logEmailVerified from './logEmailVerified'
 import getUserByUsername from './getUserByUsername'
 import setUpWidgetsForNewUser from '../widgets/setUpWidgetsForNewUser'
@@ -73,7 +72,7 @@ const createUser = async (userContext, userId, email = null, referralData = null
     throw e
   }
 
-  // Log referral data and reward referrer.
+  // Log referral data.
   if (referralData && !isEmpty(referralData)) {
     const referringUserUsername = referralData.referringUser
     const referringChannelId = (
@@ -102,15 +101,6 @@ const createUser = async (userContext, userId, email = null, referralData = null
         referring user: ${referringUserId}.
         ${e}
       `))
-    }
-
-    // Reward the referring user if one exists.
-    if (referringUserId) {
-      try {
-        await rewardReferringUser(referringUserId)
-      } catch (e) {
-        logger.error(new Error(`Could not reward referring user with ID ${referringUserId}.`))
-      }
     }
   }
 

--- a/graphql/database/users/logEmailVerified.js
+++ b/graphql/database/users/logEmailVerified.js
@@ -1,5 +1,7 @@
 
 import UserModel from './UserModel'
+import rewardReferringUser from './rewardReferringUser'
+import logger from '../../utils/logger'
 
 /**
  * Log that a user's email is verified, using the trustworthy
@@ -22,11 +24,15 @@ const logEmailVerified = async (userContext, userId) => {
     throw e
   }
 
-  // If the user's email is verified, reward their user
-  // referrer if one exists and the referrer has not already
-  // been rewarded.
+  // If the user's email is verified, reward their
+  // referring user. `rewardReferringUser` is idempotent
+  // so it's okay that we might call it more than once.
   if (userContext.emailVerified) {
-    // TODO
+    try {
+      await rewardReferringUser(userContext, userId)
+    } catch (e) {
+      logger.error(new Error(`Could not reward referring user for user ID ${userId}.`))
+    }
   }
 
   return returnedUser

--- a/graphql/database/users/logEmailVerified.js
+++ b/graphql/database/users/logEmailVerified.js
@@ -5,7 +5,8 @@ import UserModel from './UserModel'
  * Log that a user's email is verified, using the trustworthy
  * user context know that the email is truly verified. Then,
  * perform any other actions that occur when a user is
- * verified.
+ * verified. Important: this function must be idempotent,
+ * because it could be called multiple times.
  * @param {object} userContext - The user authorizer object.
  * @param {string} id - The user id.
  * @return {Promise<User>}  A promise that resolves into a User instance.
@@ -22,7 +23,8 @@ const logEmailVerified = async (userContext, userId) => {
   }
 
   // If the user's email is verified, reward their user
-  // referrer if one exists.
+  // referrer if one exists and the referrer has not already
+  // been rewarded.
   if (userContext.emailVerified) {
     // TODO
   }

--- a/graphql/database/users/logEmailVerified.js
+++ b/graphql/database/users/logEmailVerified.js
@@ -1,0 +1,33 @@
+
+import UserModel from './UserModel'
+
+/**
+ * Log that a user's email is verified, using the trustworthy
+ * user context know that the email is truly verified. Then,
+ * perform any other actions that occur when a user is
+ * verified.
+ * @param {object} userContext - The user authorizer object.
+ * @param {string} id - The user id.
+ * @return {Promise<User>}  A promise that resolves into a User instance.
+ */
+const logEmailVerified = async (userContext, userId) => {
+  var returnedUser
+  try {
+    returnedUser = await UserModel.update(userContext, {
+      id: userId,
+      emailVerified: userContext.emailVerified
+    })
+  } catch (e) {
+    throw e
+  }
+
+  // If the user's email is verified, reward their user
+  // referrer if one exists.
+  if (userContext.emailVerified) {
+    // TODO
+  }
+
+  return returnedUser
+}
+
+export default logEmailVerified

--- a/graphql/database/users/logEmailVerified.js
+++ b/graphql/database/users/logEmailVerified.js
@@ -5,7 +5,7 @@ import logger from '../../utils/logger'
 
 /**
  * Log that a user's email is verified, using the trustworthy
- * user context know that the email is truly verified. Then,
+ * user context to know that the email is truly verified. Then,
  * perform any other actions that occur when a user is
  * verified. Important: this function must be idempotent,
  * because it could be called multiple times.

--- a/graphql/database/users/rewardReferringUser.js
+++ b/graphql/database/users/rewardReferringUser.js
@@ -1,4 +1,6 @@
 
+import ReferralDataModel from '../referrals/ReferralDataModel'
+import UserModel from './UserModel'
 import {
   USER_REFERRAL_VC_REWARD
 } from '../constants'
@@ -8,15 +10,64 @@ import {
 } from '../../utils/permissions-overrides'
 import addVc from './addVc'
 import addUsersRecruited from './addUsersRecruited'
+import {
+  DATABASE_ITEM_DOES_NOT_EXIST
+} from '../../utils/exceptions'
 const override = getPermissionsOverride(REWARD_REFERRER_OVERRIDE)
 
 /**
  * Reward a referring user by increasing their VC and adding to
- * their count of recruited users.
- * @param {string} referringUserId - The ID of the referring user.
- * @return {Promise<User>}  A promise that resolves into a User instance.
+ * their count of recruited users. Only do this if the referring
+ * user exists and has not already been rewarded. Important: this
+ * function must be idempotent because it could be called more
+ * than once.
+ * @param {object} userContext - The user authorizer object.
+ * @param {string} id - The user ID of the user whose referrer we
+ *   should reward.
+ * @return {Promise<Boolean>} A Promise that resolves into a
+ *   boolean: true if we rewarded a referring user, false
+ *   otherwise.
  */
-const rewardReferringUser = async (referringUserId) => {
+const rewardReferringUser = async (userContext, userId) => {
+  // If the user does not have a referring user, return.
+  var referringUserId
+  try {
+    const referralData = await ReferralDataModel.get(userContext, userId)
+    if (referralData.referringUser) {
+      referringUserId = referralData.referringUser
+    } else {
+      return false
+    }
+  } catch (e) {
+    // Referral data may not exist.
+    if (e.code === DATABASE_ITEM_DOES_NOT_EXIST) {
+      return false
+    } else {
+      throw e
+    }
+  }
+
+  // If the referring user has already been rewarded, return.
+  try {
+    const referredUser = await UserModel.get(userContext, userId)
+    if (referredUser.referrerRewarded) {
+      return false
+    }
+  } catch (e) {
+    throw e
+  }
+
+  // Mark that the referring user has been rewarded.
+  try {
+    await UserModel.update(userContext, {
+      id: userId,
+      referrerRewarded: true
+    })
+  } catch (e) {
+    throw e
+  }
+
+  // Reward the referring user.
   try {
     await addVc(override, referringUserId,
       USER_REFERRAL_VC_REWARD)
@@ -24,6 +75,8 @@ const rewardReferringUser = async (referringUserId) => {
   } catch (e) {
     throw e
   }
+
+  return true
 }
 
 export default rewardReferringUser

--- a/graphql/database/users/rewardReferringUser.js
+++ b/graphql/database/users/rewardReferringUser.js
@@ -59,7 +59,7 @@ const rewardReferringUser = async (userContext, userId) => {
     // so we'll just ignore users who signed up before the feature
     // change. We can remove this if we backfill the "emailVerified"
     // value for all users.
-    const emailVerifyRewardChangeTime = moment('2018-09-14T17:00:00.000Z')
+    const emailVerifyRewardChangeTime = moment('2018-09-14T20:00:00.000Z')
     const userJoinedBeforeFeature = !referredUser.joined ||
       !moment(referredUser.joined).isValid() ||
       moment(referredUser.joined).isBefore(emailVerifyRewardChangeTime)

--- a/graphql/database/widgets/__mocks__/setUpWidgetsForNewUser.js
+++ b/graphql/database/widgets/__mocks__/setUpWidgetsForNewUser.js
@@ -1,0 +1,3 @@
+/* eslint-env jest */
+
+export default jest.fn(() => Promise.resolve())

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -151,6 +151,16 @@ enum EncodedRevenueValueTypeEnum {
   AMAZON_CPM
 }
 
+input LogEmailVerifiedMutationInput {
+  userId: String!
+  clientMutationId: String
+}
+
+type LogEmailVerifiedMutationPayload {
+  user: User
+  clientMutationId: String
+}
+
 input LogTabInput {
   userId: String!
   tabId: String
@@ -220,6 +230,7 @@ type Mutation {
   logUserDataConsent(input: LogUserDataConsentInput!): LogUserDataConsentPayload
   donateVc(input: DonateVcInput!): DonateVcPayload
   mergeIntoExistingUser(input: MergeIntoExistingUserInput!): MergeIntoExistingUserPayload
+  logEmailVerified(input: LogEmailVerifiedMutationInput!): LogEmailVerifiedMutationPayload
   setUserBkgImage(input: SetUserBkgImageInput!): SetUserBkgImagePayload
   setUserBkgColor(input: SetUserBkgColorInput!): SetUserBkgColorPayload
   setUserBkgCustomImage(input: SetUserBkgCustomImageInput!): SetUserBkgCustomImagePayload

--- a/web/src/__mocks__/relay-env.js
+++ b/web/src/__mocks__/relay-env.js
@@ -1,0 +1,2 @@
+
+export default {}

--- a/web/src/js/authentication/__mocks__/helpers.js
+++ b/web/src/js/authentication/__mocks__/helpers.js
@@ -1,0 +1,4 @@
+/* eslint-env jest */
+
+const mockAuthHelpers = jest.genMockFromModule('../helpers')
+module.exports = mockAuthHelpers

--- a/web/src/js/authentication/__tests__/helpers.test.js
+++ b/web/src/js/authentication/__tests__/helpers.test.js
@@ -248,12 +248,12 @@ describe('checkIfEmailVerified tests', () => {
 
     const checkIfEmailVerified = require('../helpers').checkIfEmailVerified
     const promise = checkIfEmailVerified()
-    await runAsyncTimerLoops(15)
+    await runAsyncTimerLoops(25)
     const isVerified = await promise
     expect(isVerified).toBe(false)
   })
 
-  it('reloads the Firebase user a maximum of 11 times', async () => {
+  it('reloads the Firebase user a maximum of 16 times', async () => {
     expect.assertions(1)
 
     getCurrentUser.mockResolvedValue({
@@ -268,9 +268,9 @@ describe('checkIfEmailVerified tests', () => {
 
     const checkIfEmailVerified = require('../helpers').checkIfEmailVerified
     const promise = checkIfEmailVerified()
-    await runAsyncTimerLoops(15)
+    await runAsyncTimerLoops(25)
     await promise
-    expect(reloadUser).toHaveBeenCalledTimes(11)
+    expect(reloadUser).toHaveBeenCalledTimes(16)
   })
 
   it('returns true if the email is verified after refetching the Firebase user a few times', async () => {
@@ -304,7 +304,7 @@ describe('checkIfEmailVerified tests', () => {
 
     const checkIfEmailVerified = require('../helpers').checkIfEmailVerified
     const promise = checkIfEmailVerified()
-    await runAsyncTimerLoops(15)
+    await runAsyncTimerLoops(25)
     const isVerified = await promise
     expect(isVerified).toBe(true)
   })
@@ -340,7 +340,7 @@ describe('checkIfEmailVerified tests', () => {
 
     const checkIfEmailVerified = require('../helpers').checkIfEmailVerified
     const promise = checkIfEmailVerified()
-    await runAsyncTimerLoops(15)
+    await runAsyncTimerLoops(25)
     await promise
     expect(reloadUser).toHaveBeenCalledTimes(2)
   })
@@ -444,7 +444,7 @@ describe('checkIfEmailVerified tests', () => {
         expect(logger.error).toHaveBeenCalledWith(mockErr)
         done()
       })
-    await runAsyncTimerLoops(15)
+    await runAsyncTimerLoops(25)
   })
 
   it('logs an error if getting the user throws an error', async (done) => {
@@ -465,6 +465,6 @@ describe('checkIfEmailVerified tests', () => {
         expect(logger.error).toHaveBeenCalledWith(mockErr)
         done()
       })
-    await runAsyncTimerLoops(15)
+    await runAsyncTimerLoops(25)
   })
 })

--- a/web/src/js/authentication/__tests__/user.test.js
+++ b/web/src/js/authentication/__tests__/user.test.js
@@ -301,4 +301,43 @@ describe('authentication user module tests', () => {
       username: 'SomeUsername'
     })
   })
+
+  test('reloadUser works as expected when the user exists', async () => {
+    expect.assertions(1)
+
+    // formatUser gets the username from localStorage.
+    const localStorageMgr = require('utils/localstorage-mgr').default
+    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'Shorty')
+
+    const __setFirebaseUser = require('firebase/app').__setFirebaseUser
+    const mockReload = jest.fn()
+    __setFirebaseUser({
+      uid: 'xyz987',
+      email: 'foo@example.com',
+      isAnonymous: false,
+      emailVerified: true,
+      getIdToken: jest.fn(() => 'fake-token-123'),
+      reload: mockReload
+    })
+
+    const reloadUser = require('../user').reloadUser
+    await reloadUser()
+    expect(mockReload).toHaveBeenCalledTimes(1)
+  })
+
+  test('reloadUser does not error when the user does not exist', async () => {
+    expect.assertions(1)
+
+    // formatUser gets the username from localStorage.
+    const localStorageMgr = require('utils/localstorage-mgr').default
+    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'Shorty')
+
+    const __setFirebaseUser = require('firebase/app').__setFirebaseUser
+    const mockReload = jest.fn()
+    __setFirebaseUser(null)
+
+    const reloadUser = require('../user').reloadUser
+    await reloadUser()
+    expect(mockReload).not.toHaveBeenCalled()
+  })
 })

--- a/web/src/js/authentication/__tests__/user.test.js
+++ b/web/src/js/authentication/__tests__/user.test.js
@@ -199,6 +199,42 @@ describe('authentication user module tests', () => {
     expect(firebase.auth().signOut).toHaveBeenCalledTimes(1)
   })
 
+  test('getUserToken forces a refetch when called with forceRefetch=true', async () => {
+    expect.assertions(1)
+
+    const __setFirebaseUser = require('firebase/app').__setFirebaseUser
+    const mockFirebaseGetIdToken = jest.fn()
+    __setFirebaseUser({
+      uid: 'xyz987',
+      email: 'foo@example.com',
+      isAnonymous: false,
+      emailVerified: true,
+      getIdToken: mockFirebaseGetIdToken
+    })
+
+    const getUserToken = require('../user').getUserToken
+    await getUserToken(true)
+    expect(mockFirebaseGetIdToken).toHaveBeenCalledWith(true)
+  })
+
+  test('getUserToken does not force a refetch by default', async () => {
+    expect.assertions(1)
+
+    const __setFirebaseUser = require('firebase/app').__setFirebaseUser
+    const mockFirebaseGetIdToken = jest.fn()
+    __setFirebaseUser({
+      uid: 'xyz987',
+      email: 'foo@example.com',
+      isAnonymous: false,
+      emailVerified: true,
+      getIdToken: mockFirebaseGetIdToken
+    })
+
+    const getUserToken = require('../user').getUserToken
+    await getUserToken()
+    expect(mockFirebaseGetIdToken).toHaveBeenCalledWith(undefined)
+  })
+
   test('removes some localStorage items on logout', async () => {
     expect.assertions(2)
     const localStorageMgr = require('utils/localstorage-mgr').default

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -179,27 +179,35 @@ export const createNewUser = () => {
         throw new Error('Cannot create a new user. User is not authenticated.')
       }
 
-      // Get any referral data that exists.
-      const referralData = getReferralData()
+      // Force-refetch the user ID token so it will have the
+      // correct latest value for email verification.
+      return getUserToken(true)
+        .then(() => {
+          // Get any referral data that exists.
+          const referralData = getReferralData()
 
-      // TODO:
-      // Pass the user's experimentGroups { anonUser } value
+          // TODO:
+          // Pass the user's experimentGroups { anonUser } value
 
-      return new Promise((resolve, reject) => {
-        CreateNewUserMutation(
-          environment,
-          user.id,
-          user.email,
-          referralData,
-          (response) => {
-            resolve(response.createNewUser)
-          },
-          (err) => {
-            console.error('Error at createNewUser:', err)
-            reject(new Error('Could not create new user', err))
-          }
-        )
-      })
+          return new Promise((resolve, reject) => {
+            CreateNewUserMutation(
+              environment,
+              user.id,
+              user.email,
+              referralData,
+              (response) => {
+                resolve(response.createNewUser)
+              },
+              (err) => {
+                console.error('Error at createNewUser:', err)
+                reject(new Error('Could not create new user', err))
+              }
+            )
+          })
+        })
+        .catch(e => {
+          logger.error(e)
+        })
     })
     .catch(e => {
       console.error(e)

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -218,8 +218,8 @@ export const createNewUser = () => {
 export const checkIfEmailVerified = () => {
   return new Promise((resolve, reject) => {
     var polledTimes = 0
-    const maxTimesToPoll = 10
-    const msWaitBetweenPolling = 50
+    const maxTimesToPoll = 15
+    const msWaitBetweenPolling = 250
     function seeIfEmailVerified () {
       if (polledTimes > maxTimesToPoll) {
         return resolve(false)

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -254,3 +254,20 @@ export const signInAnonymously = async () => {
       })
   })
 }
+
+/**
+ * Reload the Firebase user data from the server.
+ * @returns {Promise<undefined>}
+ */
+export const reloadUser = async () => {
+  var user
+  try {
+    user = await getCurrentFirebaseUser()
+  } catch (e) {
+    throw e
+  }
+  if (!user) {
+    return
+  }
+  await user.reload()
+}

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -136,17 +136,19 @@ export const getCurrentUserListener = () => {
 }
 
 /**
- * Get the user's token
+ * Get the user's token.
+ * @param {Boolean} forceRefresh - Whether to force Firebase to refresh
+ *   the token regardless of expiration status.
  * @returns {(string|null)} The token, if the user is authenticated;
  *   otherwise, null.
  */
-export const getUserToken = async () => {
+export const getUserToken = async (forceRefresh) => {
   try {
     const authUser = await getCurrentFirebaseUser()
     if (!authUser) {
       return null
     }
-    const token = authUser.getIdToken()
+    const token = authUser.getIdToken(forceRefresh)
     if (token) {
       return token
     } else {

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -128,10 +128,11 @@ class Authentication extends React.Component {
       return
     }
 
-    // Get or create the user. Note that we expect to call this
-    // even for anonymous users who already have a user on the
-    // server-side, because that's when we add their email to
-    // their profile.
+    // Get or create the user.
+    // Important: we expect to call this on every sign-in event,
+    // even for anonymous users who already have a user in our
+    // database, because this is when we add their email address
+    // and email verification status to their profile.
     return createNewUser()
       .then((createdOrFetchedUser) => {
         // Check if the user has verified their email.

--- a/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
+++ b/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
@@ -17,23 +17,11 @@ import {
 import logger from 'utils/logger'
 import environment from '../../../relay-env'
 import MergeIntoExistingUserMutation from 'mutations/MergeIntoExistingUserMutation'
-import {
-  checkIfEmailVerified
-} from 'authentication/helpers'
 
 class FirebaseAuthenticationUI extends React.Component {
   constructor (props) {
     super(props)
     this.configureFirebaseUI()
-  }
-
-  componentDidMount () {
-    // See if the user verified their email address so that we can
-    // log the verification. It would be better to user a cloud
-    // function for this, or at least an official callback from the
-    // Firebase SDK, but Firebase does not yet support one. See:
-    // https://stackoverflow.com/q/43503377
-    checkIfEmailVerified()
   }
 
   componentWillUnmount () {
@@ -245,16 +233,20 @@ class FirebaseAuthenticationUI extends React.Component {
 
   render () {
     return (
-      <FirebaseAuth
-        uiConfig={this.uiConfig}
-        firebaseAuth={firebase.auth()}
-      />
+      <span>
+        <FirebaseAuth
+          uiConfig={this.uiConfig}
+          firebaseAuth={firebase.auth()}
+        />
+        {this.props.children}
+      </span>
     )
   }
 }
 
 FirebaseAuthenticationUI.propTypes = {
-  onSignInSuccess: PropTypes.func.isRequired
+  onSignInSuccess: PropTypes.func.isRequired,
+  children: PropTypes.element
 }
 
 // https://github.com/facebook/react/issues/6653

--- a/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
+++ b/web/src/js/components/Authentication/FirebaseAuthenticationUI.js
@@ -17,11 +17,23 @@ import {
 import logger from 'utils/logger'
 import environment from '../../../relay-env'
 import MergeIntoExistingUserMutation from 'mutations/MergeIntoExistingUserMutation'
+import {
+  checkIfEmailVerified
+} from 'authentication/helpers'
 
 class FirebaseAuthenticationUI extends React.Component {
   constructor (props) {
     super(props)
     this.configureFirebaseUI()
+  }
+
+  componentDidMount () {
+    // See if the user verified their email address so that we can
+    // log the verification. It would be better to user a cloud
+    // function for this, or at least an official callback from the
+    // Firebase SDK, but Firebase does not yet support one. See:
+    // https://stackoverflow.com/q/43503377
+    checkIfEmailVerified()
   }
 
   componentWillUnmount () {

--- a/web/src/js/components/Authentication/FirebaseAuthenticationUIAction.js
+++ b/web/src/js/components/Authentication/FirebaseAuthenticationUIAction.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import {
+  checkIfEmailVerified
+} from 'authentication/helpers'
+
+class FirebaseAuthenticationUIAction extends React.Component {
+  componentDidMount () {
+    // See if the user verified their email address so that we can
+    // log the verification. It would be better to user a cloud
+    // function for this, or at least an official callback from the
+    // Firebase SDK, but Firebase does not yet support one. See:
+    // https://stackoverflow.com/q/43503377
+    checkIfEmailVerified()
+  }
+
+  render () {
+    return null
+  }
+}
+
+FirebaseAuthenticationUIAction.propTypes = {}
+FirebaseAuthenticationUIAction.defaultProps = {}
+
+export default FirebaseAuthenticationUIAction

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -19,6 +19,7 @@ import {
 } from 'navigation/navigation'
 import {
   getCurrentUser,
+  getUserToken,
   setUsernameInLocalStorage,
   sendVerificationEmail
 } from 'authentication/user'
@@ -62,6 +63,10 @@ const mockUserData = {
 const mockFetchUser = jest.fn()
 
 const mockNow = '2017-05-19T13:59:58.000Z'
+
+beforeAll(() => {
+  getUserToken.mockResolvedValue('some-token')
+})
 
 beforeEach(() => {
   MockDate.set(moment(mockNow))

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -37,6 +37,10 @@ import {
   getBrowserExtensionInstallTime
 } from 'utils/local-user-data-mgr'
 
+// Note: we don't mock authentication/helpers.js so that we
+// can have greater confidence in the full functionality of
+// this component. You may have to mock some modules that
+// are required in helpers.js.
 jest.mock('authentication/user')
 jest.mock('authentication/firebaseConfig') // mock the Firebase app initialization
 jest.mock('authentication/firebaseIDBErrorManager')
@@ -46,6 +50,7 @@ jest.mock('utils/experiments')
 jest.mock('utils/feature-flags')
 jest.mock('utils/local-user-data-mgr')
 jest.mock('mutations/CreateNewUserMutation')
+jest.mock('mutations/LogEmailVerifiedMutation')
 
 const mockLocationData = {
   pathname: '/newtab/auth/'

--- a/web/src/js/components/Authentication/__tests__/FirebaseAuthenticationUI.test.js
+++ b/web/src/js/components/Authentication/__tests__/FirebaseAuthenticationUI.test.js
@@ -13,9 +13,6 @@ import firebase, {
 import MergeIntoExistingUserMutation, {
   __setErrorResponse
 } from 'mutations/MergeIntoExistingUserMutation'
-import {
-  checkIfEmailVerified
-} from 'authentication/helpers'
 
 // Init Firebase
 import { initializeFirebase } from 'authentication/firebaseConfig'
@@ -350,16 +347,6 @@ describe('FirebaseAuthenticationUI tests', function () {
     await signInFailure(mockFirebaseUIErr)
     expect(onSignInSuccessMock)
       .toHaveBeenCalledWith(mockUser)
-  })
-
-  it('calls checkIfEmailVerified on mount', () => {
-    expect.assertions(1)
-
-    const FirebaseAuthenticationUI = require('../FirebaseAuthenticationUI').default
-    shallow(
-      <FirebaseAuthenticationUI {...mockProps} />
-    )
-    expect(checkIfEmailVerified).toHaveBeenCalledTimes(1)
   })
 
 // Note: no clear way to mount react-firebaseui in a JSDOM environment.

--- a/web/src/js/components/Authentication/__tests__/FirebaseAuthenticationUI.test.js
+++ b/web/src/js/components/Authentication/__tests__/FirebaseAuthenticationUI.test.js
@@ -12,14 +12,17 @@ import firebase, {
 } from 'firebase/app'
 import MergeIntoExistingUserMutation, {
   __setErrorResponse
-}
-  from 'mutations/MergeIntoExistingUserMutation'
+} from 'mutations/MergeIntoExistingUserMutation'
+import {
+  checkIfEmailVerified
+} from 'authentication/helpers'
 
 // Init Firebase
 import { initializeFirebase } from 'authentication/firebaseConfig'
 initializeFirebase()
 
 jest.mock('analytics/logEvent')
+jest.mock('authentication/helpers')
 jest.mock('authentication/user')
 jest.mock('authentication/firebaseConfig') // mock the Firebase app initialization
 jest.mock('navigation/navigation')
@@ -27,6 +30,7 @@ jest.mock('react-firebaseui')
 jest.mock('utils/logger')
 jest.mock('firebase/app')
 jest.mock('mutations/MergeIntoExistingUserMutation')
+jest.mock('mutations/LogEmailVerifiedMutation')
 jest.mock('../../../../relay-env', () => { return {} })
 
 const onSignInSuccessMock = jest.fn()
@@ -346,6 +350,16 @@ describe('FirebaseAuthenticationUI tests', function () {
     await signInFailure(mockFirebaseUIErr)
     expect(onSignInSuccessMock)
       .toHaveBeenCalledWith(mockUser)
+  })
+
+  it('calls checkIfEmailVerified on mount', () => {
+    expect.assertions(1)
+
+    const FirebaseAuthenticationUI = require('../FirebaseAuthenticationUI').default
+    shallow(
+      <FirebaseAuthenticationUI {...mockProps} />
+    )
+    expect(checkIfEmailVerified).toHaveBeenCalledTimes(1)
   })
 
 // Note: no clear way to mount react-firebaseui in a JSDOM environment.

--- a/web/src/js/components/Authentication/__tests__/FirebaseAuthenticationUIAction.test.js
+++ b/web/src/js/components/Authentication/__tests__/FirebaseAuthenticationUIAction.test.js
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+
+import React from 'react'
+import {
+  shallow
+} from 'enzyme'
+import {
+  checkIfEmailVerified
+} from 'authentication/helpers'
+import toJson from 'enzyme-to-json'
+
+jest.mock('mutations/LogEmailVerifiedMutation')
+jest.mock('authentication/helpers')
+
+const mockProps = {}
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('FirebaseAuthenticationUIAction tests', function () {
+  it('renders without error and does not have any DOM elements', () => {
+    const FirebaseAuthenticationUIAction = require('../FirebaseAuthenticationUIAction').default
+    const wrapper = shallow(
+      <FirebaseAuthenticationUIAction {...mockProps} />
+    )
+    expect(toJson(wrapper)).toEqual('')
+  })
+
+  it('calls checkIfEmailVerified on mount', async () => {
+    expect.assertions(1)
+
+    const FirebaseAuthenticationUIAction = require('../FirebaseAuthenticationUIAction').default
+    shallow(
+      <FirebaseAuthenticationUIAction {...mockProps} />
+    )
+    expect(checkIfEmailVerified).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/js/components/General/__tests__/AuthUserComponent.test.js
+++ b/web/src/js/components/General/__tests__/AuthUserComponent.test.js
@@ -18,6 +18,7 @@ import {
   verifyEmailURL
 } from 'navigation/navigation'
 import {
+  getUserToken,
   __getAuthListenerCallbacks,
   __unregisterAuthStateChangeListeners,
   __triggerAuthStateChange
@@ -55,6 +56,10 @@ jest.mock('utils/feature-flags')
 jest.mock('utils/local-user-data-mgr')
 
 const mockNow = '2017-05-19T13:59:58.000Z'
+
+beforeAll(() => {
+  getUserToken.mockResolvedValue('some-token')
+})
 
 beforeEach(() => {
   MockDate.set(moment(mockNow))

--- a/web/src/js/components/General/__tests__/AuthUserComponent.test.js
+++ b/web/src/js/components/General/__tests__/AuthUserComponent.test.js
@@ -40,8 +40,13 @@ import {
   getBrowserExtensionInstallTime
 } from 'utils/local-user-data-mgr'
 
+// Note: we don't mock authentication/helpers.js so that we
+// can have greater confidence in the full functionality of
+// this component. You may have to mock some modules that
+// are required in helpers.js.
 jest.mock('authentication/user')
 jest.mock('mutations/CreateNewUserMutation')
+jest.mock('mutations/LogEmailVerifiedMutation')
 jest.mock('navigation/navigation')
 jest.mock('utils/localstorage-mgr')
 jest.mock('web-utils')

--- a/web/src/js/mutations/LogEmailVerifiedMutation.js
+++ b/web/src/js/mutations/LogEmailVerifiedMutation.js
@@ -1,0 +1,30 @@
+import {
+  commitMutation,
+  graphql
+} from 'react-relay/compat'
+
+const mutation = graphql`
+  mutation LogEmailVerifiedMutation($input: LogEmailVerifiedMutationInput!) {
+    logEmailVerified(input: $input) {
+      user {
+        id
+      }
+    }
+  }
+`
+
+function commit (environment, userId, onCompleted = () => {}, onError = () => {}) {
+  return commitMutation(
+    environment,
+    {
+      mutation,
+      variables: {
+        input: { userId }
+      },
+      onCompleted,
+      onError
+    }
+  )
+}
+
+export default commit

--- a/web/src/js/mutations/__mocks__/LogEmailVerifiedMutation.js
+++ b/web/src/js/mutations/__mocks__/LogEmailVerifiedMutation.js
@@ -1,0 +1,45 @@
+/* eslint-env jest */
+
+var onCompletedCallback = () => {}
+var onErrorCallback = () => {}
+
+// Default response data from completed mutation.
+var defaultSuccessResponse = {
+  logEmailVerified: {
+    user: {
+      id: 'foo123'
+    }
+  }
+}
+
+var defaultErrorResponse = null
+
+// Mock Relay data returns
+export const __runOnCompleted = (response = null) => {
+  onCompletedCallback(response)
+}
+
+export const __runOnError = (response) => {
+  onErrorCallback(response)
+}
+
+export const __setSuccessResponse = response => {
+  defaultSuccessResponse = response
+}
+
+export const __setErrorResponse = response => {
+  defaultErrorResponse = response
+}
+
+export default jest.fn((environment, userId, onCompleted, onError) => {
+  onCompletedCallback = onCompleted
+  onErrorCallback = onError
+
+  // If any error or success responses are set, return them.
+  if (defaultErrorResponse) {
+    onError(defaultErrorResponse)
+  }
+  if (defaultSuccessResponse) {
+    onCompletedCallback(defaultSuccessResponse)
+  }
+})

--- a/web/src/js/routes/Route.js
+++ b/web/src/js/routes/Route.js
@@ -8,6 +8,7 @@ import DashboardView from '../components/Dashboard/DashboardView'
 
 import AuthenticationView from '../components/Authentication/AuthenticationView'
 import FirebaseAuthenticationUI from '../components/Authentication/FirebaseAuthenticationUI'
+import FirebaseAuthenticationUIAction from '../components/Authentication/FirebaseAuthenticationUIAction'
 import VerifyEmailMessage from '../components/Authentication/VerifyEmailMessage'
 import EnterUsernameForm from '../components/Authentication/EnterUsernameForm'
 import SignInIframeMessage from '../components/Authentication/SignInIframeMessage'
@@ -49,7 +50,9 @@ export default (
       </Route>
       <Route path='auth' component={AuthenticationView}>
         <IndexRoute component={FirebaseAuthenticationUI} />
-        <Route path='action' component={FirebaseAuthenticationUI} />
+        <Route path='action' component={FirebaseAuthenticationUI} >
+          <IndexRoute component={FirebaseAuthenticationUIAction} />
+        </Route>
         <Route path='verify-email' component={VerifyEmailMessage} />
         <Route path='username' component={EnterUsernameForm} />
         <Route path='welcome' component={SignInIframeMessage} />

--- a/web/src/js/utils/__tests__/test-utils.test.js
+++ b/web/src/js/utils/__tests__/test-utils.test.js
@@ -1,5 +1,9 @@
 /* eslint-env jest */
 
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
 describe('web test-utils', () => {
   test('mockGoogleTagSlotRenderEndedData returns expected defaults', () => {
     const mockGoogleTagSlotRenderEndedData = require('../test-utils').mockGoogleTagSlotRenderEndedData
@@ -55,5 +59,121 @@ describe('web test-utils', () => {
       size: '0x0',
       slotID: 'abx-xyz'
     })
+  })
+
+  test('flushAllPromises works as expected', async () => {
+    expect.assertions(1)
+
+    const flushAllPromises = require('../test-utils').flushAllPromises
+
+    const anotherTestFunc = jest.fn()
+    const testFunc = () => {
+      Promise.resolve()
+        .then(() => {
+          anotherTestFunc('hi')
+        })
+    }
+
+    testFunc()
+    await flushAllPromises()
+    expect(anotherTestFunc).toHaveBeenCalledWith('hi')
+  })
+
+  test('without flushAllPromises, the same test as above would fail', async () => {
+    expect.assertions(1)
+
+    const anotherTestFunc = jest.fn()
+    const testFunc = () => {
+      Promise.resolve()
+        .then(() => {
+          anotherTestFunc('hi')
+        })
+    }
+
+    testFunc()
+    expect(anotherTestFunc).not.toHaveBeenCalled()
+  })
+
+  test('runAsyncTimerLoops works as expected', async () => {
+    expect.assertions(1)
+    jest.useFakeTimers()
+
+    const runAsyncTimerLoops = require('../test-utils').runAsyncTimerLoops
+
+    const anotherTestFunc = jest.fn()
+    var counter = 0
+    const testFunc = () => {
+      if (counter > 2) {
+        anotherTestFunc('hi')
+      }
+      Promise.resolve()
+        .then(() => {
+          setTimeout(() => {
+            counter += 1
+            testFunc()
+          }, 5)
+        })
+    }
+
+    testFunc()
+    await runAsyncTimerLoops(5)
+    expect(anotherTestFunc).toHaveBeenCalledWith('hi')
+  })
+
+  test('without runAsyncTimerLoops, the same test as above would fail (jest.runAllTimers is not sufficient)', async () => {
+    expect.assertions(1)
+    jest.useFakeTimers()
+
+    const anotherTestFunc = jest.fn()
+    var counter = 0
+    const testFunc = () => {
+      if (counter > 2) {
+        anotherTestFunc('hi')
+      }
+      Promise.resolve()
+        .then(() => {
+          setTimeout(() => {
+            counter += 1
+            testFunc()
+          }, 5)
+        })
+    }
+
+    testFunc()
+
+    // Trying to use just run all timers.
+    jest.runAllTimers()
+
+    expect(anotherTestFunc).not.toHaveBeenCalled()
+  })
+
+  test('without runAsyncTimerLoops, the same test as above would fail (flushAllPromises is not sufficient)', async () => {
+    expect.assertions(1)
+    jest.useFakeTimers()
+
+    const flushAllPromises = require('../test-utils').flushAllPromises
+
+    const anotherTestFunc = jest.fn()
+    var counter = 0
+    const testFunc = () => {
+      if (counter > 2) {
+        anotherTestFunc('hi')
+      }
+      Promise.resolve()
+        .then(() => {
+          setTimeout(() => {
+            counter += 1
+            testFunc()
+          }, 5)
+        })
+    }
+
+    testFunc()
+
+    // Trying to use just run all timers.
+    jest.runAllTimers()
+
+    await flushAllPromises()
+    expect(anotherTestFunc).not.toHaveBeenCalled()
   })
 })

--- a/web/src/js/utils/test-utils.js
+++ b/web/src/js/utils/test-utils.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 
 import React from 'react'
 
@@ -173,4 +174,27 @@ export const createMockReactComponent = (componentName, childProps = null) => {
   }
   MockComponent.displayName = componentName || 'MyMockComponent'
   return MockComponent
+}
+
+/**
+ * Flush the Promise resolution queue. See:
+ * https://github.com/facebook/jest/issues/2157
+ * @return {Promise<undefined>}
+ */
+export const flushAllPromises = async () => {
+  await new Promise(resolve => setImmediate(resolve))
+}
+
+/**
+ * Flush the Promise resolution queue, then all timers, and
+ * repeat the given number of times. This is useful for
+ * recursive async code that sets new timers.
+ * https://github.com/facebook/jest/issues/2157
+ * @return {Promise<undefined>}
+ */
+export const runAsyncTimerLoops = async (numLoops) => {
+  for (var i = 0; i < numLoops; i++) {
+    await flushAllPromises()
+    jest.runAllTimers()
+  }
 }


### PR DESCRIPTION
This PR aims to reduce potential user referral fraud (to earn hearts), which is much easier when we allow anonymous user creation. Because some code logic is a little tenuous, this PR also increases the likelihood that we'll fail to reward a referrer.

The code here is a little messy, because Firebase unfortunately [does not support](https://stackoverflow.com/q/43503377) triggering a cloud function when an email is verified, nor is there an "onEmailVerified" callback from the JS SDK. We deal with this limitation by:
1. setting a user's email as verified on sign-in if the Firebase claims show the email is verified. The email address will be immediately verified for identity providers that are auto-verified (such as Google sign-in).
2. attempting to log a user's email as verified when they visit an `/newtab/auth/action/` URL (the page they'll visit when they click an email verification link)
    * Here, we poll Firebase a number of times to see if the email is verified.
    * If the email's verified, we force-reload the user ID token (to refresh the email verification claim) and log the email as verified.
    * This is imperfect. It will fail if: 1) Firebase takes more than a few seconds to say the email is verified (because we'll give up polling); or 2) the user navigates away before we're able to confirm and log the email verification.

When a user's email is logged as verified, we'll reward the referrer if they haven't already been rewarded. Logging email verification can and likely will occur multiple times (each time a user signs in). That's ok.

This PR also adds two test util functions to aid in async web testing: `flushAllPromises` and `runAsyncTimerLoops`.