### PR TITLE
Enable experiment with various ad sizes 

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -192,6 +192,17 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
           ANONYMOUS_ALLOWED: { value: experimentConfig.anonSignIn.ANONYMOUS_ALLOWED }
         }
       })
+    },
+    variousAdSizes: {
+      type: new GraphQLEnumType({
+        name: 'ExperimentGroupVariousAdSizes',
+        description: 'The test of enabling many different ad sizes',
+        values: {
+          NONE: { value: experimentConfig.variousAdSizes.NONE },
+          STANDARD: { value: experimentConfig.variousAdSizes.STANDARD },
+          VARIOUS: { value: experimentConfig.variousAdSizes.VARIOUS }
+        }
+      })
     }
   }
 })

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -163,6 +163,9 @@ class User extends BaseModel {
       // Group assignments for experiments / split-tests
       testGroupAnonSignIn: types.number().integer().allow(null)
         .description(`Which group the user is in for the "anonymous user sign-in"
+          split-test. This value is assigned on the client so is not trustworthy.`),
+      testGroupVariousAdSizes: types.number().integer().allow(null)
+        .description(`Which group the user is in for the "various ad sizes"
           split-test. This value is assigned on the client so is not trustworthy.`)
     }
   }

--- a/graphql/database/users/__tests__/logUserExperimentGroups.test.js
+++ b/graphql/database/users/__tests__/logUserExperimentGroups.test.js
@@ -69,6 +69,25 @@ describe('logUserExperimentGroups', () => {
     })
   })
 
+  it('sets the testGroupVariousAdSizes value when it is provided', async () => {
+    expect.assertions(1)
+
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const mockExperimentGroups = {
+      variousAdSizes: 1
+    }
+    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
+    const logUserExperimentGroups = require('../logUserExperimentGroups').default
+    await logUserExperimentGroups(userContext, userContext.id, mockExperimentGroups)
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      testGroupVariousAdSizes: 1,
+      updated: moment.utc().toISOString()
+    })
+  })
+
   it('does not update the item when no experiment groups are provided', async () => {
     expect.assertions(1)
 

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -42,6 +42,10 @@ const logUserExperimentGroups = async (userContext, userId, experimentGroups = {
     !isNil(validatedGroups.anonSignIn) ? {
       testGroupAnonSignIn: validatedGroups.anonSignIn
     }
+      : null,
+    !isNil(validatedGroups.variousAdSizes) ? {
+      testGroupVariousAdSizes: validatedGroups.variousAdSizes
+    }
       : null
   )
   try {

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -8,6 +8,12 @@ const experimentConfig = {
     NONE: 0,
     AUTHED_USER_ONLY: 1,
     ANONYMOUS_ALLOWED: 2
+  },
+  // @experiment-various-ad-sizes
+  variousAdSizes: {
+    NONE: 0,
+    STANDARD: 1,
+    VARIOUS: 2
   }
 }
 

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -169,6 +169,14 @@ enum ExperimentGroupAnonSignIn {
 """The experimental groups to which the user is assigned"""
 input ExperimentGroups {
   anonSignIn: ExperimentGroupAnonSignIn
+  variousAdSizes: ExperimentGroupVariousAdSizes
+}
+
+"""The test of enabling many different ad sizes"""
+enum ExperimentGroupVariousAdSizes {
+  NONE
+  STANDARD
+  VARIOUS
 }
 
 input LogEmailVerifiedMutationInput {

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -3,8 +3,14 @@
 import {
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
+import {
+  getVariousAdSizesTestGroup,
+  VARIOUS_AD_SIZES_GROUP_NO_GROUP,
+  VARIOUS_AD_SIZES_GROUP_VARIOUS
+} from 'js/utils/experiments'
 
 jest.mock('js/utils/feature-flags')
+jest.mock('js/utils/experiments')
 
 describe('ad settings', () => {
   test('ad IDs and ad slot IDs are as expected', () => {
@@ -23,7 +29,8 @@ describe('ad settings', () => {
   })
 
   test('getVerticalAdSizes returns the expected ad sizes when various ad sizes are disabled', () => {
-    isVariousAdSizesEnabled.mockReturnValueOnce(false)
+    isVariousAdSizesEnabled.mockReturnValue(false)
+    getVariousAdSizesTestGroup.mockReturnValue(VARIOUS_AD_SIZES_GROUP_NO_GROUP)
     const getVerticalAdSizes = require('js/ads/adSettings').getVerticalAdSizes
     expect(getVerticalAdSizes()).toEqual(
       [
@@ -33,7 +40,8 @@ describe('ad settings', () => {
   })
 
   test('getHorizontalAdSizes returns the expected ad sizes when various ad sizes are disabled', () => {
-    isVariousAdSizesEnabled.mockReturnValueOnce(false)
+    isVariousAdSizesEnabled.mockReturnValue(false)
+    getVariousAdSizesTestGroup.mockReturnValue(VARIOUS_AD_SIZES_GROUP_NO_GROUP)
     const getHorizontalAdSizes = require('js/ads/adSettings').getHorizontalAdSizes
     expect(getHorizontalAdSizes()).toEqual(
       [
@@ -43,7 +51,8 @@ describe('ad settings', () => {
   })
 
   test('getVerticalAdSizes returns the expected ad sizes when various ad sizes are enabled', () => {
-    isVariousAdSizesEnabled.mockReturnValueOnce(true)
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    getVariousAdSizesTestGroup.mockReturnValue(VARIOUS_AD_SIZES_GROUP_VARIOUS)
     const getVerticalAdSizes = require('js/ads/adSettings').getVerticalAdSizes
     expect(getVerticalAdSizes()).toEqual(
       [
@@ -66,7 +75,8 @@ describe('ad settings', () => {
   })
 
   test('getHorizontalAdSizes returns the expected ad sizes when various ad sizes are enabled', () => {
-    isVariousAdSizesEnabled.mockReturnValueOnce(true)
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    getVariousAdSizesTestGroup.mockReturnValue(VARIOUS_AD_SIZES_GROUP_VARIOUS)
     const getHorizontalAdSizes = require('js/ads/adSettings').getHorizontalAdSizes
     expect(getHorizontalAdSizes()).toEqual(
       [

--- a/web/src/js/ads/adSettings.js
+++ b/web/src/js/ads/adSettings.js
@@ -2,6 +2,10 @@
 import {
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
+import {
+  getVariousAdSizesTestGroup,
+  VARIOUS_AD_SIZES_GROUP_VARIOUS
+} from 'js/utils/experiments'
 
 // Time to wait for the entire ad auction before
 // calling the ad server.
@@ -25,8 +29,6 @@ export const VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385742501-0'
 export const HORIZONTAL_AD_UNIT_ID = '/43865596/HBTL'
 export const HORIZONTAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385677836-0'
 
-// TODO: limit new ad sizes to a test group
-
 /**
  * Get an array of ad sizes (each an array with two numbers)
  * of the acceptable ad sizes to display for the veritcal
@@ -34,7 +36,11 @@ export const HORIZONTAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385677836-0'
  * @return {Array[Array]} An array of ad sizes
  */
 export const getVerticalAdSizes = () => {
-  return isVariousAdSizesEnabled() ? [
+  const showVariousAdSizes = (
+    isVariousAdSizesEnabled() &&
+    getVariousAdSizesTestGroup() === VARIOUS_AD_SIZES_GROUP_VARIOUS
+  )
+  return showVariousAdSizes ? [
     [300, 250],
     // Wider than we probably want to allow.
     // [336, 280],
@@ -64,7 +70,11 @@ export const getVerticalAdSizes = () => {
  * @return {Array[Array]} An array of ad sizes
  */
 export const getHorizontalAdSizes = () => {
-  return isVariousAdSizesEnabled() ? [
+  const showVariousAdSizes = (
+    isVariousAdSizesEnabled() &&
+    getVariousAdSizesTestGroup() === VARIOUS_AD_SIZES_GROUP_VARIOUS
+  )
+  return showVariousAdSizes ? [
     [728, 90],
     [728, 210],
     [720, 300],

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -62,6 +62,7 @@ export const STORAGE_APPROX_EXTENSION_INSTALL_TIME = 'tab.newUser.approxInstallT
 
 // tab.experiments: values related to split-testing features
 export const STORAGE_EXPERIMENT_ANON_USER = 'tab.experiments.anonUser'
+export const STORAGE_EXPERIMENT_VARIOUS_AD_SIZES = 'tab.experiments.variousAdSizes'
 
 /**
   Error codes passed from server-side.

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -4,10 +4,12 @@ import localStorageMgr, {
   __mockClear
 } from 'js/utils/localstorage-mgr'
 import {
-  isAnonymousUserSignInEnabled
+  isAnonymousUserSignInEnabled,
+  isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
-  STORAGE_EXPERIMENT_ANON_USER
+  STORAGE_EXPERIMENT_ANON_USER,
+  STORAGE_EXPERIMENT_VARIOUS_AD_SIZES
 } from 'js/constants'
 
 jest.mock('js/utils/localstorage-mgr')
@@ -18,17 +20,23 @@ afterEach(() => {
 })
 
 describe('experiments', () => {
+  /* Tests for all experiments */
+
   test('assignUserToTestGroups saves the user\'s test groups to localStorage', () => {
     // Control for randomness.
     jest.spyOn(Math, 'random').mockReturnValue(0)
 
     // Make sure any experiment-related features are enabled.
     isAnonymousUserSignInEnabled.mockReturnValue(true)
+    isVariousAdSizesEnabled.mockReturnValue(true)
 
     const assignUserToTestGroups = require('js/utils/experiments').assignUserToTestGroups
     assignUserToTestGroups()
     expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.experiments.anonUser', 'auth')
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.experiments.variousAdSizes', 'standard')
   })
+
+  /* Tests for the "anonymous user" test */
 
   test('assignUserToTestGroups saves a "none" test group value for the anonUser test when the feature is not enabled', () => {
     // Anonymous user sign-in is not enabled.
@@ -79,7 +87,7 @@ describe('experiments', () => {
     isAnonymousUserSignInEnabled.mockReturnValue(true)
     localStorageMgr.setItem(STORAGE_EXPERIMENT_ANON_USER, 'unauthed')
     const getUserTestGroupsForMutation = require('js/utils/experiments').getUserTestGroupsForMutation
-    expect(getUserTestGroupsForMutation()).toEqual({
+    expect(getUserTestGroupsForMutation()).toMatchObject({
       anonSignIn: 'ANONYMOUS_ALLOWED'
     })
   })
@@ -88,8 +96,63 @@ describe('experiments', () => {
     isAnonymousUserSignInEnabled.mockReturnValue(true)
     localStorageMgr.removeItem(STORAGE_EXPERIMENT_ANON_USER)
     const getUserTestGroupsForMutation = require('js/utils/experiments').getUserTestGroupsForMutation
-    expect(getUserTestGroupsForMutation()).toEqual({
+    expect(getUserTestGroupsForMutation()).toMatchObject({
       anonSignIn: 'NONE'
+    })
+  })
+
+  /* Tests for the "various ad sizes" test */
+
+  test('assignUserToTestGroups saves a "none" test group value for the "various ad sizes" test when the feature is not enabled', () => {
+    isVariousAdSizesEnabled.mockReturnValue(false)
+    const assignUserToTestGroups = require('js/utils/experiments').assignUserToTestGroups
+    assignUserToTestGroups()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith('tab.experiments.variousAdSizes', 'none')
+  })
+
+  test('getVariousAdSizesTestGroup returns the saved test group', () => {
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    localStorageMgr.setItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES, 'various')
+    const getVariousAdSizesTestGroup = require('js/utils/experiments').getVariousAdSizesTestGroup
+    const testGroup = getVariousAdSizesTestGroup()
+    expect(testGroup).toBe('various')
+  })
+
+  test('getVariousAdSizesTestGroup returns "none" if there is no saved test group', () => {
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    localStorageMgr.removeItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES)
+    const getVariousAdSizesTestGroup = require('js/utils/experiments').getVariousAdSizesTestGroup
+    const testGroup = getVariousAdSizesTestGroup()
+    expect(testGroup).toBe('none')
+  })
+
+  test('getVariousAdSizesTestGroup returns "none" if the saved test group value is not a valid test group', () => {
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    localStorageMgr.setItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES, 'blah')
+    const getVariousAdSizesTestGroup = require('js/utils/experiments').getVariousAdSizesTestGroup
+    const testGroup = getVariousAdSizesTestGroup()
+    expect(testGroup).toBe('none')
+  })
+
+  test('getUserTestGroupsForMutation returns the expected value for an assigned group', () => {
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    const getUserTestGroupsForMutation = require('js/utils/experiments').getUserTestGroupsForMutation
+    localStorageMgr.setItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES, 'standard')
+    expect(getUserTestGroupsForMutation()).toMatchObject({
+      variousAdSizes: 'STANDARD'
+    })
+    localStorageMgr.setItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES, 'various')
+    expect(getUserTestGroupsForMutation()).toMatchObject({
+      variousAdSizes: 'VARIOUS'
+    })
+  })
+
+  test('getUserTestGroupsForMutation returns the expected value when the user is not assigned to a group', () => {
+    isVariousAdSizesEnabled.mockReturnValue(true)
+    localStorageMgr.removeItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES)
+    const getUserTestGroupsForMutation = require('js/utils/experiments').getUserTestGroupsForMutation
+    expect(getUserTestGroupsForMutation()).toMatchObject({
+      variousAdSizes: 'NONE'
     })
   })
 })

--- a/web/src/js/utils/__tests__/feature-flags.test.js
+++ b/web/src/js/utils/__tests__/feature-flags.test.js
@@ -29,9 +29,9 @@ describe('feature flags', () => {
     expect(isAnonymousUserSignInEnabled()).toBe(false)
   })
 
-  test('isVariousAdSizesEnabled is false', () => {
+  test('isVariousAdSizesEnabled is true', () => {
     const isVariousAdSizesEnabled = require('js/utils/feature-flags')
       .isVariousAdSizesEnabled
-    expect(isVariousAdSizesEnabled()).toBe(false)
+    expect(isVariousAdSizesEnabled()).toBe(true)
   })
 })

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -1,11 +1,78 @@
 
 import localStorageMgr from 'js/utils/localstorage-mgr'
 import {
-  isAnonymousUserSignInEnabled
+  isAnonymousUserSignInEnabled,
+  isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
-  STORAGE_EXPERIMENT_ANON_USER
+  STORAGE_EXPERIMENT_ANON_USER,
+  STORAGE_EXPERIMENT_VARIOUS_AD_SIZES
 } from 'js/constants'
+
+// Various ad sizes test
+export const VARIOUS_AD_SIZES_GROUP_NO_GROUP = 'none'
+export const VARIOUS_AD_SIZES_GROUP_STANDARD = 'standard'
+export const VARIOUS_AD_SIZES_GROUP_VARIOUS = 'various'
+
+// @experiment-various-ad-sizes
+/**
+ * Return the test group for the various ad sizes test from
+ * localStorage. If no test group is set, return the 'none'
+ * test group.
+ * @returns {String} One of the valid test group names.
+ */
+export const getVariousAdSizesTestGroup = () => {
+  const item = localStorageMgr.getItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES)
+  var testGroup = VARIOUS_AD_SIZES_GROUP_NO_GROUP
+  if (item === VARIOUS_AD_SIZES_GROUP_STANDARD ||
+    item === VARIOUS_AD_SIZES_GROUP_VARIOUS
+  ) {
+    testGroup = item
+  }
+  return testGroup
+}
+
+// @experiment-various-ad-sizes
+/**
+ * Assigns the user to a test group for the various ad sizes
+ * test and stores the test group in localStorage.
+ * @returns {undefined}
+ */
+const assignVariousAdSizesTestGroup = () => {
+  const variousAdsEnabled = isVariousAdSizesEnabled()
+  const groups = [
+    VARIOUS_AD_SIZES_GROUP_STANDARD,
+    VARIOUS_AD_SIZES_GROUP_VARIOUS
+  ]
+  var testGroup = variousAdsEnabled
+    // Equal chance of control vs. experimental group
+    ? (
+      groups[Math.floor(Math.random() * groups.length)]
+    )
+    : VARIOUS_AD_SIZES_GROUP_NO_GROUP
+
+  // Store the group in localStorage.
+  localStorageMgr.setItem(STORAGE_EXPERIMENT_VARIOUS_AD_SIZES, testGroup)
+}
+
+// @experiment-various-ad-sizes
+/**
+ * Converts the test group value to its corresponding string
+ * used by the server-side, compliant with our GraphQL schema.
+ * @param {String} testGroup - One of the constants representing
+ *   the user's test group.
+ * @returns {String} The string representing the test group,
+ *   compliant with our GraphQL schema.
+ */
+const variousAdSizesTestGroupToSchemaValue = testGroup => {
+  // Corresponds to server-side enum.
+  const map = {
+    [VARIOUS_AD_SIZES_GROUP_NO_GROUP]: 'NONE',
+    [VARIOUS_AD_SIZES_GROUP_STANDARD]: 'STANDARD',
+    [VARIOUS_AD_SIZES_GROUP_VARIOUS]: 'VARIOUS'
+  }
+  return map[testGroup]
+}
 
 // Anonymous user sign-in test
 export const ANON_USER_GROUP_NO_GROUP = 'none'
@@ -60,6 +127,7 @@ const assignAnonymousUserTestGroup = () => {
  */
 export const assignUserToTestGroups = () => {
   assignAnonymousUserTestGroup()
+  assignVariousAdSizesTestGroup()
 }
 
 // @experiment-anon-sign-in
@@ -93,6 +161,7 @@ const anonymousTestGroupToSchemaValue = testGroup => {
  */
 export const getUserTestGroupsForMutation = () => {
   return {
-    anonSignIn: anonymousTestGroupToSchemaValue(getAnonymousUserTestGroup())
+    anonSignIn: anonymousTestGroupToSchemaValue(getAnonymousUserTestGroup()),
+    variousAdSizes: variousAdSizesTestGroupToSchemaValue(getVariousAdSizesTestGroup())
   }
 }

--- a/web/src/js/utils/feature-flags.js
+++ b/web/src/js/utils/feature-flags.js
@@ -7,4 +7,4 @@ export const isAnonymousUserSignInEnabled = () => {
 }
 
 // @experiment-various-ad-sizes
-export const isVariousAdSizesEnabled = () => false
+export const isVariousAdSizesEnabled = () => true


### PR DESCRIPTION
Enable a test to show some new users various ad sizes and other new users the standard ad sizes.

* Add `testGroupVariousAdSizes` to user model
* Assign new users to the control ("standard") or experimental ("various") group, 50/50 split
* Only show new ad sizes to users in the experimental group
* Enable the feature flag for various ad sizes