### PR TITLE
Show a prompt on the dashboard to ask anonymous users to sign in

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -77,6 +77,7 @@
     "precss": "^1.4.0",
     "promise": "7.1.1",
     "prop-types": "^15.5.10",
+    "qs": "^6.5.2",
     "raven-js": "^3.24.0",
     "react": "^15.4.2",
     "react-color": "^2.13.8",

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -16,6 +16,9 @@ import {
 } from 'navigation/navigation'
 import { isEqual } from 'lodash/lang'
 import LogoWithText from '../Logo/LogoWithText'
+import {
+  getUrlParameters
+} from 'utils/utils'
 
 // Handle the authentication flow:
 //   check if current user is fully authenticated and redirect
@@ -103,8 +106,12 @@ class Authentication extends React.Component {
       throw e
     }
 
+    // When anonymous users choose to sign in, do not go back to the
+    // dashboard.
+    const stayOnAuthPage = getUrlParameters()['noredirect'] === 'true'
+
     // The user is fully authed, so go to the dashboard.
-    if (!redirected) {
+    if (!redirected && !stayOnAuthPage) {
       goToDashboard()
     }
   }

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -22,10 +22,14 @@ import {
   getCurrentUser,
   sendVerificationEmail
 } from 'authentication/user'
+import {
+  getUrlParameters
+} from 'utils/utils'
 
 jest.mock('authentication/helpers')
 jest.mock('authentication/user')
 jest.mock('navigation/navigation')
+jest.mock('utils/utils')
 
 const mockLocationData = {
   pathname: '/newtab/auth/'
@@ -44,6 +48,7 @@ beforeEach(() => {
   // Reset an unauthed user as the default.
   checkAuthStateAndRedirectIfNeeded.mockResolvedValue(true)
   getCurrentUser.mockResolvedValue(null)
+  getUrlParameters.mockReturnValue({})
 })
 
 afterEach(() => {
@@ -121,6 +126,72 @@ describe('Authentication.js tests', function () {
       username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: true
+    })
+
+    const Authentication = require('../Authentication').default
+    const wrapper = shallow(
+      <Authentication
+        location={mockLocationData}
+        user={mockUserData}
+        fetchUser={mockFetchUser}
+      />
+    )
+
+    // Wait for mount to complete.
+    const component = wrapper.instance()
+    await component.componentDidMount()
+
+    expect(goToDashboard).toHaveBeenCalled()
+  })
+
+  it('does not redirect to the app if the user is fully authenticated but the URL has the noredirect param', async () => {
+    expect.assertions(1)
+
+    // User is fully authed.
+    checkAuthStateAndRedirectIfNeeded.mockResolvedValue(false)
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'foo@bar.com',
+      username: 'SomeUsername',
+      isAnonymous: false,
+      emailVerified: true
+    })
+
+    getUrlParameters.mockReturnValue({
+      noredirect: 'true'
+    })
+
+    const Authentication = require('../Authentication').default
+    const wrapper = shallow(
+      <Authentication
+        location={mockLocationData}
+        user={mockUserData}
+        fetchUser={mockFetchUser}
+      />
+    )
+
+    // Wait for mount to complete.
+    const component = wrapper.instance()
+    await component.componentDidMount()
+
+    expect(goToDashboard).not.toHaveBeenCalled()
+  })
+
+  it('redirect to the app if the user is fully authenticated but the URL has an invalid noredirect param', async () => {
+    expect.assertions(1)
+
+    // User is fully authed.
+    checkAuthStateAndRedirectIfNeeded.mockResolvedValue(false)
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'foo@bar.com',
+      username: 'SomeUsername',
+      isAnonymous: false,
+      emailVerified: true
+    })
+
+    getUrlParameters.mockReturnValue({
+      noredirect: 'something'
     })
 
     const Authentication = require('../Authentication').default

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -194,7 +194,7 @@ class Dashboard extends React.Component {
                         marginRight: 10
                       }}
                       onClick={() => {
-                        goTo(loginURL)
+                        goTo(loginURL, { noredirect: 'true' })
                       }}
                     >
                       Sign In

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -383,7 +383,7 @@ describe('Dashboard component', () => {
       .find('[data-test-id="anon-sign-in-prompt-dashboard"]')
       .find(Button)
     button.simulate('click')
-    expect(goTo).toHaveBeenCalledWith('/newtab/auth/')
+    expect(goTo).toHaveBeenCalledWith('/newtab/auth/', { noredirect: 'true' })
   })
 
   it('does not display the anonymous user sign-in prompt when the user is not anonymous', async () => {

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -21,9 +21,17 @@ import ErrorMessage from 'general/ErrorMessage'
 import NewUserTour from '../NewUserTourContainer'
 import localStorageMgr from 'utils/localstorage-mgr'
 import { STORAGE_NEW_USER_HAS_COMPLETED_TOUR } from '../../../constants'
+import { getCurrentUser } from 'authentication/user'
+import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import {
+  goTo
+} from 'navigation/navigation'
 
 jest.mock('analytics/logEvent')
 jest.mock('utils/localstorage-mgr')
+jest.mock('authentication/user')
+jest.mock('navigation/navigation')
 
 const mockNow = '2018-05-15T10:30:00.000'
 
@@ -293,5 +301,114 @@ describe('Dashboard component', () => {
     )
     expect(wrapper.find(WidgetsContainer).prop('isCampaignLive')).toBe(true)
     expect(wrapper.find(CampaignBaseContainer).prop('isCampaignLive')).toBe(true)
+  })
+
+  it('displays the anonymous user sign-in prompt when the user is anonymous', async () => {
+    expect.assertions(1)
+
+    getCurrentUser.mockResolvedValueOnce({
+      id: 'some-id-here',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false
+    })
+
+    const DashboardComponent = require('../DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+
+    // Wait for the component to determine whether the
+    // user is anonymous.
+    await wrapper.instance().determineAnonymousStatus()
+    wrapper.update()
+    expect(
+      wrapper.find('[data-test-id="anon-sign-in-prompt-dashboard"]').length
+    ).toBe(1)
+  })
+
+  it('displays the correct text for the anonymous user sign-in prompt', async () => {
+    expect.assertions(1)
+
+    getCurrentUser.mockResolvedValueOnce({
+      id: 'some-id-here',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false
+    })
+
+    const DashboardComponent = require('../DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+
+    // Wait for the component to determine whether the
+    // user is anonymous.
+    await wrapper.instance().determineAnonymousStatus()
+    wrapper.update()
+
+    expect(
+      wrapper
+        .find('[data-test-id="anon-sign-in-prompt-dashboard"]')
+        .find(Typography)
+        .children()
+        .text()
+    ).toBe('Sign in to save your progress!')
+  })
+
+  it('the anonymous user sign-in button leads to the correct URL', async () => {
+    expect.assertions(1)
+
+    getCurrentUser.mockResolvedValueOnce({
+      id: 'some-id-here',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false
+    })
+
+    const DashboardComponent = require('../DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+
+    // Wait for the component to determine whether the
+    // user is anonymous.
+    await wrapper.instance().determineAnonymousStatus()
+    wrapper.update()
+
+    const button = wrapper
+      .find('[data-test-id="anon-sign-in-prompt-dashboard"]')
+      .find(Button)
+    button.simulate('click')
+    expect(goTo).toHaveBeenCalledWith('/newtab/auth/')
+  })
+
+  it('does not display the anonymous user sign-in prompt when the user is not anonymous', async () => {
+    expect.assertions(1)
+
+    getCurrentUser.mockResolvedValueOnce({
+      id: 'some-id-here',
+      email: 'somebody@example.com',
+      username: 'IAmSomebody',
+      isAnonymous: false,
+      emailVerified: true
+    })
+
+    const DashboardComponent = require('../DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+
+    // Wait for the component to determine whether the
+    // user is anonymous.
+    await wrapper.instance().determineAnonymousStatus()
+    wrapper.update()
+
+    expect(
+      wrapper.find('[data-test-id="anon-sign-in-prompt-dashboard"]').length
+    ).toBe(0)
   })
 })

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -1,4 +1,5 @@
 import { browserHistory } from 'react-router'
+import qs from 'qs'
 
 // TODO: replace this with Link navigation via react-router.
 
@@ -6,8 +7,13 @@ import { browserHistory } from 'react-router'
 const protocol = process.env.WEBSITE_PROTOCOL ? process.env.WEBSITE_PROTOCOL : 'https'
 const baseUrl = `${protocol}://${process.env.WEBSITE_DOMAIN}`
 
-export const goTo = (location) => {
-  browserHistory.push(location)
+export const goTo = (location, paramsObj = {}) => {
+  browserHistory.push({
+    pathname: location,
+    search: qs.stringify(paramsObj)
+      ? `?${qs.stringify(paramsObj)}`
+      : null
+  })
 }
 
 export const replaceUrl = (location) => {

--- a/web/src/js/utils/__mocks__/utils.js
+++ b/web/src/js/utils/__mocks__/utils.js
@@ -3,4 +3,7 @@
 const webUtilsMock = jest.genMockFromModule('../utils')
 
 webUtilsMock.isInIframe = jest.fn(() => false)
+webUtilsMock.getUrlParameters = jest.fn(() => {
+  return {}
+})
 module.exports = webUtilsMock

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -6,6 +6,7 @@ import {
   STORAGE_REFERRAL_DATA_REFERRING_USER
 } from '../constants'
 import XRegExp from 'xregexp'
+import qs from 'qs'
 
 /**
  * Determine if a username string is valid.
@@ -22,20 +23,8 @@ export const validateUsername = (username) => {
   return re.test(username)
 }
 
-// 'utm_medium'
-// 'utm_source'
-// 'utm_campaign'
-// 'utm_term'
-// 'utm_content'
-// 'tfac_id'
-
 export const getUrlParameters = () => {
-  var vars = {}
-  window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi,
-    function (m, key, value) {
-      vars[key] = value
-    })
-  return vars
+  return qs.parse(window.location.search, { ignoreQueryPrefix: true })
 }
 
 // BEGIN: referral data helpers

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5455,11 +5455,7 @@ istanbul-api@^1.3.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
-
-istanbul-lib-coverage@^1.2.0:
+istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
 
@@ -8264,6 +8260,10 @@ q@^1.1.2:
 qs@6.4.0, qs@^6.1.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+qs@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 qs@~6.3.0:
   version "6.3.2"


### PR DESCRIPTION
Also support a `noredirect=true` URL parameter for the authentication page to avoid redirecting anonymous users back to the dashboard.