### PR TITLE
Make email and username optional in components

### DIFF
--- a/web/src/js/components/Settings/Account/AccountComponent.js
+++ b/web/src/js/components/Settings/Account/AccountComponent.js
@@ -60,7 +60,6 @@ class Account extends React.Component {
     displayConsentUI()
   }
 
-  // TODO: handle no username for anonymous users
   render () {
     const { user } = this.props
     return (
@@ -69,9 +68,9 @@ class Account extends React.Component {
           Account
         </Typography>
         <Divider />
-        <AccountItem name={'Username'} value={user.username} />
+        <AccountItem name={'Username'} value={user.username ? user.username : 'Not signed in'} />
         <Divider />
-        <AccountItem name={'Email'} value={user.email} />
+        <AccountItem name={'Email'} value={user.email ? user.email : 'Not signed in'} />
         { this.state.showDataPrivacyOption
           ? (
             <span>
@@ -100,8 +99,8 @@ class Account extends React.Component {
 
 Account.propTypes = {
   user: PropTypes.shape({
-    email: PropTypes.string.isRequired,
-    username: PropTypes.string.isRequired
+    email: PropTypes.string,
+    username: PropTypes.string
   })
 }
 

--- a/web/src/js/components/Settings/Account/__tests__/AccountComponent.test.js
+++ b/web/src/js/components/Settings/Account/__tests__/AccountComponent.test.js
@@ -2,8 +2,10 @@
 
 import React from 'react'
 import {
+  mount,
   shallow
 } from 'enzyme'
+import Typography from '@material-ui/core/Typography'
 jest.mock('utils/client-location')
 
 const getMockUserData = () => {
@@ -108,5 +110,51 @@ describe('Account component', () => {
 
     const LogConsentData = require('../../../Dashboard/LogConsentDataContainer').default
     expect(wrapper.find(LogConsentData).length > 0).toBe(false)
+  })
+
+  it('displays the username', () => {
+    const AccountComponent = require('../AccountComponent').default
+    const userData = getMockUserData()
+    const wrapper = mount(
+      <AccountComponent user={userData} />
+    )
+    const typographies = wrapper.find(Typography)
+    expect(typographies.at(1).text()).toBe('Username')
+    expect(typographies.at(2).text()).toBe('somebody123')
+  })
+
+  it('displays the email address', () => {
+    const AccountComponent = require('../AccountComponent').default
+    const userData = getMockUserData()
+    const wrapper = mount(
+      <AccountComponent user={userData} />
+    )
+    const typographies = wrapper.find(Typography)
+    expect(typographies.at(3).text()).toBe('Email')
+    expect(typographies.at(4).text()).toBe('somebody@example.com')
+  })
+
+  it('displays a placeholder when there is no username', () => {
+    const AccountComponent = require('../AccountComponent').default
+    const userData = getMockUserData()
+    delete userData.username
+    const wrapper = mount(
+      <AccountComponent user={userData} />
+    )
+    const typographies = wrapper.find(Typography)
+    expect(typographies.at(1).text()).toBe('Username')
+    expect(typographies.at(2).text()).toBe('Not signed in')
+  })
+
+  it('displays a placeholder when there is no email address', () => {
+    const AccountComponent = require('../AccountComponent').default
+    const userData = getMockUserData()
+    delete userData.email
+    const wrapper = mount(
+      <AccountComponent user={userData} />
+    )
+    const typographies = wrapper.find(Typography)
+    expect(typographies.at(3).text()).toBe('Email')
+    expect(typographies.at(4).text()).toBe('Not signed in')
   })
 })

--- a/web/src/js/components/Settings/Profile/InviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/InviteFriendComponent.js
@@ -23,8 +23,11 @@ const styles = theme => ({
 
 class InviteFriend extends React.Component {
   getReferralUrl () {
-    // TODO: handle no username for anonymous users
-    return `https://tab.gladly.io/?u=${this.props.user.username}`
+    const baseURL = 'https://tab.gladly.io'
+    const referralUrl = this.props.user.username
+      ? `${baseURL}/?u=${this.props.user.username}`
+      : baseURL
+    return referralUrl
   }
 
   onTextFieldClicked () {
@@ -42,7 +45,10 @@ class InviteFriend extends React.Component {
         onClick={this.onTextFieldClicked.bind(this)}
         value={referralUrl}
         label={'Share this link'}
-        helperText={"and you'll get 350 Hearts for every person who joins!"}
+        helperText={this.props.user.username
+          ? `and you'll get 350 Hearts for every person who joins!`
+          : `and have a bigger positive impact!`
+        }
         InputProps={{
           classes: {
             underline: classes.inputUnderline
@@ -68,7 +74,7 @@ class InviteFriend extends React.Component {
 
 InviteFriend.propTypes = {
   user: PropTypes.shape({
-    username: PropTypes.string.isRequired
+    username: PropTypes.string
   }),
   classes: PropTypes.object.isRequired,
   style: PropTypes.object

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -35,6 +35,7 @@ class ProfileStats extends React.Component {
       flexBasis: '20%',
       margin: spacingPx
     }
+    const greeting = user.username ? `Hi, ${user.username}!` : 'Hi!'
     return (
       <div>
         <Paper
@@ -57,7 +58,7 @@ class ProfileStats extends React.Component {
             }}
           />
           <p>
-            <span style={{fontWeight: 500}}>Hi, {user.username}!</span>
+            <span style={{fontWeight: 500}}>{greeting}</span>
             <span> Here's all your great work Tabbing, by the numbers.</span>
           </p>
         </Paper>
@@ -138,7 +139,7 @@ class ProfileStats extends React.Component {
 ProfileStats.propTypes = {
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    username: PropTypes.string.isRequired,
+    username: PropTypes.string,
     heartsUntilNextLevel: PropTypes.number.isRequired,
     joined: PropTypes.string.isRequired,
     level: PropTypes.number.isRequired,

--- a/web/src/js/components/Settings/Profile/__tests__/InviteFriendComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/InviteFriendComponent.test.js
@@ -1,6 +1,8 @@
 /* eslint-env jest */
 
 import React from 'react'
+import TextField from '@material-ui/core/TextField'
+import { cloneDeep } from 'lodash/lang'
 import {
   mount,
   shallow
@@ -31,6 +33,39 @@ describe('Invite friend component', () => {
       <InviteFriendComponent {...mockProps} />
     )
     const referralUrl = 'https://tab.gladly.io/?u=bob'
-    expect(wrapper.find('input').first().prop('value')).toBe(referralUrl)
+    expect(wrapper.find(TextField).first().prop('value')).toBe(referralUrl)
+  })
+
+  it('contains the correct description text', () => {
+    const InviteFriendComponent = require('../InviteFriendComponent').default
+    const wrapper = mount(
+      <InviteFriendComponent {...mockProps} />
+    )
+    expect(wrapper.find(TextField).first().prop('label')).toBe(`Share this link`)
+    expect(wrapper.find(TextField).first().prop('helperText')).toBe(
+      `and you'll get 350 Hearts for every person who joins!`)
+  })
+
+  it('contains the correct referral URL when there is no provided username', () => {
+    const InviteFriendComponent = require('../InviteFriendComponent').default
+    const newMockProps = cloneDeep(mockProps)
+    newMockProps.user.username = undefined
+    const wrapper = mount(
+      <InviteFriendComponent {...newMockProps} />
+    )
+    const referralUrl = 'https://tab.gladly.io'
+    expect(wrapper.find(TextField).first().prop('value')).toBe(referralUrl)
+  })
+
+  it('contains the correct description text  when there is no provided username', () => {
+    const InviteFriendComponent = require('../InviteFriendComponent').default
+    const newMockProps = cloneDeep(mockProps)
+    newMockProps.user.username = undefined
+    const wrapper = mount(
+      <InviteFriendComponent {...newMockProps} />
+    )
+    expect(wrapper.find(TextField).first().prop('label')).toBe(`Share this link`)
+    expect(wrapper.find(TextField).first().prop('helperText')).toBe(
+      `and have a bigger positive impact!`)
   })
 })

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+
+import React from 'react'
+import {
+  shallow
+} from 'enzyme'
+
+const mockProps = {
+  user: {
+    id: 'some-user-id-here',
+    username: 'Bob',
+    heartsUntilNextLevel: 23,
+    joined: '2017-12-25T07:08:11.472Z',
+    level: 8,
+    maxTabsDay: {
+      date: '2018-01-01T10:50:44.942Z',
+      numTabs: 431
+    },
+    numUsersRecruited: 2,
+    tabs: 3121,
+    vcDonatedAllTime: 2539
+  }
+}
+
+describe('Profile stats component', () => {
+  it('renders without error', () => {
+    const ProfileStatsComponent = require('../ProfileStatsComponent').default
+    shallow(
+      <ProfileStatsComponent {...mockProps} />
+    )
+  })
+})

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -1,9 +1,13 @@
 /* eslint-env jest */
 
 import React from 'react'
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import { cloneDeep } from 'lodash/lang'
 import {
+  mount,
   shallow
 } from 'enzyme'
+import Stat from '../StatComponent'
 
 const mockProps = {
   user: {
@@ -28,5 +32,36 @@ describe('Profile stats component', () => {
     shallow(
       <ProfileStatsComponent {...mockProps} />
     )
+  })
+
+  it('has the expected number of stats', () => {
+    const ProfileStatsComponent = require('../ProfileStatsComponent').default
+    const wrapper = shallow(
+      <ProfileStatsComponent {...mockProps} />
+    )
+    expect(wrapper.find(Stat).length).toBe(6)
+  })
+
+  it('contains the correct greeting when there is a username', () => {
+    const ProfileStatsComponent = require('../ProfileStatsComponent').default
+    // @material-ui-1-todo: remove MuiThemeProvider wrapper
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <ProfileStatsComponent {...mockProps} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.find('p').first().find('span').first().text()).toBe('Hi, Bob!')
+  })
+
+  it('contains the correct greeting when there is no username', () => {
+    const ProfileStatsComponent = require('../ProfileStatsComponent').default
+    const newMockProps = cloneDeep(mockProps)
+    delete newMockProps.user.username
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <ProfileStatsComponent {...newMockProps} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.find('p').first().find('span').first().text()).toBe('Hi!')
   })
 })


### PR DESCRIPTION
When the user is anonymous (does not have an email or username), show alternative text/placeholders for the referral URL component, the account page, and stats page.