### PR TITLE
 Disable the authentication redirect acceptance test for now

### DIFF
--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -3,6 +3,7 @@ import { get } from 'lodash/object'
 
 // Experiments with valid experiment group values.
 const experimentConfig = {
+  // @experiment-anon-sign-in
   anonSignIn: {
     NONE: 0,
     AUTHED_USER_ONLY: 1,

--- a/web/e2e-tests/__tests__/basics.test.js
+++ b/web/e2e-tests/__tests__/basics.test.js
@@ -9,7 +9,9 @@
 
 let driver
 afterEach(() => {
-  return driver.quit()
+  if (driver && driver.quit) {
+    return driver.quit()
+  }
 })
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 35e3

--- a/web/e2e-tests/__tests__/basics.test.js
+++ b/web/e2e-tests/__tests__/basics.test.js
@@ -1,8 +1,11 @@
 /* eslint-env jest */
 /* globals jasmine */
 
-import driverUtils from '../utils/driver-utils'
-import { getDriver, getAppBaseUrl } from '../utils/driver-mgr'
+// import driverUtils from '../utils/driver-utils'
+// import {
+//   getDriver,
+//   getAppBaseUrl
+// } from '../utils/driver-mgr'
 
 let driver
 afterEach(() => {
@@ -11,15 +14,23 @@ afterEach(() => {
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 35e3
 
-const getAbsoluteUrl = (relativeUrl) => {
-  return `${getAppBaseUrl()}${relativeUrl}`
-}
+// const getAbsoluteUrl = (relativeUrl) => {
+//   return `${getAppBaseUrl()}${relativeUrl}`
+// }
 
 // Sanity checking that the app deployed and loads correctly
 describe('Basic integration tests', () => {
-  it('should load the auth page', async () => {
-    driver = getDriver('Basic integration tests: should load auth page')
-    await driverUtils(driver).navigateTo(getAbsoluteUrl('/newtab/'))
-    await driverUtils(driver).waitForElementExistsByTestId('authentication-page')
-  }, 30e3)
+  // @experiment-anon-sign-in
+  // TODO: re-enable after completing the anonymous sign-in experiement.
+  //   The random split-test will break this test.
+
+  // it('should load the auth page', async () => {
+  //   driver = getDriver('Basic integration tests: should load auth page')
+  //   await driverUtils(driver).navigateTo(getAbsoluteUrl('/newtab/'))
+  //   await driverUtils(driver).waitForElementExistsByTestId('authentication-page')
+  // }, 30e3)
+
+  it('should pass this placeholder test', () => {
+    expect(true).toBe(true)
+  })
 })

--- a/web/src/js/utils/feature-flags.js
+++ b/web/src/js/utils/feature-flags.js
@@ -1,4 +1,5 @@
 
+// @experiment-anon-sign-in
 export const isAnonymousUserSignInEnabled = () => {
   return process.env.FEATURE_FLAG_ANON_USER_SIGN_IN
     ? process.env.FEATURE_FLAG_ANON_USER_SIGN_IN === 'true'


### PR DESCRIPTION
The anonymous user sign-in experiment will break this test due to random group assignment. Re-enable this test after we end that experiment.