### PR TITLE
Log the user's test groups on user creation

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -313,9 +313,6 @@ const userType = new GraphQLObjectType({
       type: GraphQLBoolean,
       description: 'Whether this user was created by an existing user and then merged into the existing user'
     }
-    // experimentGroups: {
-    //   type: ExperimentGroupsType,
-    // }
   }),
   interfaces: [nodeInterface]
 })

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -97,7 +97,9 @@ class User extends BaseModel {
       lastTabTimestamp: types.string().isoDate(),
       mergedIntoExistingUser: types.boolean(),
       emailVerified: types.boolean(),
-      referrerRewarded: types.boolean()
+      referrerRewarded: types.boolean(),
+      // Group assignments for experiments / split-tests
+      testGroupAnonSignIn: types.number().integer().allow(null)
     }
   }
 

--- a/graphql/database/users/__tests__/logUserExperimentGroups.test.js
+++ b/graphql/database/users/__tests__/logUserExperimentGroups.test.js
@@ -1,0 +1,152 @@
+/* eslint-env jest */
+
+import moment from 'moment'
+import {
+  DatabaseOperation,
+  getMockUserContext,
+  getMockUserInstance,
+  mockDate,
+  setMockDBResponse
+} from '../../test-utils'
+import {
+  getValidatedExperimentGroups
+} from '../../../utils/experiments'
+
+jest.mock('../../databaseClient')
+jest.mock('../../../utils/experiments')
+
+const userContext = getMockUserContext()
+
+beforeAll(() => {
+  mockDate.on()
+})
+
+afterAll(() => {
+  mockDate.off()
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  getValidatedExperimentGroups.mockReturnValue({})
+})
+
+describe('logUserExperimentGroups', () => {
+  it('sets the testGroupAnonSignIn value when it is provided', async () => {
+    expect.assertions(1)
+
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const mockExperimentGroups = {
+      anonSignIn: 1
+    }
+    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    await logUserExperimentGroups(userContext, userContext.id, mockExperimentGroups)
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      testGroupAnonSignIn: 1,
+      updated: moment.utc().toISOString()
+    })
+  })
+
+  it('does not update the item when no experiment groups are provided', async () => {
+    expect.assertions(1)
+
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const mockExperimentGroups = {}
+    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    await logUserExperimentGroups(userContext, userContext.id, mockExperimentGroups)
+    expect(updateQuery).not.toHaveBeenCalled()
+  })
+
+  it('does not update the item when called with a null experimentGroups', async () => {
+    expect.assertions(1)
+
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const mockExperimentGroups = null
+    getValidatedExperimentGroups.mockReturnValueOnce({}) // Will return an empty object
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    await logUserExperimentGroups(userContext, userContext.id, mockExperimentGroups)
+    expect(updateQuery).not.toHaveBeenCalled()
+  })
+
+  it('returns the user object when experiment groups are provided', async () => {
+    expect.assertions(1)
+
+    // Mock DB response.
+    const expectedReturnedUser = Object.assign(
+      {},
+      getMockUserInstance(),
+      {
+        testGroupAnonSignIn: 1
+      }
+    )
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      {
+        Attributes: expectedReturnedUser
+      }
+    )
+
+    const mockExperimentGroups = {
+      anonSignIn: 1
+    }
+    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    const returnedUser = await logUserExperimentGroups(userContext, userContext.id,
+      mockExperimentGroups)
+    expect(returnedUser).toEqual(expectedReturnedUser)
+  })
+
+  it('returns the user object when no experiment groups are provided', async () => {
+    expect.assertions(1)
+
+    // Mock DB response.
+    const expectedReturnedUser = Object.assign(
+      {},
+      getMockUserInstance()
+    )
+    setMockDBResponse(
+      DatabaseOperation.GET,
+      {
+        Item: expectedReturnedUser
+      }
+    )
+
+    const mockExperimentGroups = {}
+    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    const returnedUser = await logUserExperimentGroups(userContext, userContext.id,
+      mockExperimentGroups)
+    expect(returnedUser).toEqual(expectedReturnedUser)
+  })
+
+  it('does not save a test group value if it is invalid', async () => {
+    expect.assertions(1)
+
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    // Have the validated groups differ from provided.
+    const mockExperimentGroups = {
+      anonSignIn: 34543543
+    }
+    getValidatedExperimentGroups.mockReturnValueOnce({
+      anonSignIn: null
+    })
+
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    await logUserExperimentGroups(userContext, userContext.id, mockExperimentGroups)
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      // Note: testGroupAnonSignIn not modified
+      updated: moment.utc().toISOString()
+    })
+  })
+})

--- a/graphql/database/users/createUser.js
+++ b/graphql/database/users/createUser.js
@@ -5,6 +5,7 @@ import moment from 'moment'
 import UserModel from './UserModel'
 import logReferralData from '../referrals/logReferralData'
 import logEmailVerified from './logEmailVerified'
+import logUserExperimentGroups from './logUserExperimentGroups'
 import getUserByUsername from './getUserByUsername'
 import setUpWidgetsForNewUser from '../widgets/setUpWidgetsForNewUser'
 import logger from '../../utils/logger'
@@ -18,9 +19,11 @@ import logger from '../../utils/logger'
  * @param {string|null} email - The user's email (provided by the client, not
  *   from user claims)
  * @param {object|null} referralData - Referral data.
+ * @param {object|null} experimentGroups - Any experimental test groups to
+ *   which the user has been assigned.
  * @return {Promise<User>}  A promise that resolves into a User instance.
  */
-const createUser = async (userContext, userId, email = null, referralData = null) => {
+const createUser = async (userContext, userId, email = null, referralData = null, experimentGroups = {}) => {
   // Get or create the user.
   const userInfo = {
     id: userId,
@@ -102,6 +105,13 @@ const createUser = async (userContext, userId, email = null, referralData = null
         ${e}
       `))
     }
+  }
+
+  // Log the experimental groups to which the user belongs.
+  try {
+    returnedUser = await logUserExperimentGroups(userContext, userId, experimentGroups)
+  } catch (e) {
+    throw e
   }
 
   // Add the 'justCreated' field so the client can know it's

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -1,0 +1,55 @@
+
+import UserModel from './UserModel'
+import { isEmpty } from 'lodash/lang'
+import {
+  getValidatedExperimentGroups
+} from '../../utils/experiments'
+
+/**
+ * Update the user to include the experiment groups to which they've
+ * been assigned. Validate the group values and only store them if
+ * they're valid.
+ * @param {object} userContext - The user authorizer object.
+ * @param {string} userId - The user's ID.
+ * @param {object|null} experimentGroups - Any experimental test groups to
+ *   which the user has been assigned. This will take the shape of the
+ *   ExperimentGroupsType object in our GraphQL schema.
+ * @return {Promise<User>}  A promise that resolves into a User instance.
+ */
+const logUserExperimentGroups = async (userContext, userId, experimentGroups = {}) => {
+  var returnedUser
+
+  // If there are no experiment groups to update, simply get and
+  // return the user.
+  if (isEmpty(experimentGroups)) {
+    try {
+      returnedUser = await UserModel.get(userContext, userId)
+    } catch (e) {
+      throw e
+    }
+    return returnedUser
+  }
+
+  const validatedGroups = getValidatedExperimentGroups(experimentGroups)
+
+  // Unpack and conditionally update experiment groups. Only do this
+  // for experiment groups that the client assigns, because the client
+  // can modify these data.
+  const userDataToUpdate = Object.assign(
+    {
+      id: userId
+    },
+    validatedGroups.anonSignIn ? {
+      testGroupAnonSignIn: validatedGroups.anonSignIn
+    }
+      : null
+  )
+  try {
+    returnedUser = await UserModel.update(userContext, userDataToUpdate)
+  } catch (e) {
+    throw e
+  }
+  return returnedUser
+}
+
+export default logUserExperimentGroups

--- a/graphql/utils/__tests__/experiments.test.js
+++ b/graphql/utils/__tests__/experiments.test.js
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+
+beforeEach(() => {
+  // Modify the experiments for testing.
+  const experiments = require('../experiments')
+  experiments.experimentConfig = {
+    anonSignIn: {
+      NONE: 0,
+      AUTHED_USER_ONLY: 1,
+      ANONYMOUS_ALLOWED: 2
+    },
+    fooTest: {
+      NONE: 0,
+      SOME_OTHER_GROUP: 1
+    },
+    anImportantTest: {
+      FAIL: 'fail',
+      SUCCEED: 'succeed',
+      AMBIGUOUS: 'ambiguous'
+    }
+  }
+})
+
+afterEach(() => {
+  jest.resetModules()
+})
+
+describe('experiments', () => {
+  test('returns expected experiment groups when all are valid', () => {
+    const getValidatedExperimentGroups = require('../experiments')
+      .getValidatedExperimentGroups
+    const expGroups = getValidatedExperimentGroups({
+      anonSignIn: 1,
+      fooTest: 0,
+      anImportantTest: 'ambiguous'
+    })
+    expect(expGroups).toEqual({
+      anonSignIn: 1,
+      fooTest: 0,
+      anImportantTest: 'ambiguous'
+    })
+  })
+
+  test('returns all null experiment groups when none are provided', () => {
+    const getValidatedExperimentGroups = require('../experiments')
+      .getValidatedExperimentGroups
+    const expGroups = getValidatedExperimentGroups({})
+    expect(expGroups).toEqual({
+      anonSignIn: null,
+      fooTest: null,
+      anImportantTest: null
+    })
+  })
+
+  test('returns a null experiment group value when the group value is invalid', () => {
+    const getValidatedExperimentGroups = require('../experiments')
+      .getValidatedExperimentGroups
+    const expGroups = getValidatedExperimentGroups({
+      anonSignIn: 3020,
+      fooTest: 1,
+      anImportantTest: 'this is invalid!'
+    })
+    expect(expGroups).toEqual({
+      anonSignIn: null,
+      fooTest: 1,
+      anImportantTest: null
+    })
+  })
+
+  test('returns all null experiment groups when nothing is provdied', () => {
+    const getValidatedExperimentGroups = require('../experiments')
+      .getValidatedExperimentGroups
+    const expGroups = getValidatedExperimentGroups()
+    expect(expGroups).toEqual({
+      anonSignIn: null,
+      fooTest: null,
+      anImportantTest: null
+    })
+  })
+
+  test('returns an empty object when there are no experiments', () => {
+    const experiments = require('../experiments')
+    experiments.experimentConfig = {}
+    const getValidatedExperimentGroups = require('../experiments')
+      .getValidatedExperimentGroups
+    const expGroups = getValidatedExperimentGroups({
+      anonSignIn: 1,
+      fooTest: 0,
+      anImportantTest: 'ambiguous'
+    })
+    expect(expGroups).toEqual({})
+  })
+})

--- a/graphql/utils/__tests__/experiments.test.js
+++ b/graphql/utils/__tests__/experiments.test.js
@@ -67,7 +67,7 @@ describe('experiments', () => {
     })
   })
 
-  test('returns all null experiment groups when nothing is provdied', () => {
+  test('returns all null experiment groups when nothing is provided', () => {
     const getValidatedExperimentGroups = require('../experiments')
       .getValidatedExperimentGroups
     const expGroups = getValidatedExperimentGroups()

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -1,0 +1,72 @@
+
+import { get } from 'lodash/object'
+
+// Experiments with valid experiment group values.
+const experimentConfig = {
+  anonSignIn: {
+    NONE: 0,
+    AUTHED_USER_ONLY: 1,
+    ANONYMOUS_ALLOWED: 2
+  }
+}
+
+/**
+ * Return an object of the configured experiments.
+ * @return {Object} An object with a key for each experiment name.
+ */
+const getExperiments = () => {
+  // Calling exports to be able to modify the experimentGroups
+  // variable during testing while keeping it in this file.
+  return exports.experimentConfig
+}
+
+/**
+ * Return an array of the names of configured experiments.
+ * @return {String[]} An array of the names of all experiments.
+ */
+const getAllExperiments = () => {
+  return Object.keys(getExperiments())
+}
+
+/**
+ * Return whether an experiment group value is valid for the given
+ * experiment.
+ * @param {String} experimentName - The name of the experiment
+ * @param {Number} groupVal - The value of the assigned group
+ * @return {Boolean} Whether the groupVal is a valid group option
+ *   for the given experiment with name experimentName.
+ */
+const isValidExperimentGroup = (experimentName, groupVal) => {
+  const validGroupValues = Object.values(getExperiments()[experimentName])
+  return validGroupValues.indexOf(groupVal) > -1
+}
+
+/**
+ * Validate an object of experiments with assigned group values,
+ * returning group values that are guaranteed to be valid or null.
+ * Provided experiment group values that are undefined or invalid
+ * are returned as null.
+ * @param {Object} clientExperimentGroups - Any experimental test
+ *   groups to which the user has been assigned. This will take
+ *   the shape of the ExperimentGroupsType object in our GraphQL
+ *   schema.
+ * @return {Object} The validated experiment groups. This will take
+ *   the shape of the ExperimentGroupsType object in our GraphQL
+ *   schema.
+ */
+const getValidatedExperimentGroups = (clientExperimentGroups) => {
+  return getAllExperiments().reduce((map, experimentName) => {
+    const clientGroupVal = get(clientExperimentGroups, experimentName)
+    const validatedGroupVal = isValidExperimentGroup(experimentName, clientGroupVal)
+      ? clientGroupVal
+      : null
+    return Object.assign({}, map, {
+      [experimentName]: validatedGroupVal
+    })
+  }, {})
+}
+
+export {
+  experimentConfig,
+  getValidatedExperimentGroups
+}

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -108,6 +108,7 @@ input CreateNewUserInput {
   userId: String!
   email: String
   referralData: ReferralData
+  experimentGroups: ExperimentGroups
   clientMutationId: String
 }
 
@@ -149,6 +150,18 @@ input EncodedRevenueValue {
 # The type of transformation we should use to resolve the object into a revenue value
 enum EncodedRevenueValueTypeEnum {
   AMAZON_CPM
+}
+
+# The test of allowing anonymous user authentication
+enum ExperimentGroupAnonSignIn {
+  NONE
+  AUTHED_USER_ONLY
+  ANONYMOUS_ALLOWED
+}
+
+# The experimental groups to which the user is assigned
+input ExperimentGroups {
+  anonSignIn: ExperimentGroupAnonSignIn
 }
 
 input LogEmailVerifiedMutationInput {

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -24,7 +24,8 @@ import CreateNewUserMutation from 'mutations/CreateNewUserMutation'
 import LogEmailVerifiedMutation from 'mutations/LogEmailVerifiedMutation'
 import {
   ANON_USER_GROUP_UNAUTHED_ALLOWED,
-  getAnonymousUserTestGroup
+  getAnonymousUserTestGroup,
+  getUserTestGroupsForMutation
 } from 'utils/experiments'
 import {
   isAnonymousUserSignInEnabled
@@ -186,8 +187,8 @@ export const createNewUser = () => {
           // Get any referral data that exists.
           const referralData = getReferralData()
 
-          // TODO:
-          // Pass the user's experimentGroups { anonUser } value
+          // Pass the user's assigned experiment groups.
+          const experimentGroups = getUserTestGroupsForMutation()
 
           return new Promise((resolve, reject) => {
             CreateNewUserMutation(
@@ -195,6 +196,7 @@ export const createNewUser = () => {
               user.id,
               user.email,
               referralData,
+              experimentGroups,
               (response) => {
                 resolve(response.createNewUser)
               },

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -179,7 +179,7 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -637,7 +637,7 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -691,7 +691,7 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -756,7 +756,7 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',

--- a/web/src/js/components/General/__tests__/AuthUserComponent.test.js
+++ b/web/src/js/components/General/__tests__/AuthUserComponent.test.js
@@ -123,7 +123,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -196,7 +196,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -241,7 +241,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -279,7 +279,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -320,7 +320,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -358,7 +358,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -393,7 +393,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -428,7 +428,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -466,7 +466,7 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',

--- a/web/src/js/mutations/CreateNewUserMutation.js
+++ b/web/src/js/mutations/CreateNewUserMutation.js
@@ -15,13 +15,13 @@ const mutation = graphql`
   }
 `
 
-function commit (environment, userId, email, referralData, onCompleted, onError) {
+function commit (environment, userId, email, referralData, experimentGroups, onCompleted, onError) {
   return commitMutation(
     environment,
     {
       mutation,
       variables: {
-        input: { userId, email, referralData }
+        input: { userId, email, referralData, experimentGroups }
       },
       onCompleted: (response) => {
         onCompleted(response)

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -74,4 +74,22 @@ describe('experiments', () => {
     const testGroup = getAnonymousUserTestGroup()
     expect(testGroup).toBe('none')
   })
+
+  test('getUserTestGroupsForMutation returns the expected value for an assigned group', () => {
+    isAnonymousUserSignInEnabled.mockReturnValue(true)
+    localStorageMgr.setItem(STORAGE_EXPERIMENT_ANON_USER, 'unauthed')
+    const getUserTestGroupsForMutation = require('../experiments').getUserTestGroupsForMutation
+    expect(getUserTestGroupsForMutation()).toEqual({
+      anonSignIn: 'ANONYMOUS_ALLOWED'
+    })
+  })
+
+  test('getUserTestGroupsForMutation returns the expected value when the user is not assigned to a group', () => {
+    isAnonymousUserSignInEnabled.mockReturnValue(true)
+    localStorageMgr.removeItem(STORAGE_EXPERIMENT_ANON_USER)
+    const getUserTestGroupsForMutation = require('../experiments').getUserTestGroupsForMutation
+    expect(getUserTestGroupsForMutation()).toEqual({
+      anonSignIn: 'NONE'
+    })
+  })
 })

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -59,3 +59,37 @@ const assignAnonymousUserTestGroup = () => {
 export const assignUserToTestGroups = () => {
   assignAnonymousUserTestGroup()
 }
+
+/**
+ * Converts the anonymous test group value to its corresponding
+ * string used by the server-side, compliant with our GraphQL
+ * schema.
+ * @param {String} testGroup - One of the constants representing
+ *   the user's test group for the anonymous user test.
+ * @returns {String} The string representing the test group,
+ *   compliant with our GraphQL schema.
+ */
+const anonymousTestGroupToSchemaValue = testGroup => {
+  // Corresponds to server-side enum.
+  const map = {
+    [ANON_USER_GROUP_NO_GROUP]: 'NONE',
+    [ANON_USER_GROUP_AUTH_REQUIRED]: 'AUTHED_USER_ONLY',
+    [ANON_USER_GROUP_UNAUTHED_ALLOWED]: 'ANONYMOUS_ALLOWED'
+  }
+  return map[testGroup]
+}
+
+/**
+ * Returns an object with a key for each active experiment. Each
+ * key's value is an integer representing the test group to which
+ * the user is assigned for that test. The object takes the shape
+ * of our GraphQL schema's ExperimentGroupsType.
+ * @returns {Object} The object of experiment group assignments
+ *   for the user, taking the shape of our GraphQL schema's
+ *   ExperimentGroupsType.
+ */
+export const getUserTestGroupsForMutation = () => {
+  return {
+    anonSignIn: anonymousTestGroupToSchemaValue(getAnonymousUserTestGroup())
+  }
+}


### PR DESCRIPTION
Some tests, like the anonymous user sign0n, assign the user to test groups on the client side before user creation. This PR makes sure we log the user's test group for the anonymous user sign-in when we create the user.

* Add a numeric `testGroupAnonSignIn` field to the User model
* Add an `ExperimentGroupsType` GraphQL object
* Send an "experiment groups" object in the mutation when creating a new user, then store the user's experiment groups in the database