### PR TITLE
Fix showing an explanation for mandatory anonymous sign-ins

### DIFF
--- a/web/src/js/authentication/__tests__/helpers.test.js
+++ b/web/src/js/authentication/__tests__/helpers.test.js
@@ -5,9 +5,9 @@ import {
   goTo,
   replaceUrl,
   goToDashboard,
-  goToLogin,
   authMessageURL,
   enterUsernameURL,
+  loginURL,
   missingEmailMessageURL,
   verifyEmailURL
 } from 'navigation/navigation'
@@ -86,7 +86,7 @@ afterEach(() => {
 
 describe('checkAuthStateAndRedirectIfNeeded tests', () => {
   it('[no-anon-allowed] does not redirect if the user is fully authenticated', async () => {
-    expect.assertions(5)
+    expect.assertions(3)
     setIfAnonymousUserIsAllowed(false)
 
     const checkAuthStateAndRedirectIfNeeded = require('../helpers')
@@ -101,14 +101,12 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
     const redirected = await checkAuthStateAndRedirectIfNeeded(user)
 
     expect(redirected).toBe(false)
-    expect(goToDashboard).not.toHaveBeenCalled()
     expect(goTo).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
-    expect(goToLogin).not.toHaveBeenCalled()
   })
 
   it('[anon] does not redirect when the user is anonymous and is allowed to be anonymous', async () => {
-    expect.assertions(5)
+    expect.assertions(4)
     setIfAnonymousUserIsAllowed(true)
 
     const user = {
@@ -127,7 +125,6 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
     expect(goToDashboard).not.toHaveBeenCalled()
     expect(goTo).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
-    expect(goToLogin).not.toHaveBeenCalled()
   })
 
   it('[anon] does not create a new user when the user is unauthed and the user installed the extension not-too-recently', async () => {
@@ -278,7 +275,7 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
     const redirected = await checkAuthStateAndRedirectIfNeeded(user)
 
     expect(redirected).toBe(true)
-    expect(goToLogin).toHaveBeenCalledTimes(1)
+    expect(replaceUrl).toHaveBeenCalledWith(loginURL, {})
   })
 
   it('[anon] redirects when the user is unauthed and the user does not have an extension install time in local storage', async () => {
@@ -315,11 +312,11 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
     const redirected = await checkAuthStateAndRedirectIfNeeded(user)
 
     expect(redirected).toBe(true)
-    expect(goToLogin).toHaveBeenCalledTimes(1)
+    expect(replaceUrl).toHaveBeenCalledWith(loginURL, {})
   })
 
   it('[anon] does not redirect when the user is unauthed and the user installed very recently', async () => {
-    expect.assertions(5)
+    expect.assertions(4)
     setIfAnonymousUserIsAllowed(true)
 
     // The user installed just now
@@ -356,7 +353,6 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
     expect(goToDashboard).not.toHaveBeenCalled()
     expect(goTo).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
-    expect(goToLogin).not.toHaveBeenCalled()
   })
 
   it('[no-anon-allowed] redirects to the sign-in view if the user is unauthed and NOT within an iframe', async () => {
@@ -391,7 +387,7 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
       .checkAuthStateAndRedirectIfNeeded
     const redirected = await checkAuthStateAndRedirectIfNeeded(user)
 
-    expect(goToLogin).toHaveBeenCalledTimes(1)
+    expect(replaceUrl).toHaveBeenCalledWith(loginURL, {})
     expect(redirected).toBe(true)
   })
 
@@ -420,7 +416,7 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
       .checkAuthStateAndRedirectIfNeeded
     await checkAuthStateAndRedirectIfNeeded(user)
 
-    expect(goTo).toHaveBeenCalledWith(authMessageURL)
+    expect(replaceUrl).toHaveBeenCalledWith(authMessageURL, {})
   })
 
   it('[no-anon-allowed] still creates an anonymous user before requiring sign-in', async () => {
@@ -488,7 +484,8 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
       .checkAuthStateAndRedirectIfNeeded
     await checkAuthStateAndRedirectIfNeeded(user)
 
-    expect(goToLogin).toHaveBeenCalledTimes(1)
+    expect(replaceUrl)
+      .toHaveBeenCalledWith(loginURL, { mandatory: 'true' }) // includes URL param
   })
 
   it('does not redirect to the login screen if the user is anonymous and has been around less than the time needed for us to ask them to sign in', async () => {
@@ -516,7 +513,7 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
       .checkAuthStateAndRedirectIfNeeded
     await checkAuthStateAndRedirectIfNeeded(user)
 
-    expect(goToLogin).not.toHaveBeenCalled()
+    expect(replaceUrl).not.toHaveBeenCalled()
   })
 
   it('redirects to the login screen if the user is anonymous but is not in the anonymous sign-up experimental group', async () => {
@@ -544,7 +541,7 @@ describe('checkAuthStateAndRedirectIfNeeded tests', () => {
       .checkAuthStateAndRedirectIfNeeded
     await checkAuthStateAndRedirectIfNeeded(user)
 
-    expect(goToLogin).toHaveBeenCalledTimes(1)
+    expect(replaceUrl).toHaveBeenCalledWith(loginURL, {})
   })
 
   it('[no-anon-allowed] redirects to missing email screen if authed and there is no email address', async () => {

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -260,9 +260,10 @@ class Authentication extends React.Component {
                 >
                   <Typography variant={'body2'}>Hey there!</Typography>
                   <Typography variant={'body1'}>
-                      We ask you to sign in after a while to make sure you don't lose access to
-                      your new tab data, like your notes, bookmarks, and Hearts. Signing in also lets
-                      you sync your tab between browsers – nice!
+                      We ask you to sign in after a while so you don't lose
+                      access to your notes, bookmarks, and Hearts (even if you drop your
+                      computer in a puddle). Signing in also lets you sync your tab between
+                      browsers – nice!
                   </Typography>
                 </div>
               </Paper>

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -12,6 +12,7 @@ import {
 } from 'authentication/helpers'
 import {
   goTo,
+  authMessageURL,
   missingEmailMessageURL,
   verifyEmailURL,
   goToDashboard
@@ -174,7 +175,12 @@ class Authentication extends React.Component {
   }
 
   render () {
-    const showRequiredSignInExplanation = this.state.isMandatoryAnonymousSignIn
+    const showRequiredSignInExplanation = (
+      this.state.isMandatoryAnonymousSignIn &&
+      // Don't display the message on the iframe auth message page, because
+      // it will have its own message.
+      this.props.location.pathname.indexOf(authMessageURL) === -1
+    )
     return (
       <span
         data-test-id={'authentication-page'}

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -258,8 +258,8 @@ class Authentication extends React.Component {
                     maxWidth: 600
                   }}
                 >
+                  <Typography variant={'body2'}>Hey there!</Typography>
                   <Typography variant={'body1'}>
-                    <Typography variant={'body2'}>Hey there!</Typography>
                       We ask you to sign in after a while to make sure you don't lose access to
                       your new tab data, like your notes, bookmarks, and Hearts. Signing in also lets
                       you sync your tab between browsers – nice!

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -48,10 +48,8 @@ class Authentication extends React.Component {
     super(props)
     this.state = {
       loadChildren: false,
-      // FIXME: disabled for now because of bad logic.
       // Whether we are requiring the anonymous user to sign in.
-      isMandatoryAnonymousSignIn: false,
-      isUserAnonymous: false // Set after mount if true
+      isMandatoryAnonymousSignIn: getUrlParameters()['mandatory'] === 'true'
     }
   }
 
@@ -59,8 +57,6 @@ class Authentication extends React.Component {
     this.mounted = true
 
     await this.navigateToAuthStep()
-
-    await this.determineAnonymousStatus()
 
     // Don't render any children until after checking the user's
     // authed state. Otherwise, immediate unmounting of
@@ -85,24 +81,6 @@ class Authentication extends React.Component {
     if (!isEqual(nextProps.user, this.props.user)) {
       this.navigateToAuthStep()
     }
-  }
-
-  /**
-   * Check if the user is anonymous and update state with the
-   * anonymous status.
-   * @return {Promise<undefined>} A Promise that resolves after
-   *   the state has been updated.
-   */
-  async determineAnonymousStatus () {
-    const currentUser = await getCurrentUser()
-    const isAnon = currentUser && currentUser.isAnonymous
-    return new Promise((resolve, reject) => {
-      this.setState({
-        isUserAnonymous: isAnon
-      }, () => {
-        resolve()
-      })
-    })
   }
 
   // Whether this is rendering an /auth/action/ page, which include
@@ -196,8 +174,7 @@ class Authentication extends React.Component {
   }
 
   render () {
-    const showRequiredSignInExplanation = this.state.isUserAnonymous &&
-      this.state.isMandatoryAnonymousSignIn
+    const showRequiredSignInExplanation = this.state.isMandatoryAnonymousSignIn
     return (
       <span
         data-test-id={'authentication-page'}
@@ -242,8 +219,8 @@ class Authentication extends React.Component {
               : null
             }
           </span>
-          { showRequiredSignInExplanation
-            ? null : (
+          { !showRequiredSignInExplanation
+            ? (
               // Using same style as homepage
               <span
                 data-test-id={'endorsement-quote'}
@@ -260,9 +237,10 @@ class Authentication extends React.Component {
                 <p style={{ color: '#838383', fontWeight: '400' }}>- USA Today</p>
               </span>
             )
+            : null
           }
         </span>
-        { (showRequiredSignInExplanation)
+        { showRequiredSignInExplanation
           ? (
             <div
               data-test-id={'anon-sign-in-fyi'}

--- a/web/src/js/components/Authentication/SignInIframeMessage.js
+++ b/web/src/js/components/Authentication/SignInIframeMessage.js
@@ -1,10 +1,14 @@
 import React from 'react'
 import { Paper } from 'material-ui'
+import Typography from '@material-ui/core/Typography'
 import RaisedButton from 'material-ui/RaisedButton'
 import {
   absoluteUrl,
   loginURL
 } from 'navigation/navigation'
+import {
+  getUrlParameters
+} from 'utils/utils'
 
 // This view primarily exists as an intermediary to open
 // the authentication page outside of an iframe, because
@@ -14,11 +18,20 @@ import {
 // and open a new tab; our browser extensions currently iframe
 // the page.
 class SignInIframeMessage extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      // Whether we are requiring the anonymous user to sign in.
+      isMandatoryAnonymousSignIn: getUrlParameters()['mandatory'] === 'true'
+    }
+  }
+
   openAuthOutsideIframe () {
     window.open(absoluteUrl(loginURL), '_top')
   }
 
   render () {
+    const showRequiredSignInExplanation = this.state.isMandatoryAnonymousSignIn
     var buttonLabel = 'SIGN IN'
     return (
       <Paper
@@ -26,11 +39,28 @@ class SignInIframeMessage extends React.Component {
         style={{
           padding: 24,
           maxWidth: 400,
-          backgroundColor: '#FFF'
+          backgroundColor: '#FFF',
+          marginBottom: 60
         }}
       >
-        <h3>Let's get started!</h3>
-        <p>Sign in to customize your new tab page and raise money for your favorite causes.</p>
+        <Typography variant={'title'}>
+          {
+            showRequiredSignInExplanation
+              ? `Great job so far!`
+              : `Let's get started!`
+          }
+        </Typography>
+        {
+          showRequiredSignInExplanation
+            ? <Typography variant={'body1'}>
+              You've already made a positive impact! Let's keep this progress safe:
+              sign in to makes you don't lose your new tab page (even if you drop your computer
+              in a puddle).
+            </Typography>
+            : <Typography variant={'body1'}>
+              Sign in to customize your new tab page and raise money for your favorite causes.
+            </Typography>
+        }
         <span
           style={{
             display: 'flex',

--- a/web/src/js/components/Authentication/SignInIframeMessage.js
+++ b/web/src/js/components/Authentication/SignInIframeMessage.js
@@ -54,7 +54,8 @@ class SignInIframeMessage extends React.Component {
           showRequiredSignInExplanation
             ? <Typography variant={'body1'}>
               You've already made a positive impact! Let's keep this progress safe:
-              sign in to makes you don't lose your new tab page (even if you drop your computer
+              we ask you to sign in after a while so you don't lose access
+              to your notes, bookmarks, and Hearts (even if you drop your computer
               in a puddle).
             </Typography>
             : <Typography variant={'body1'}>

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -119,6 +119,7 @@ describe('Authentication.js tests', function () {
 
     const Authentication = require('../Authentication').default
     const mockProps = MockProps()
+    mockProps.location.pathname = '/newtab/auth/'
 
     // Sign-in is mandatory when there is a "mandatory=true" URL param.
     getUrlParameters.mockReturnValue({
@@ -147,6 +148,42 @@ describe('Authentication.js tests', function () {
     expect(wrapper
       .find('[data-test-id="endorsement-quote"]').length
     ).toBe(0)
+  })
+
+  it('does not display the sign-in explanation when it is a mandatory sign-in but we\'re on the iframe message page', async () => {
+    expect.assertions(2)
+
+    const Authentication = require('../Authentication').default
+    const mockProps = MockProps()
+    mockProps.location.pathname = '/newtab/auth/welcome/'
+
+    // Sign-in is mandatory when there is a "mandatory=true" URL param.
+    getUrlParameters.mockReturnValue({
+      mandatory: 'true'
+    })
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false
+    })
+
+    const wrapper = shallow(
+      <Authentication {...mockProps} />
+    )
+
+    // Wait for mount to complete.
+    const component = wrapper.instance()
+    await component.componentDidMount()
+    wrapper.update()
+
+    expect(wrapper
+      .find('[data-test-id="anon-sign-in-fyi"]').length
+    ).toBe(0)
+    expect(wrapper
+      .find('[data-test-id="endorsement-quote"]').length
+    ).toBe(1)
   })
 
   it('calls the `navigateToAuthStep` method on mount', async () => {

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -95,60 +95,59 @@ describe('Authentication.js tests', function () {
     ).toBe(1)
   })
 
-  // it('typically does not display the sign-in explanation', async () => {
-  //   expect.assertions(1)
+  it('typically does not display the sign-in explanation', async () => {
+    expect.assertions(1)
 
-  //   const Authentication = require('../Authentication').default
-  //   const mockProps = MockProps()
-  //   const wrapper = shallow(
-  //     <Authentication {...mockProps} />
-  //   )
+    const Authentication = require('../Authentication').default
+    const mockProps = MockProps()
+    const wrapper = shallow(
+      <Authentication {...mockProps} />
+    )
 
-  //   // Wait for mount to complete.
-  //   const component = wrapper.instance()
-  //   await component.componentDidMount()
-  //   wrapper.update()
+    // Wait for mount to complete.
+    const component = wrapper.instance()
+    await component.componentDidMount()
+    wrapper.update()
 
-  //   expect(wrapper
-  //     .find('[data-test-id="anon-sign-in-fyi"]').length
-  //   ).toBe(0)
-  // })
+    expect(wrapper
+      .find('[data-test-id="anon-sign-in-fyi"]').length
+    ).toBe(0)
+  })
 
-  // it('displays the sign-in explanation (and hides the quote) when it is a mandatory sign-in', async () => {
-  //   expect.assertions(2)
+  it('displays the sign-in explanation (and hides the quote) when it is a mandatory sign-in', async () => {
+    expect.assertions(2)
 
-  //   const Authentication = require('../Authentication').default
-  //   const mockProps = MockProps()
+    const Authentication = require('../Authentication').default
+    const mockProps = MockProps()
 
-  //   // Sign-in is mandatory when it's an anonymous user without a
-  //   // "noredirect" URL parameter who still has an install ID in
-  //   // localStorage.
-  //   getUrlParameters.mockReturnValue({})
-  //   getCurrentUser.mockResolvedValue({
-  //     id: 'abc123',
-  //     email: null,
-  //     username: null,
-  //     isAnonymous: true,
-  //     emailVerified: false
-  //   })
-  //   getBrowserExtensionInstallId.mockReturnValue('some-install-id')
+    // Sign-in is mandatory when there is a "mandatory=true" URL param.
+    getUrlParameters.mockReturnValue({
+      mandatory: 'true'
+    })
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false
+    })
 
-  //   const wrapper = shallow(
-  //     <Authentication {...mockProps} />
-  //   )
+    const wrapper = shallow(
+      <Authentication {...mockProps} />
+    )
 
-  //   // Wait for mount to complete.
-  //   const component = wrapper.instance()
-  //   await component.componentDidMount()
-  //   wrapper.update()
+    // Wait for mount to complete.
+    const component = wrapper.instance()
+    await component.componentDidMount()
+    wrapper.update()
 
-  //   expect(wrapper
-  //     .find('[data-test-id="anon-sign-in-fyi"]').length
-  //   ).toBe(1)
-  //   expect(wrapper
-  //     .find('[data-test-id="endorsement-quote"]').length
-  //   ).toBe(0)
-  // })
+    expect(wrapper
+      .find('[data-test-id="anon-sign-in-fyi"]').length
+    ).toBe(1)
+    expect(wrapper
+      .find('[data-test-id="endorsement-quote"]').length
+    ).toBe(0)
+  })
 
   it('calls the `navigateToAuthStep` method on mount', async () => {
     expect.assertions(1)

--- a/web/src/js/components/Authentication/__tests__/SignInIframeMessage.test.js
+++ b/web/src/js/components/Authentication/__tests__/SignInIframeMessage.test.js
@@ -5,16 +5,22 @@ import {
   shallow
 } from 'enzyme'
 import toJson from 'enzyme-to-json'
+import Typography from '@material-ui/core/Typography'
+import {
+  getUrlParameters
+} from 'utils/utils'
 
-describe('SignInIframeMessage tests', function () {
-  it('renders without error', function () {
+jest.mock('utils/utils')
+
+describe('SignInIframeMessage tests', () => {
+  it('renders without error', () => {
     const SignInIframeMessage = require('../SignInIframeMessage').default
     shallow(
       <SignInIframeMessage />
     )
   })
 
-  it('redirects the page when clicking the sign-in button', function () {
+  it('redirects the page when clicking the sign-in button', () => {
     const SignInIframeMessage = require('../SignInIframeMessage').default
 
     // Mock window.open
@@ -30,7 +36,42 @@ describe('SignInIframeMessage tests', function () {
     expect(window.open).toHaveBeenCalled()
   })
 
-  it('matches expected snapshot', function () {
+  it('has the expected copy', () => {
+    const SignInIframeMessage = require('../SignInIframeMessage').default
+    const wrapper = shallow(
+      <SignInIframeMessage />
+    )
+    expect(
+      wrapper.find(Typography)
+        .first().children().text())
+      .toBe(`Let's get started!`)
+    expect(
+      wrapper.find(Typography)
+        .at(1).children().text())
+      .toBe(
+        `Sign in to customize your new tab page and raise money for your favorite causes.`)
+  })
+
+  it('shows the explanation copy when an anonymous user is now required to sign in', () => {
+    getUrlParameters.mockReturnValueOnce({
+      mandatory: 'true'
+    })
+    const SignInIframeMessage = require('../SignInIframeMessage').default
+    const wrapper = shallow(
+      <SignInIframeMessage />
+    )
+    expect(
+      wrapper.find(Typography)
+        .first().children().text())
+      .toBe(`Great job so far!`)
+    expect(
+      wrapper.find(Typography)
+        .at(1).children().text())
+      .toMatch(
+        `You've already made a positive impact! Let's keep this progress safe:`)
+  })
+
+  it('matches expected snapshot', () => {
     const SignInIframeMessage = require('../SignInIframeMessage').default
     const wrapper = shallow(
       <SignInIframeMessage />

--- a/web/src/js/components/Authentication/__tests__/__snapshots__/SignInIframeMessage.test.js.snap
+++ b/web/src/js/components/Authentication/__tests__/__snapshots__/SignInIframeMessage.test.js.snap
@@ -7,6 +7,7 @@ exports[`SignInIframeMessage tests matches expected snapshot 1`] = `
   style={
     Object {
       "backgroundColor": "#FFF",
+      "marginBottom": 60,
       "maxWidth": 400,
       "padding": 24,
     }
@@ -14,12 +15,16 @@ exports[`SignInIframeMessage tests matches expected snapshot 1`] = `
   transitionEnabled={true}
   zDepth={1}
 >
-  <h3>
+  <WithStyles(Typography)
+    variant="title"
+  >
     Let's get started!
-  </h3>
-  <p>
+  </WithStyles(Typography)>
+  <WithStyles(Typography)
+    variant="body1"
+  >
     Sign in to customize your new tab page and raise money for your favorite causes.
-  </p>
+  </WithStyles(Typography)>
   <span
     style={
       Object {

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -16,8 +16,13 @@ export const goTo = (location, paramsObj = {}) => {
   })
 }
 
-export const replaceUrl = (location) => {
-  browserHistory.replace(location)
+export const replaceUrl = (location, paramsObj = {}) => {
+  browserHistory.replace({
+    pathname: location,
+    search: qs.stringify(paramsObj)
+      ? `?${qs.stringify(paramsObj)}`
+      : null
+  })
 }
 
 export const externalRedirect = (externalURL) => {

--- a/web/src/js/theme/defaultV1.js
+++ b/web/src/js/theme/defaultV1.js
@@ -23,7 +23,13 @@ const theme = createMuiTheme({
   },
   typography: {
     fontSize: 14,
-    fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif'
+    fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+    title: {
+      lineHeight: '1.7em'
+    },
+    subheading: {
+      lineHeight: '1.16667em'
+    }
   },
   overrides: {
     MuiButtonBase: {


### PR DESCRIPTION
If the user was previously using the new tab page anonymously, but we're requiring them to sign in, show a custom message on the authentication pages to explain why we're asking them to sign in. Do not show this message to other users.