### PR TITLE
Log install data when creating a new user

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -873,7 +873,9 @@ const createNewUserMutation = mutationWithClientMutationId({
     userId: { type: new GraphQLNonNull(GraphQLString) },
     email: { type: GraphQLString },
     referralData: { type: ReferralDataInput },
-    experimentGroups: { type: ExperimentGroupsType }
+    experimentGroups: { type: ExperimentGroupsType },
+    extensionInstallId: { type: GraphQLString },
+    extensionInstallTimeApprox: { type: GraphQLString }
   },
   outputFields: {
     user: {
@@ -881,8 +883,10 @@ const createNewUserMutation = mutationWithClientMutationId({
       resolve: user => user
     }
   },
-  mutateAndGetPayload: ({ userId, email, referralData, experimentGroups }, context) => {
-    return createUser(context.user, userId, email, referralData, experimentGroups)
+  mutateAndGetPayload: ({ userId, email, referralData, experimentGroups,
+    extensionInstallId, extensionInstallTimeApprox }, context) => {
+    return createUser(context.user, userId, email, referralData, experimentGroups,
+      extensionInstallId, extensionInstallTimeApprox)
   }
 })
 

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -154,6 +154,12 @@ class User extends BaseModel {
       referrerRewarded: types.boolean()
         .description(`This is true if the user was referred by another user and we
           have credited the referring user for the recruit.`),
+      extensionInstallId: types.string()
+        .description(`The unique ID we create when the user installs the extension.
+          This value is assigned on the client so is not trustworthy.`),
+      extensionInstallTimeApprox: types.string().isoDate()
+        .description(`The approximate datetime the user installed the extension.
+          This value is assigned on the client so is not trustworthy.`),
       // Group assignments for experiments / split-tests
       testGroupAnonSignIn: types.number().integer().allow(null)
         .description(`Which group the user is in for the "anonymous user sign-in"

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -144,7 +144,7 @@ class User extends BaseModel {
         .description(`The datetime of the last time the user opened a tab`),
       mergedIntoExistingUser: types.boolean()
         .description(`This is true if this user was anonymous but then later signed
-          in as another existing user.This value is assigned on the client so is not
+          in as another existing user. This value is assigned on the client so is not
           trustworthy`),
       emailVerified: types.boolean()
         .description(`Whether the user has verified their email with our auth service
@@ -154,7 +154,7 @@ class User extends BaseModel {
       referrerRewarded: types.boolean()
         .description(`This is true if the user was referred by another user and we
           have credited the referring user for the recruit.`),
-      extensionInstallId: types.string()
+      extensionInstallId: types.string().uuid()
         .description(`The unique ID we create when the user installs the extension.
           This value is assigned on the client so is not trustworthy.`),
       extensionInstallTimeApprox: types.string().isoDate()

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -144,7 +144,8 @@ class User extends BaseModel {
         .description(`The datetime of the last time the user opened a tab`),
       mergedIntoExistingUser: types.boolean()
         .description(`This is true if this user was anonymous but then later signed
-          in as another existing user.`),
+          in as another existing user.This value is assigned on the client so is not
+          trustworthy`),
       emailVerified: types.boolean()
         .description(`Whether the user has verified their email with our auth service
           (Firebase). Our system of logging email verification here is flaky, so a
@@ -156,7 +157,7 @@ class User extends BaseModel {
       // Group assignments for experiments / split-tests
       testGroupAnonSignIn: types.number().integer().allow(null)
         .description(`Which group the user is in for the "anonymous user sign-in"
-          split-test.`)
+          split-test. This value is assigned on the client so is not trustworthy.`)
     }
   }
 

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -54,7 +54,7 @@ function getExpectedCreateItemFromUserInfo (userInfo) {
 }
 
 describe('createUser when user does not exist', () => {
-  it('works as expected without referralData', async () => {
+  it('works as expected with email address but without other optional arguments', async () => {
     expect.assertions(2)
 
     // Mock database responses.
@@ -169,6 +169,43 @@ describe('createUser when user does not exist', () => {
       id: userInfo.id,
       email: 'someotheremail@example.com'
     })
+    expect(getOrCreateMethod)
+      .toHaveBeenCalledWith(userContext, expectedCreateItem)
+  })
+
+  it('works as expected with extensionInstallId and extensionInstallTimeApprox', async () => {
+    expect.assertions(1)
+
+    // Mock database responses.
+    const userInfo = getMockUserInfo()
+    const userReturnedFromCreate = getMockUserInstance(Object.assign({}, userInfo))
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      {
+        Attributes: userReturnedFromCreate
+      }
+    )
+
+    const getOrCreateMethod = jest.spyOn(UserModel, 'getOrCreate')
+    const referralData = null
+    const experimentGroups = null
+    const userContext = cloneDeep(defaultUserContext)
+    userContext.emailVerified = false
+    logUserExperimentGroups.mockResolvedValueOnce(userReturnedFromCreate)
+
+    const extensionInstallId = 'some-id-here'
+    const extensionInstallTimeApprox = '2018-08-18T01:12:59.187Z'
+
+    await createUser(userContext, userInfo.id,
+      userInfo.email, referralData, experimentGroups,
+      extensionInstallId, extensionInstallTimeApprox)
+
+    const expectedCreateItem = Object.assign(
+      getExpectedCreateItemFromUserInfo(userInfo),
+      {
+        extensionInstallId: extensionInstallId,
+        extensionInstallTimeApprox: extensionInstallTimeApprox
+      })
     expect(getOrCreateMethod)
       .toHaveBeenCalledWith(userContext, expectedCreateItem)
   })

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -193,7 +193,7 @@ describe('createUser when user does not exist', () => {
     userContext.emailVerified = false
     logUserExperimentGroups.mockResolvedValueOnce(userReturnedFromCreate)
 
-    const extensionInstallId = 'some-id-here'
+    const extensionInstallId = '9359e548-1bd8-4bf1-9e10-09b5b6b4df34'
     const extensionInstallTimeApprox = '2018-08-18T01:12:59.187Z'
 
     await createUser(userContext, userInfo.id,

--- a/graphql/database/users/createUser.js
+++ b/graphql/database/users/createUser.js
@@ -1,5 +1,5 @@
 
-import { isEmpty } from 'lodash/lang'
+import { isEmpty, isNil } from 'lodash/lang'
 import { get } from 'lodash/object'
 import moment from 'moment'
 import UserModel from './UserModel'
@@ -23,17 +23,28 @@ import logger from '../../utils/logger'
  *   which the user has been assigned.
  * @return {Promise<User>}  A promise that resolves into a User instance.
  */
-const createUser = async (userContext, userId, email = null, referralData = null, experimentGroups = {}) => {
+const createUser = async (userContext, userId, email = null, referralData = null,
+  experimentGroups = {}, extensionInstallId = null, extensionInstallTimeApprox = null) => {
   // Get or create the user.
-  const userInfo = {
-    id: userId,
-    // This email address is from the user claims so will be
-    // the same as the email address provided during authentication,
-    // but it isn't guaranteed to be verified (may not truly belong
-    // to the user).
-    email: userContext.email || null,
-    joined: moment.utc().toISOString()
-  }
+  const userInfo = Object.assign(
+    {
+      id: userId,
+      // This email address is from the user claims so will be
+      // the same as the email address provided during authentication,
+      // but it isn't guaranteed to be verified (may not truly belong
+      // to the user).
+      email: userContext.email || null,
+      joined: moment.utc().toISOString()
+    },
+    !isNil(extensionInstallId) ? {
+      extensionInstallId: extensionInstallId
+    }
+      : null,
+    !isNil(extensionInstallTimeApprox) ? {
+      extensionInstallTimeApprox: extensionInstallTimeApprox
+    }
+      : null
+  )
   try {
     var response = await UserModel.getOrCreate(userContext, userInfo)
   } catch (e) {

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -109,6 +109,8 @@ input CreateNewUserInput {
   email: String
   referralData: ReferralData
   experimentGroups: ExperimentGroups
+  extensionInstallId: String
+  extensionInstallTimeApprox: String
   clientMutationId: String
 }
 

--- a/web/src/js/authentication/__tests__/helpers.test.js
+++ b/web/src/js/authentication/__tests__/helpers.test.js
@@ -26,6 +26,10 @@ import logger from 'utils/logger'
 import {
   getUserTestGroupsForMutation
 } from 'utils/experiments'
+import {
+  getBrowserExtensionInstallId,
+  getBrowserExtensionInstallTime
+} from 'utils/local-user-data-mgr'
 
 jest.mock('authentication/user')
 jest.mock('navigation/navigation')
@@ -37,6 +41,7 @@ jest.mock('authentication/user')
 jest.mock('../../../relay-env')
 jest.mock('utils/logger')
 jest.mock('utils/experiments')
+jest.mock('utils/local-user-data-mgr')
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -137,6 +142,10 @@ describe('createNewUser tests', () => {
     expect.assertions(1)
     getUserToken.mockResolvedValue('some-token')
     getReferralData.mockImplementationOnce(() => null)
+    const mockUUID = '9359e548-1bd8-4bf1-9e10-09b5b6b4df34'
+    getBrowserExtensionInstallId.mockReturnValueOnce(mockUUID)
+    const mockExtensionInstallTime = '2018-08-18T01:12:59.187Z'
+    getBrowserExtensionInstallTime.mockReturnValueOnce(mockExtensionInstallTime)
     getUserTestGroupsForMutation.mockReturnValueOnce({
       anonSignIn: 'ANONYMOUS_ALLOWED'
     })
@@ -152,7 +161,8 @@ describe('createNewUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -169,7 +179,8 @@ describe('createNewUser tests', () => {
 
     expect(CreateNewUserMutation)
       .toHaveBeenCalledWith({}, 'abc123', 'somebody@example.com', null,
-        { anonSignIn: 'ANONYMOUS_ALLOWED' }, expect.any(Function), expect.any(Function))
+        { anonSignIn: 'ANONYMOUS_ALLOWED' }, mockUUID, mockExtensionInstallTime,
+        expect.any(Function), expect.any(Function))
   })
 
   it('returns the new user data', async () => {
@@ -189,7 +200,8 @@ describe('createNewUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -230,7 +242,8 @@ describe('createNewUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -271,7 +284,8 @@ describe('createNewUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -308,7 +322,8 @@ describe('createNewUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementationOnce(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -31,6 +31,7 @@ import {
   isAnonymousUserSignInEnabled
 } from 'utils/feature-flags'
 import {
+  getBrowserExtensionInstallId,
   getBrowserExtensionInstallTime
 } from 'utils/local-user-data-mgr'
 import logger from 'utils/logger'
@@ -184,11 +185,11 @@ export const createNewUser = () => {
       // correct latest value for email verification.
       return getUserToken(true)
         .then(() => {
-          // Get any referral data that exists.
+          // Get additional data we want to log with creation.
           const referralData = getReferralData()
-
-          // Pass the user's assigned experiment groups.
           const experimentGroups = getUserTestGroupsForMutation()
+          const installId = getBrowserExtensionInstallId()
+          const installTime = getBrowserExtensionInstallTime()
 
           return new Promise((resolve, reject) => {
             CreateNewUserMutation(
@@ -197,6 +198,8 @@ export const createNewUser = () => {
               user.email,
               referralData,
               experimentGroups,
+              installId,
+              installTime,
               (response) => {
                 resolve(response.createNewUser)
               },

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -179,7 +179,8 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -637,7 +638,8 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -691,7 +693,8 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -756,7 +759,8 @@ describe('Authentication.js tests', function () {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',

--- a/web/src/js/components/Dashboard/FirstTabView.js
+++ b/web/src/js/components/Dashboard/FirstTabView.js
@@ -4,6 +4,7 @@ import {
   replaceUrl
 } from 'navigation/navigation'
 import {
+  setBrowserExtensionInstallId,
   setBrowserExtensionInstallTime
 } from 'utils/local-user-data-mgr'
 import {
@@ -16,6 +17,9 @@ class FirstTabView extends React.Component {
   componentDidMount () {
     // Here, we can do anything we need to do before
     // going to the main dashboard.
+
+    // Set a unique install ID in local storage.
+    setBrowserExtensionInstallId()
 
     // Set this as the user's installed time, which helps us
     // distinguish truly new users from returning users who

--- a/web/src/js/components/Dashboard/__tests__/FirstTabView.test.js
+++ b/web/src/js/components/Dashboard/__tests__/FirstTabView.test.js
@@ -7,6 +7,7 @@ import {
 
 import { replaceUrl } from 'navigation/navigation'
 import {
+  setBrowserExtensionInstallId,
   setBrowserExtensionInstallTime
 } from 'utils/local-user-data-mgr'
 import {
@@ -39,7 +40,15 @@ describe('FirstTabView', function () {
     expect(replaceUrl).toHaveBeenCalledWith('/newtab/')
   })
 
-  it('calls to set the extension install time', () => {
+  it('calls to set the extension install ID in local storage', () => {
+    const FirstTabView = require('../FirstTabView').default
+    shallow(
+      <FirstTabView {...mockProps} />
+    )
+    expect(setBrowserExtensionInstallId).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls to set the extension install time in local storage', () => {
     const FirstTabView = require('../FirstTabView').default
     shallow(
       <FirstTabView {...mockProps} />

--- a/web/src/js/components/General/__tests__/AuthUserComponent.test.js
+++ b/web/src/js/components/General/__tests__/AuthUserComponent.test.js
@@ -123,7 +123,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -196,7 +197,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -241,7 +243,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -279,7 +282,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -320,7 +324,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -358,7 +363,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -393,7 +399,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -428,7 +435,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',
@@ -466,7 +474,8 @@ describe('AuthUser tests', () => {
 
     // Mock a response from new user creation
     CreateNewUserMutation.mockImplementation(
-      (environment, userId, email, referralData, experimentGroups, onCompleted, onError) => {
+      (environment, userId, email, referralData, experimentGroups, installId,
+        installTime, onCompleted, onError) => {
         onCompleted({
           createNewUser: {
             id: 'abc123',

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -57,6 +57,7 @@ export const STORAGE_NEW_CONSENT_DATA_EXISTS = 'tab.consentData.newConsentDataEx
 //   data we need for unauthenticated users or temporary data we
 //   don't want to store server-side. Stored client-side only.
 export const STORAGE_NEW_USER_HAS_COMPLETED_TOUR = 'tab.newUser.hasCompletedTour'
+export const STORAGE_EXTENSION_INSTALL_ID = 'tab.newUser.extensionInstallId'
 export const STORAGE_APPROX_EXTENSION_INSTALL_TIME = 'tab.newUser.approxInstallTime'
 
 // tab.experiments: values related to split-testing features

--- a/web/src/js/mutations/CreateNewUserMutation.js
+++ b/web/src/js/mutations/CreateNewUserMutation.js
@@ -15,13 +15,21 @@ const mutation = graphql`
   }
 `
 
-function commit (environment, userId, email, referralData, experimentGroups, onCompleted, onError) {
+function commit (environment, userId, email, referralData, experimentGroups,
+  extensionInstallId, extensionInstallTimeApprox, onCompleted, onError) {
   return commitMutation(
     environment,
     {
       mutation,
       variables: {
-        input: { userId, email, referralData, experimentGroups }
+        input: {
+          userId,
+          email,
+          referralData,
+          experimentGroups,
+          extensionInstallId,
+          extensionInstallTimeApprox
+        }
       },
       onCompleted: (response) => {
         onCompleted(response)

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -1,12 +1,14 @@
 /* eslint-env jest */
 
 import moment from 'moment'
+import uuid from 'uuid/v4'
 import MockDate from 'mockdate'
 import localStorageMgr, {
   __mockClear
 } from '../localstorage-mgr'
 
 jest.mock('../localstorage-mgr')
+jest.mock('uuid/v4')
 
 const mockNow = '2018-04-12T10:30:00.000'
 
@@ -100,6 +102,33 @@ describe('local user data manager', () => {
     incrementTabsOpenedToday()
     expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.user.lastTabDay.count', 1)
     expect(localStorageMgr.setItem).not.toHaveBeenCalledWith('tab.user.lastTabDay.date', moment.utc().toISOString())
+  })
+
+  // setBrowserExtensionInstallId method
+  it('sets the extension install ID in localStorage', () => {
+    const mockUUID = '9359e548-1bd8-4bf1-9e10-09b5b6b4df34'
+    uuid.mockReturnValueOnce(mockUUID)
+    const setBrowserExtensionInstallId = require('../local-user-data-mgr').setBrowserExtensionInstallId
+    setBrowserExtensionInstallId()
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.newUser.extensionInstallId', mockUUID)
+  })
+
+  // getBrowserExtensionInstallId
+  it('gets the extension install ID from localStorage', () => {
+    const mockUUID = '9359e548-1bd8-4bf1-9e10-09b5b6b4df34'
+    uuid.mockReturnValueOnce(mockUUID)
+    localStorageMgr.setItem('tab.newUser.extensionInstallId', mockUUID)
+    const getBrowserExtensionInstallId = require('../local-user-data-mgr').getBrowserExtensionInstallId
+    const installId = getBrowserExtensionInstallId()
+    expect(installId).toBe(mockUUID)
+  })
+
+  it('returns null if the extension ID in localStorage does not exist', () => {
+    localStorageMgr.removeItem('tab.newUser.extensionInstallId')
+    const getBrowserExtensionInstallId = require('../local-user-data-mgr').getBrowserExtensionInstallId
+    const installTime = getBrowserExtensionInstallId()
+    expect(installTime).toBeNull()
   })
 
   // setBrowserExtensionInstallTime method

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -1,7 +1,9 @@
 
 import moment from 'moment'
+import uuid from 'uuid/v4'
 import localStorageMgr from 'utils/localstorage-mgr'
 import {
+  STORAGE_EXTENSION_INSTALL_ID,
   STORAGE_APPROX_EXTENSION_INSTALL_TIME,
   STORAGE_TABS_RECENT_DAY_COUNT,
   STORAGE_TABS_LAST_TAB_OPENED_DATE
@@ -89,6 +91,30 @@ export const incrementTabsOpenedToday = function () {
     setLastTabOpenedDateInLocalStorage()
     setTabCountInLocalStorage(1)
   }
+}
+
+/**
+ * Saves a UUID to localStorage as the "extension install ID",
+ * which may be helpful in determining if multiple anonymous
+ * users belong to the same user.
+ * @returns {undefined}
+ */
+export const setBrowserExtensionInstallId = () => {
+  localStorageMgr.setItem(STORAGE_EXTENSION_INSTALL_ID, uuid())
+}
+
+/**
+ * Gets the extension install ID from localStorage if it exists.
+ * extension (from localStorage).
+ * @returns {String|null} A UUID string, or null if it does not
+ *   exist.
+ */
+export const getBrowserExtensionInstallId = () => {
+  const installId = localStorageMgr.getItem(STORAGE_EXTENSION_INSTALL_ID)
+  if (!installId) {
+    return null
+  }
+  return installId
 }
 
 /**


### PR DESCRIPTION
This PR starts sending the client-created "approximate extension install time" when creating a new user. We also create a UUID "extension install ID" on `/newtab/first-tab/` and include it. We store these values on the user when they're available.