### PR TITLE
Safer database item creation and update

### DIFF
--- a/graphql/database/base/BaseModel.js
+++ b/graphql/database/base/BaseModel.js
@@ -319,7 +319,7 @@ class BaseModel {
    *   if one exists with the same hash key
    * @return {Object} item - The created item
   */
-  static async create (userContext, item, overwrite = true) {
+  static async create (userContext, item, overwrite = false) {
     // logger.debug(`Creating item in ${this.tableName}: ${JSON.stringify(item, null, 2)}`)
     const self = this
     const hashKey = item[this.hashKey]

--- a/graphql/database/base/__tests__/BaseModel-queries.test.js
+++ b/graphql/database/base/__tests__/BaseModel-queries.test.js
@@ -282,7 +282,14 @@ describe('BaseModel queries', () => {
           name: item.name,
           updated: moment.utc().toISOString()
         },
-        TableName: ExampleModel.tableName
+        TableName: ExampleModel.tableName,
+        ConditionExpression: '(#id <> :id)',
+        ExpressionAttributeNames: {
+          '#id': 'id'
+        },
+        ExpressionAttributeValues: {
+          ':id': item.id
+        }
       }
     )
 
@@ -315,7 +322,14 @@ describe('BaseModel queries', () => {
         name: ExampleModel.fieldDefaults.name,
         updated: moment.utc().toISOString()
       },
-      TableName: ExampleModel.tableName
+      TableName: ExampleModel.tableName,
+      ConditionExpression: '(#id <> :id)',
+      ExpressionAttributeNames: {
+        '#id': 'id'
+      },
+      ExpressionAttributeValues: {
+        ':id': createdItem.id
+      }
     })
 
     // Verify returned object.
@@ -721,7 +735,14 @@ describe('BaseModel queries', () => {
           name: item.name,
           updated: '2017-12-25T07:15:02.025Z'
         },
-        TableName: ExampleModel.tableName
+        TableName: ExampleModel.tableName,
+        ConditionExpression: '(#id <> :id)',
+        ExpressionAttributeNames: {
+          '#id': 'id'
+        },
+        ExpressionAttributeValues: {
+          ':id': item.id
+        }
       }
     )
   })

--- a/graphql/database/widgets/__tests__/setUpWidgetsForNewUser.test.js
+++ b/graphql/database/widgets/__tests__/setUpWidgetsForNewUser.test.js
@@ -1,27 +1,66 @@
 /* eslint-env jest */
 
 import setUpWidgetsForNewUser from '../setUpWidgetsForNewUser'
+import UserWidgetModel from '../userWidget/UserWidgetModel'
 import {
-  updateWidgetEnabled
-} from '../updateWidget'
-import {
-  getMockUserContext
+  addTimestampFieldsToItem,
+  getMockUserContext,
+  mockDate
 } from '../../test-utils'
 
-jest.mock('../updateWidget')
+jest.mock('../../databaseClient')
 
 const userContext = getMockUserContext()
 const userId = userContext.id
 
+beforeAll(() => {
+  mockDate.on()
+})
+
+afterAll(() => {
+  mockDate.off()
+})
+
 describe('setUpWidgetsForNewUser', () => {
-  it('calls expected functions', async () => {
+  it('sets up all the widgets we expect', async () => {
+    const userWidgetModelCreate = jest.spyOn(UserWidgetModel, 'create')
     const returnedVal = await setUpWidgetsForNewUser(userContext, userId)
-    expect(updateWidgetEnabled.mock.calls).toEqual([
-      [userContext, userId, 'a8cfd733-639b-49d4-a822-116cc7e5c2e2', true],
-      [userContext, userId, '63859963-f691-42f6-bc80-ac83eddc4104', true],
-      [userContext, userId, '4f254eca-36c8-45d8-a91c-e5b6051b0d6d', true],
-      [userContext, userId, '8b5e572b-7f44-45ea-965b-55e6a22ca190', true]
-    ])
+
+    expect(userWidgetModelCreate)
+      .toHaveBeenCalledWith(userContext, addTimestampFieldsToItem({
+        userId: userId,
+        widgetId: 'a8cfd733-639b-49d4-a822-116cc7e5c2e2',
+        enabled: true
+      }))
+    expect(userWidgetModelCreate)
+      .toHaveBeenCalledWith(userContext, addTimestampFieldsToItem({
+        userId: userId,
+        widgetId: '63859963-f691-42f6-bc80-ac83eddc4104',
+        enabled: true
+      }))
+    expect(userWidgetModelCreate)
+      .toHaveBeenCalledWith(userContext, addTimestampFieldsToItem({
+        userId: userId,
+        widgetId: '4f254eca-36c8-45d8-a91c-e5b6051b0d6d',
+        enabled: true
+      }))
+    expect(userWidgetModelCreate)
+      .toHaveBeenCalledWith(userContext, addTimestampFieldsToItem({
+        userId: userId,
+        widgetId: '8b5e572b-7f44-45ea-965b-55e6a22ca190',
+        enabled: true
+      }))
+    expect(userWidgetModelCreate)
+      .toHaveBeenCalledWith(userContext, addTimestampFieldsToItem({
+        userId: userId,
+        widgetId: 'b7645e93-62d0-4293-83fc-c19d499eaefe',
+        enabled: false
+      }))
+    expect(returnedVal).toBe(true)
+  })
+
+  it('returns true when there are no errors', async () => {
+    const returnedVal = await setUpWidgetsForNewUser(userContext, userId)
     expect(returnedVal).toBe(true)
   })
 })

--- a/graphql/database/widgets/setUpWidgetsForNewUser.js
+++ b/graphql/database/widgets/setUpWidgetsForNewUser.js
@@ -1,7 +1,5 @@
 
-import {
-  updateWidgetEnabled
-} from './updateWidget'
+import UserWidgetModel from './userWidget/UserWidgetModel'
 
 const Promise = require('bluebird')
 
@@ -25,12 +23,12 @@ const widgetConfigurations = [
   {
     id: '8b5e572b-7f44-45ea-965b-55e6a22ca190',
     enabled: true
+  },
+  // To-dos
+  {
+    id: 'b7645e93-62d0-4293-83fc-c19d499eaefe',
+    enabled: false
   }
-  // // To-dos
-  // {
-  //   id: 'b7645e93-62d0-4293-83fc-c19d499eaefe',
-  //   enabled: false
-  // },
 ]
 
 /**
@@ -43,16 +41,17 @@ const widgetConfigurations = [
 export default async (userContext, userId) => {
   return Promise.all(widgetConfigurations.map(async (widgetConfig) => {
     try {
-      await updateWidgetEnabled(userContext, userId, widgetConfig.id,
-        widgetConfig.enabled)
+      await UserWidgetModel.create(userContext, {
+        userId: userId,
+        widgetId: widgetConfig.id,
+        enabled: widgetConfig.enabled
+      })
     } catch (err) {
       throw err
     }
   }))
     .then(data => true)
     .catch(err => {
-      console.error('setUpWidgetsForNewUser error')
-      console.error(err)
       throw err
     })
 }

--- a/graphql/database/widgets/userWidget/UserWidgetModel.js
+++ b/graphql/database/widgets/userWidget/UserWidgetModel.js
@@ -27,6 +27,8 @@ class UserWidget extends BaseModel {
     return tableNames.userWidgets
   }
 
+  // Note: due to a bug, the "created" timestamp field does not
+  // exist on UserWidget items created before 2018 Sept 21.
   static get schema () {
     const self = this
     return {

--- a/graphql/database/widgets/userWidget/__tests__/updateUserWidgetConfig.test.js
+++ b/graphql/database/widgets/userWidget/__tests__/updateUserWidgetConfig.test.js
@@ -28,6 +28,8 @@ afterEach(() => {
 
 describe('updateUserWidgetConfig', () => {
   it('works as expected', async () => {
+    expect.assertions(2)
+
     const userInfo = getMockUserInfo()
     const userWidget = new UserWidgetModel({
       userId: userInfo.id,
@@ -60,5 +62,132 @@ describe('updateUserWidgetConfig', () => {
         config: newConfig
       })
     expect(updatedWidget).toEqual(expectedWidget)
+  })
+
+  it('tries to create the object if it does not already exist', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const userWidgetCreate = jest.spyOn(UserWidgetModel, 'create')
+
+    // Set that the item doesn't exist when updating.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'ConditionalCheckFailedException' }
+    )
+
+    // Set the return for the created object.
+    const userWidget = new UserWidgetModel({
+      userId: userInfo.id,
+      widgetId: 'ab5082cc-151a-4a9a-9289-06906670fd4e',
+      enabled: false,
+      config: {
+        foo: 'bar'
+      }
+    })
+    const newConfig = { foo: 'boop' }
+    const expectedWidget = Object.assign({}, userWidget, {
+      config: newConfig,
+      updated: moment.utc().toISOString()
+    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: expectedWidget
+      }
+    )
+
+    await updateUserWidgetConfig(userContext, userInfo.id,
+      userWidget.widgetId, newConfig)
+    expect(userWidgetCreate).toHaveBeenCalledWith(userContext, {
+      userId: userInfo.id,
+      widgetId: userWidget.widgetId,
+      created: moment.utc().toISOString(),
+      updated: moment.utc().toISOString(),
+      config: newConfig
+    })
+  })
+
+  it('returns the created object if it does not already exist', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+
+    // Set that the item doesn't exist when updating.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'ConditionalCheckFailedException' }
+    )
+
+    // Set the return for the created object.
+    const userWidget = new UserWidgetModel({
+      userId: userInfo.id,
+      widgetId: 'ab5082cc-151a-4a9a-9289-06906670fd4e',
+      enabled: false,
+      config: {
+        foo: 'bar'
+      }
+    })
+    const newConfig = { foo: 'boop' }
+    const expectedWidget = Object.assign({}, userWidget, {
+      config: newConfig,
+      created: moment.utc().toISOString(),
+      updated: moment.utc().toISOString()
+    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: expectedWidget
+      }
+    )
+
+    const returnedUserWidget = await updateUserWidgetConfig(userContext,
+      userInfo.id, userWidget.widgetId, newConfig)
+    expect(returnedUserWidget).toEqual(expectedWidget)
+  })
+
+  it('throws when there is an update error other than failed conditional check', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const widgetId = 'ab5082cc-151a-4a9a-9289-06906670fd4e'
+
+    // Set some other update error.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'SomethingElse' }
+    )
+
+    return expect(updateUserWidgetConfig(userContext,
+        userInfo.id, widgetId, { some: 'config' }))
+      .rejects.toThrow()
+  })
+
+  it('throws when there is a create error', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const widgetId = 'ab5082cc-151a-4a9a-9289-06906670fd4e'
+
+    // Set that the item doesn't exist when updating.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'ConditionalCheckFailedException' }
+    )
+
+    // Set some error during creation.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      { code: 'SomethingWentWrong' }
+    )
+
+    return expect(updateUserWidgetConfig(userContext,
+        userInfo.id, widgetId, { some: 'config' }))
+      .rejects.toThrow()
   })
 })

--- a/graphql/database/widgets/userWidget/__tests__/updateUserWidgetEnabled.test.js
+++ b/graphql/database/widgets/userWidget/__tests__/updateUserWidgetEnabled.test.js
@@ -57,4 +57,125 @@ describe('updateUserWidgetEnabled', () => {
       })
     expect(updatedWidget).toEqual(expectedWidget)
   })
+
+  it('tries to create the object if it does not already exist', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const userWidgetCreate = jest.spyOn(UserWidgetModel, 'create')
+
+    // Set that the item doesn't exist when updating.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'ConditionalCheckFailedException' }
+    )
+
+    // Set the return for the created object.
+    const userWidget = new UserWidgetModel({
+      userId: userInfo.id,
+      widgetId: 'ab5082cc-151a-4a9a-9289-06906670fd4e',
+      enabled: false
+    })
+    const newEnabledStatus = true
+    const expectedWidget = Object.assign({}, userWidget, {
+      enabled: newEnabledStatus,
+      updated: moment.utc().toISOString()
+    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: expectedWidget
+      }
+    )
+
+    await updateUserWidgetEnabled(userContext, userInfo.id,
+      userWidget.widgetId, newEnabledStatus)
+    expect(userWidgetCreate).toHaveBeenCalledWith(userContext, {
+      userId: userInfo.id,
+      widgetId: userWidget.widgetId,
+      created: moment.utc().toISOString(),
+      updated: moment.utc().toISOString(),
+      enabled: newEnabledStatus
+    })
+  })
+
+  it('returns the created object if it does not already exist', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+
+    // Set that the item doesn't exist when updating.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'ConditionalCheckFailedException' }
+    )
+
+    // Set the return for the created object.
+    const userWidget = new UserWidgetModel({
+      userId: userInfo.id,
+      widgetId: 'ab5082cc-151a-4a9a-9289-06906670fd4e',
+      enabled: false
+    })
+    const newEnabledStatus = true
+    const expectedWidget = Object.assign({}, userWidget, {
+      enabled: newEnabledStatus,
+      created: moment.utc().toISOString(),
+      updated: moment.utc().toISOString()
+    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: expectedWidget
+      }
+    )
+
+    const returnedUserWidget = await updateUserWidgetEnabled(userContext,
+      userInfo.id, userWidget.widgetId, newEnabledStatus)
+    expect(returnedUserWidget).toEqual(expectedWidget)
+  })
+
+  it('throws when there is an update error other than failed conditional check', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const widgetId = 'ab5082cc-151a-4a9a-9289-06906670fd4e'
+
+    // Set some other update error.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'SomethingElse' }
+    )
+
+    return expect(updateUserWidgetEnabled(userContext,
+        userInfo.id, widgetId, true))
+      .rejects.toThrow()
+  })
+
+  it('throws when there is a create error', async () => {
+    expect.assertions(1)
+
+    const userInfo = getMockUserInfo()
+    const widgetId = 'ab5082cc-151a-4a9a-9289-06906670fd4e'
+
+    // Set that the item doesn't exist when updating.
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      { code: 'ConditionalCheckFailedException' }
+    )
+
+    // Set some error during creation.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      { code: 'SomethingWentWrong' }
+    )
+
+    return expect(updateUserWidgetEnabled(userContext,
+        userInfo.id, widgetId, true))
+      .rejects.toThrow()
+  })
 })

--- a/graphql/database/widgets/userWidget/updateUserWidgetConfig.js
+++ b/graphql/database/widgets/userWidget/updateUserWidgetConfig.js
@@ -11,9 +11,30 @@ import UserWidgetModel from './UserWidgetModel'
  * Widget.
  */
 export default async (userContext, userId, widgetId, config) => {
-  return UserWidgetModel.update(userContext, {
-    userId: userId,
-    widgetId: widgetId,
-    config: config
-  })
+  var userWidget
+  try {
+    userWidget = await UserWidgetModel.update(userContext, {
+      userId: userId,
+      widgetId: widgetId,
+      config: config
+    })
+  } catch (e) {
+    // The item likely does not exist. This might happen when a
+    // user modifies the config of a widget they've never used.
+    // Try to create the widget.
+    if (e.code === 'ConditionalCheckFailedException') {
+      try {
+        userWidget = await UserWidgetModel.create(userContext, {
+          userId: userId,
+          widgetId: widgetId,
+          config: config
+        })
+      } catch (e) {
+        throw e
+      }
+    } else {
+      throw e
+    }
+  }
+  return userWidget
 }

--- a/graphql/database/widgets/userWidget/updateUserWidgetEnabled.js
+++ b/graphql/database/widgets/userWidget/updateUserWidgetEnabled.js
@@ -11,9 +11,30 @@ import UserWidgetModel from './UserWidgetModel'
  * Widget.
  */
 export default async (userContext, userId, widgetId, enabled) => {
-  return UserWidgetModel.update(userContext, {
-    userId: userId,
-    widgetId: widgetId,
-    enabled: enabled
-  })
+  var userWidget
+  try {
+    userWidget = await UserWidgetModel.update(userContext, {
+      userId: userId,
+      widgetId: widgetId,
+      enabled: enabled
+    })
+  } catch (e) {
+    // The item likely does not exist. This might happen when a
+    // user enables a widget they've never used.
+    // Try to create the widget.
+    if (e.code === 'ConditionalCheckFailedException') {
+      try {
+        userWidget = await UserWidgetModel.create(userContext, {
+          userId: userId,
+          widgetId: widgetId,
+          enabled: enabled
+        })
+      } catch (e) {
+        throw e
+      }
+    } else {
+      throw e
+    }
+  }
+  return userWidget
 }


### PR DESCRIPTION
Fixes #322 

This PR prevents updates on non-existing database items (prevent items with missing fields) and prevents creations on existing items by default (prevent data loss by overwrite).