### PR TITLE
Support varying numbers of ad units (between 0 and 3)

### DIFF
--- a/web/src/js/ads/__mocks__/adSettings.js
+++ b/web/src/js/ads/__mocks__/adSettings.js
@@ -6,9 +6,12 @@ adSettings.CONSENT_MANAGEMENT_TIMEOUT = 50
 adSettings.BIDDER_TIMEOUT = 700
 adSettings.VERTICAL_AD_UNIT_ID = '/11223344/HBTR'
 adSettings.VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1357913579-0'
+adSettings.SECOND_VERTICAL_AD_UNIT_ID = '/44556677/HBTR2'
+adSettings.SECOND_VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-11235813-0'
 adSettings.HORIZONTAL_AD_UNIT_ID = '/99887766/HBTL'
 adSettings.HORIZONTAL_AD_SLOT_DOM_ID = 'div-gpt-ad-24682468-0'
 
+adSettings.getNumberOfAdsToShow = jest.fn(() => 2)
 adSettings.getVerticalAdSizes = jest.fn(() => [[300, 250]])
 adSettings.getHorizontalAdSizes = jest.fn(() => [[728, 90]])
 

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 
 import {
+  isThirdAdEnabled,
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
@@ -26,6 +27,20 @@ describe('ad settings', () => {
     expect(VERTICAL_AD_SLOT_DOM_ID).toBe('div-gpt-ad-1464385742501-0')
     expect(HORIZONTAL_AD_UNIT_ID).toBe('/43865596/HBTL')
     expect(HORIZONTAL_AD_SLOT_DOM_ID).toBe('div-gpt-ad-1464385677836-0')
+  })
+
+  test('getNumberOfAdsToShow returns 2 when the "3rd ad" feature is disabled', () => {
+    isThirdAdEnabled.mockReturnValue(false)
+    getVariousAdSizesTestGroup.mockReturnValue(VARIOUS_AD_SIZES_GROUP_NO_GROUP)
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(2)
+  })
+
+  test('getNumberOfAdsToShow returns 3 when the "3rd ad" feature is enabled', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getVariousAdSizesTestGroup.mockReturnValue(VARIOUS_AD_SIZES_GROUP_NO_GROUP)
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(3)
   })
 
   test('getVerticalAdSizes returns the expected ad sizes when various ad sizes are disabled', () => {

--- a/web/src/js/ads/adSettings.js
+++ b/web/src/js/ads/adSettings.js
@@ -24,6 +24,10 @@ export const BIDDER_TIMEOUT = 700
 export const VERTICAL_AD_UNIT_ID = '/43865596/HBTR'
 export const VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385742501-0'
 
+// "Second vertical ad" = the extra rectangle ad.
+export const SECOND_VERTICAL_AD_UNIT_ID = '/43865596/HBTR2'
+export const SECOND_VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1539903223131-0'
+
 // "Horizontal ad" = the ad that's typically wider than
 // it is tall. Historically, the bottom long leaderboard ad.
 export const HORIZONTAL_AD_UNIT_ID = '/43865596/HBTL'

--- a/web/src/js/ads/adSettings.js
+++ b/web/src/js/ads/adSettings.js
@@ -1,5 +1,6 @@
 
 import {
+  isThirdAdEnabled,
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
@@ -32,6 +33,14 @@ export const SECOND_VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1539903223131-0'
 // it is tall. Historically, the bottom long leaderboard ad.
 export const HORIZONTAL_AD_UNIT_ID = '/43865596/HBTL'
 export const HORIZONTAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385677836-0'
+
+/**
+ * Get the number of banner ads to show on the new tab page.
+ * @return {Number} The number of ads
+ */
+export const getNumberOfAdsToShow = () => {
+  return isThirdAdEnabled() ? 3 : 2
+}
 
 /**
  * Get an array of ad sizes (each an array with two numbers)

--- a/web/src/js/ads/amazon/amazonBidder.js
+++ b/web/src/js/ads/amazon/amazonBidder.js
@@ -1,6 +1,7 @@
 
 import getAmazonTag from 'js/ads/amazon/getAmazonTag'
 import {
+  getNumberOfAdsToShow,
   getVerticalAdSizes,
   getHorizontalAdSizes,
   BIDDER_TIMEOUT,
@@ -48,7 +49,25 @@ export const storeAmazonBids = () => {
  *   bid requests return or time out.
  */
 function initApstag () {
+  const numAds = getNumberOfAdsToShow()
+  if (numAds < 1) {
+    return
+  }
   const apstag = getAmazonTag()
+
+  // Only get bids for the horizontal ad slot if only
+  // one ad is enabled.
+  const slots = [{
+    slotID: HORIZONTAL_AD_SLOT_DOM_ID,
+    sizes: getHorizontalAdSizes()
+  }]
+  if (numAds > 1) {
+    slots.push({
+      slotID: VERTICAL_AD_SLOT_DOM_ID,
+      sizes: getVerticalAdSizes()
+    })
+  }
+
   return new Promise((resolve, reject) => {
     apstag.init({
       pubID: '3397',
@@ -59,16 +78,7 @@ function initApstag () {
     })
     apstag.fetchBids(
       {
-        slots: [
-          {
-            slotID: VERTICAL_AD_SLOT_DOM_ID,
-            sizes: getVerticalAdSizes()
-          },
-          {
-            slotID: HORIZONTAL_AD_SLOT_DOM_ID,
-            sizes: getHorizontalAdSizes()
-          }
-        ],
+        slots: slots,
         timeout: BIDDER_TIMEOUT
       },
       function (bids) {

--- a/web/src/js/ads/google/__tests__/setUpGoogleAds.test.js
+++ b/web/src/js/ads/google/__tests__/setUpGoogleAds.test.js
@@ -3,6 +3,7 @@
 import setUpGoogleAds from 'js/ads/google/setUpGoogleAds'
 import getGoogleTag from 'js/ads/google/getGoogleTag'
 import {
+  getNumberOfAdsToShow,
   getVerticalAdSizes,
   getHorizontalAdSizes
 } from 'js/ads/adSettings'
@@ -23,14 +24,49 @@ describe('setUpGoogleAds', function () {
     setUpGoogleAds()
   })
 
-  it('defines the ad slots', () => {
+  it('does not define ad slots when showing zero ads', () => {
+    getNumberOfAdsToShow.mockReturnValue(0)
     setUpGoogleAds()
     const googletag = getGoogleTag()
+    expect(googletag.defineSlot).not.toHaveBeenCalled()
+  })
+
+  it('defines the expected ad slots when showing 1 ad', () => {
+    getNumberOfAdsToShow.mockReturnValue(1)
+    setUpGoogleAds()
+    const googletag = getGoogleTag()
+    expect(googletag.defineSlot.mock.calls.length).toBe(1)
+    expect(googletag.defineSlot.mock.calls[0]).toEqual(
+      ['/99887766/HBTL', expect.any(Array), 'div-gpt-ad-24682468-0']
+    )
+  })
+
+  it('defines the expected ad slots when showing 2 ads', () => {
+    getNumberOfAdsToShow.mockReturnValue(2)
+    setUpGoogleAds()
+    const googletag = getGoogleTag()
+    expect(googletag.defineSlot.mock.calls.length).toBe(2)
     expect(googletag.defineSlot.mock.calls[0]).toEqual(
       ['/99887766/HBTL', expect.any(Array), 'div-gpt-ad-24682468-0']
     )
     expect(googletag.defineSlot.mock.calls[1]).toEqual(
       ['/11223344/HBTR', expect.any(Array), 'div-gpt-ad-1357913579-0']
+    )
+  })
+
+  it('defines the expected ad slots when showing 3 ads', () => {
+    getNumberOfAdsToShow.mockReturnValue(3)
+    setUpGoogleAds()
+    const googletag = getGoogleTag()
+    expect(googletag.defineSlot.mock.calls.length).toBe(3)
+    expect(googletag.defineSlot.mock.calls[0]).toEqual(
+      ['/99887766/HBTL', expect.any(Array), 'div-gpt-ad-24682468-0']
+    )
+    expect(googletag.defineSlot.mock.calls[1]).toEqual(
+      ['/11223344/HBTR', expect.any(Array), 'div-gpt-ad-1357913579-0']
+    )
+    expect(googletag.defineSlot.mock.calls[2]).toEqual(
+      ['/44556677/HBTR2', expect.any(Array), 'div-gpt-ad-11235813-0']
     )
   })
 

--- a/web/src/js/ads/google/setUpGoogleAds.js
+++ b/web/src/js/ads/google/setUpGoogleAds.js
@@ -5,6 +5,8 @@ import {
   getHorizontalAdSizes,
   VERTICAL_AD_UNIT_ID,
   VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_UNIT_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
   HORIZONTAL_AD_UNIT_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
 } from 'js/ads/adSettings'
@@ -14,16 +16,27 @@ export default () => {
   const horizontalAdSizes = getHorizontalAdSizes()
   const verticalAdSizes = getVerticalAdSizes()
   googletag.cmd.push(function () {
+    // Leaderboard
     googletag.defineSlot(
       HORIZONTAL_AD_UNIT_ID,
       horizontalAdSizes,
       HORIZONTAL_AD_SLOT_DOM_ID
     ).addService(googletag.pubads())
+
+    // Rectangle #1
     googletag.defineSlot(
       VERTICAL_AD_UNIT_ID,
       verticalAdSizes,
       VERTICAL_AD_SLOT_DOM_ID
     ).addService(googletag.pubads())
+
+    // Rectangle #2
+    googletag.defineSlot(
+      SECOND_VERTICAL_AD_UNIT_ID,
+      verticalAdSizes,
+      SECOND_VERTICAL_AD_SLOT_DOM_ID
+    ).addService(googletag.pubads())
+
     googletag.pubads().enableSingleRequest()
     googletag.enableServices()
   })

--- a/web/src/js/ads/google/setUpGoogleAds.js
+++ b/web/src/js/ads/google/setUpGoogleAds.js
@@ -1,6 +1,7 @@
 
 import getGoogleTag from 'js/ads/google/getGoogleTag'
 import {
+  getNumberOfAdsToShow,
   getVerticalAdSizes,
   getHorizontalAdSizes,
   VERTICAL_AD_UNIT_ID,
@@ -15,28 +16,32 @@ export default () => {
   const googletag = getGoogleTag()
   const horizontalAdSizes = getHorizontalAdSizes()
   const verticalAdSizes = getVerticalAdSizes()
+  const numAdsToShow = getNumberOfAdsToShow()
   googletag.cmd.push(function () {
-    // Leaderboard
-    googletag.defineSlot(
-      HORIZONTAL_AD_UNIT_ID,
-      horizontalAdSizes,
-      HORIZONTAL_AD_SLOT_DOM_ID
-    ).addService(googletag.pubads())
-
-    // Rectangle #1
-    googletag.defineSlot(
-      VERTICAL_AD_UNIT_ID,
-      verticalAdSizes,
-      VERTICAL_AD_SLOT_DOM_ID
-    ).addService(googletag.pubads())
-
-    // Rectangle #2
-    googletag.defineSlot(
-      SECOND_VERTICAL_AD_UNIT_ID,
-      verticalAdSizes,
-      SECOND_VERTICAL_AD_SLOT_DOM_ID
-    ).addService(googletag.pubads())
-
+    if (numAdsToShow > 0) {
+      // Leaderboard
+      googletag.defineSlot(
+        HORIZONTAL_AD_UNIT_ID,
+        horizontalAdSizes,
+        HORIZONTAL_AD_SLOT_DOM_ID
+      ).addService(googletag.pubads())
+    }
+    if (numAdsToShow > 1) {
+      // Rectangle #1
+      googletag.defineSlot(
+        VERTICAL_AD_UNIT_ID,
+        verticalAdSizes,
+        VERTICAL_AD_SLOT_DOM_ID
+      ).addService(googletag.pubads())
+    }
+    if (numAdsToShow > 2) {
+      // Rectangle #2
+      googletag.defineSlot(
+        SECOND_VERTICAL_AD_UNIT_ID,
+        verticalAdSizes,
+        SECOND_VERTICAL_AD_SLOT_DOM_ID
+      ).addService(googletag.pubads())
+    }
     googletag.pubads().enableSingleRequest()
     googletag.enableServices()
   })

--- a/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
+++ b/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
@@ -259,8 +259,6 @@ describe('prebidConfig', function () {
       adUnitConfig[1]['bids'].every(bid => {
         return [
           'brealtime',
-          'openx',
-          'pulsepoint',
           'sonobi',
           'sovrn'
         ].indexOf(bid['bidder']) > -1
@@ -270,7 +268,9 @@ describe('prebidConfig', function () {
       adUnitConfig[2]['bids'].every(bid => {
         return [
           'aol',
-          'rhythmone'
+          'rhythmone',
+          'openx',
+          'pulsepoint'
         ].indexOf(bid['bidder']) > -1
       })
     ).toBe(true)

--- a/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
+++ b/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
@@ -67,8 +67,10 @@ describe('prebidConfig', function () {
   })
 
   it('uses ad sizes from the ad settings', async () => {
-    expect.assertions(2)
-    getVerticalAdSizes.mockReturnValueOnce([[250, 250], [300, 600]])
+    expect.assertions(3)
+    getVerticalAdSizes
+      .mockReturnValueOnce([[250, 250], [300, 600]])
+      .mockReturnValueOnce([[300, 250]])
     getHorizontalAdSizes.mockReturnValueOnce([[728, 90], [720, 300]])
     const pbjs = getPrebidPbjs()
     await prebidConfig()
@@ -77,6 +79,8 @@ describe('prebidConfig', function () {
     expect(adUnitConfig[0]['mediaTypes']['banner']['sizes'])
       .toEqual([[250, 250], [300, 600]])
     expect(adUnitConfig[1]['mediaTypes']['banner']['sizes'])
+      .toEqual([[300, 250]])
+    expect(adUnitConfig[2]['mediaTypes']['banner']['sizes'])
       .toEqual([[728, 90], [720, 300]])
   })
 

--- a/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
+++ b/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
@@ -8,8 +8,12 @@ import getPrebidPbjs, {
 } from 'js/ads/prebid/getPrebidPbjs'
 import { getDefaultTabGlobal } from 'js/utils/test-utils'
 import {
+  getNumberOfAdsToShow,
   getVerticalAdSizes,
-  getHorizontalAdSizes
+  getHorizontalAdSizes,
+  VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
+  HORIZONTAL_AD_SLOT_DOM_ID
 } from 'js/ads/adSettings'
 
 jest.mock('js/ads/adSettings')
@@ -64,24 +68,6 @@ describe('prebidConfig', function () {
     expect(adUnitConfig[0]['code']).toBeDefined()
     expect(adUnitConfig[0]['mediaTypes']).toBeDefined()
     expect(adUnitConfig[0]['bids']).toBeDefined()
-  })
-
-  it('uses ad sizes from the ad settings', async () => {
-    expect.assertions(3)
-    getVerticalAdSizes
-      .mockReturnValueOnce([[250, 250], [300, 600]])
-      .mockReturnValueOnce([[300, 250]])
-    getHorizontalAdSizes.mockReturnValueOnce([[728, 90], [720, 300]])
-    const pbjs = getPrebidPbjs()
-    await prebidConfig()
-
-    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
-    expect(adUnitConfig[0]['mediaTypes']['banner']['sizes'])
-      .toEqual([[250, 250], [300, 600]])
-    expect(adUnitConfig[1]['mediaTypes']['banner']['sizes'])
-      .toEqual([[300, 250]])
-    expect(adUnitConfig[2]['mediaTypes']['banner']['sizes'])
-      .toEqual([[728, 90], [720, 300]])
   })
 
   it('includes the consentManagement setting when in the EU', async () => {
@@ -140,5 +126,153 @@ describe('prebidConfig', function () {
     await prebidConfig()
 
     expect(pbjs.setConfig.mock.calls[0][0]['consentManagement']).toBeUndefined()
+  })
+
+  it('uses ad sizes from the ad settings', async () => {
+    expect.assertions(3)
+    getNumberOfAdsToShow.mockReturnValue(3)
+    getVerticalAdSizes.mockReturnValue([[250, 250]])
+    getHorizontalAdSizes.mockReturnValue([[728, 90]])
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(adUnitConfig[0]['mediaTypes']['banner']['sizes'])
+      .toEqual([[728, 90]])
+    expect(adUnitConfig[1]['mediaTypes']['banner']['sizes'])
+      .toEqual([[250, 250]])
+    expect(adUnitConfig[2]['mediaTypes']['banner']['sizes'])
+      .toEqual([[250, 250]])
+  })
+
+  it('gets bids for only the horizontal ad when there is only one ad', async () => {
+    expect.assertions(2)
+    getNumberOfAdsToShow.mockReturnValueOnce(1)
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(adUnitConfig.length).toBe(1)
+    expect(adUnitConfig[0]['code']).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+  })
+
+  it('gets bids for the horizontal ad and vertical ad when there are two ads', async () => {
+    expect.assertions(3)
+    getNumberOfAdsToShow.mockReturnValueOnce(2)
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(adUnitConfig.length).toBe(2)
+    expect(adUnitConfig[0]['code']).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+    expect(adUnitConfig[1]['code']).toBe(VERTICAL_AD_SLOT_DOM_ID)
+  })
+
+  it('gets bids for the horizontal ad and two vertical ads when there are three ads', async () => {
+    expect.assertions(4)
+    getNumberOfAdsToShow.mockReturnValueOnce(3)
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(adUnitConfig.length).toBe(3)
+    expect(adUnitConfig[0]['code']).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+    expect(adUnitConfig[1]['code']).toBe(VERTICAL_AD_SLOT_DOM_ID)
+    expect(adUnitConfig[2]['code']).toBe(SECOND_VERTICAL_AD_SLOT_DOM_ID)
+  })
+
+  it('when there is one ad, the list of bidders for the ad match what is expected', async () => {
+    expect.assertions(1)
+    getNumberOfAdsToShow.mockReturnValueOnce(1)
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(
+      adUnitConfig[0]['bids'].every(bid => {
+        return [
+          'aol',
+          'brealtime',
+          'openx',
+          'pulsepoint',
+          'rhythmone',
+          'sonobi',
+          'sovrn'
+        ].indexOf(bid['bidder']) > -1
+      })
+    ).toBe(true)
+  })
+
+  it('when there are two ads, the list of bidders for each ad match what is expected', async () => {
+    expect.assertions(2)
+    getNumberOfAdsToShow.mockReturnValueOnce(2)
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(
+      adUnitConfig[0]['bids'].every(bid => {
+        return [
+          'aol',
+          'brealtime',
+          'openx',
+          'pulsepoint',
+          'rhythmone',
+          'sonobi',
+          'sovrn'
+        ].indexOf(bid['bidder']) > -1
+      })
+    ).toBe(true)
+    expect(
+      adUnitConfig[1]['bids'].every(bid => {
+        return [
+          'aol',
+          'brealtime',
+          'openx',
+          'pulsepoint',
+          'rhythmone',
+          'sonobi',
+          'sovrn'
+        ].indexOf(bid['bidder']) > -1
+      })
+    ).toBe(true)
+  })
+
+  it('when there are three ads, the list of bidders for each ad match what is expected', async () => {
+    expect.assertions(3)
+    getNumberOfAdsToShow.mockReturnValueOnce(3)
+    const pbjs = getPrebidPbjs()
+    await prebidConfig()
+    const adUnitConfig = pbjs.addAdUnits.mock.calls[0][0]
+    expect(
+      adUnitConfig[0]['bids'].every(bid => {
+        return [
+          'aol',
+          'brealtime',
+          'openx',
+          'pulsepoint',
+          'rhythmone',
+          'sonobi',
+          'sovrn'
+        ].indexOf(bid['bidder']) > -1
+      })
+    ).toBe(true)
+    expect(
+      adUnitConfig[1]['bids'].every(bid => {
+        return [
+          'brealtime',
+          'openx',
+          'pulsepoint',
+          'sonobi',
+          'sovrn'
+        ].indexOf(bid['bidder']) > -1
+      })
+    ).toBe(true)
+    expect(
+      adUnitConfig[2]['bids'].every(bid => {
+        return [
+          'aol',
+          'rhythmone'
+        ].indexOf(bid['bidder']) > -1
+      })
+    ).toBe(true)
   })
 })

--- a/web/src/js/ads/prebid/prebidConfig.js
+++ b/web/src/js/ads/prebid/prebidConfig.js
@@ -2,6 +2,7 @@
 import getPrebidPbjs from 'js/ads/prebid/getPrebidPbjs'
 import { isInEuropeanUnion } from 'js/utils/client-location'
 import {
+  getNumberOfAdsToShow,
   getVerticalAdSizes,
   getHorizontalAdSizes,
   CONSENT_MANAGEMENT_TIMEOUT,
@@ -11,6 +12,224 @@ import {
   HORIZONTAL_AD_UNIT_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
 } from 'js/ads/adSettings'
+
+const getAdUnits = () => {
+  const numAdsToShow = getNumberOfAdsToShow()
+
+  // Leaderboard-style ad with all bidders
+  const horizontalAdUnit = {
+    code: HORIZONTAL_AD_SLOT_DOM_ID,
+    mediaTypes: {
+      banner: {
+        sizes: getHorizontalAdSizes()
+      }
+    },
+    bids: [
+      {
+        bidder: 'sonobi',
+        params: {
+          dom_id: HORIZONTAL_AD_SLOT_DOM_ID,
+          ad_unit: HORIZONTAL_AD_UNIT_ID
+        }
+      },
+      {
+        bidder: 'pulsepoint',
+        params: {
+          cf: '728X90',
+          cp: '560174',
+          ct: '460981'
+        }
+      },
+      {
+        bidder: 'aol',
+        params: {
+          network: '10559.1',
+          placement: '4117691',
+          alias: 'desktop_newtab_728x90',
+          sizeId: '225'
+        }
+      },
+      {
+        bidder: 'sovrn',
+        params: {
+          tagid: '438918'
+        }
+      },
+      {
+        bidder: 'openx',
+        params: {
+          unit: '538658529',
+          delDomain: 'tabforacause-d.openx.net'
+        }
+      },
+      {
+        bidder: 'brealtime',
+        params: {
+          placementId: '10955287'
+        }
+      },
+      {
+        bidder: 'rhythmone',
+        params: {
+          placementId: '73423'
+        }
+      }
+    ]
+  }
+
+  // Rectangle-style ad with all bidders
+  const verticalAdUnitForTwoAds = {
+    code: VERTICAL_AD_SLOT_DOM_ID,
+    mediaTypes: {
+      banner: {
+        sizes: getVerticalAdSizes()
+      }
+    },
+    bids: [
+      {
+        bidder: 'sonobi',
+        params: {
+          dom_id: VERTICAL_AD_SLOT_DOM_ID,
+          ad_unit: VERTICAL_AD_UNIT_ID
+        }
+      },
+      {
+        bidder: 'pulsepoint',
+        params: {
+          cf: '300X250',
+          cp: '560174',
+          ct: '460982'
+        }
+      },
+      {
+        bidder: 'aol',
+        params: {
+          network: '10559.1',
+          placement: '4117692',
+          alias: 'desktop_newtab_300x250',
+          sizeId: '170'
+        }
+      },
+      {
+        bidder: 'sovrn',
+        params: {
+          tagid: '438916'
+        }
+      },
+      {
+        bidder: 'openx',
+        params: {
+          unit: '538658529',
+          delDomain: 'tabforacause-d.openx.net'
+        }
+      },
+      {
+        bidder: 'brealtime',
+        params: {
+          placementId: '10955690'
+        }
+      },
+      {
+        bidder: 'rhythmone',
+        params: {
+          placementId: '73423'
+        }
+      }
+    ]
+  }
+
+  // Rectangle-style ad with some bidders for when
+  // we are showing three ads
+  const firstVerticalAdUnitForThreeAds = {
+    code: VERTICAL_AD_SLOT_DOM_ID,
+    mediaTypes: {
+      banner: {
+        sizes: getVerticalAdSizes()
+      }
+    },
+    bids: [
+      {
+        bidder: 'sonobi',
+        params: {
+          dom_id: VERTICAL_AD_SLOT_DOM_ID,
+          ad_unit: VERTICAL_AD_UNIT_ID
+        }
+      },
+      {
+        bidder: 'pulsepoint',
+        params: {
+          cf: '300X250',
+          cp: '560174',
+          ct: '460982'
+        }
+      },
+      {
+        bidder: 'sovrn',
+        params: {
+          tagid: '438916'
+        }
+      },
+      {
+        bidder: 'openx',
+        params: {
+          unit: '538658529',
+          delDomain: 'tabforacause-d.openx.net'
+        }
+      },
+      {
+        bidder: 'brealtime',
+        params: {
+          placementId: '10955690'
+        }
+      }
+    ]
+  }
+
+  // Second rectangle-style ad with some bidders for when
+  // we are showing three ads
+  const secondVerticalAdUnitForThreeAds = {
+    code: SECOND_VERTICAL_AD_SLOT_DOM_ID,
+    mediaTypes: {
+      banner: {
+        sizes: getVerticalAdSizes()
+      }
+    },
+    bids: [
+      {
+        bidder: 'aol',
+        params: {
+          network: '10559.1',
+          placement: '4117692',
+          alias: 'desktop_newtab_300x250',
+          sizeId: '170'
+        }
+      },
+      {
+        bidder: 'rhythmone',
+        params: {
+          placementId: '73423'
+        }
+      }
+    ]
+  }
+
+  if (!numAdsToShow) {
+    return []
+  } else if (numAdsToShow === 1) {
+    return [horizontalAdUnit]
+  } else if (numAdsToShow === 2) {
+    return [
+      horizontalAdUnit,
+      verticalAdUnitForTwoAds
+    ]
+  } else {
+    return [
+      horizontalAdUnit,
+      firstVerticalAdUnitForThreeAds,
+      secondVerticalAdUnitForThreeAds
+    ]
+  }
+}
 
 /**
  * Return a promise that resolves when the Prebid auction is
@@ -32,151 +251,7 @@ export default () => {
     }
     const requiresConsentManagement = !!isInEU
 
-    // Note: brealtime is automatically aliased by the
-    // AppNexus bid adapter.
-    const adUnits = [{
-      code: VERTICAL_AD_SLOT_DOM_ID,
-      mediaTypes: {
-        banner: {
-          sizes: getVerticalAdSizes()
-        }
-      },
-      bids: [
-        {
-          bidder: 'sonobi',
-          params: {
-            dom_id: VERTICAL_AD_SLOT_DOM_ID,
-            ad_unit: VERTICAL_AD_UNIT_ID
-          }
-        },
-        {
-          bidder: 'pulsepoint',
-          params: {
-            cf: '300X250',
-            cp: '560174',
-            ct: '460982'
-          }
-        },
-        // {
-        //   bidder: 'aol',
-        //   params: {
-        //     network: '10559.1',
-        //     placement: '4117692',
-        //     alias: 'desktop_newtab_300x250',
-        //     sizeId: '170'
-        //   }
-        // },
-        {
-          bidder: 'sovrn',
-          params: {
-            tagid: '438916'
-          }
-        },
-        {
-          bidder: 'openx',
-          params: {
-            unit: '538658529',
-            delDomain: 'tabforacause-d.openx.net'
-          }
-        },
-        {
-          bidder: 'brealtime',
-          params: {
-            placementId: '10955690'
-          }
-        }
-        // {
-        //   bidder: 'rhythmone',
-        //   params: {
-        //     placementId: '73423'
-        //   }
-        // }
-      ]
-    },
-    {
-      code: SECOND_VERTICAL_AD_SLOT_DOM_ID,
-      mediaTypes: {
-        banner: {
-          sizes: getVerticalAdSizes()
-        }
-      },
-      bids: [
-        {
-          bidder: 'aol',
-          params: {
-            network: '10559.1',
-            placement: '4117692',
-            alias: 'desktop_newtab_300x250',
-            sizeId: '170'
-          }
-        },
-        {
-          bidder: 'rhythmone',
-          params: {
-            placementId: '73423'
-          }
-        }
-      ]
-    },
-    {
-      code: HORIZONTAL_AD_SLOT_DOM_ID,
-      mediaTypes: {
-        banner: {
-          sizes: getHorizontalAdSizes()
-        }
-      },
-      bids: [
-        {
-          bidder: 'sonobi',
-          params: {
-            dom_id: HORIZONTAL_AD_SLOT_DOM_ID,
-            ad_unit: HORIZONTAL_AD_UNIT_ID
-          }
-        },
-        {
-          bidder: 'pulsepoint',
-          params: {
-            cf: '728X90',
-            cp: '560174',
-            ct: '460981'
-          }
-        },
-        {
-          bidder: 'aol',
-          params: {
-            network: '10559.1',
-            placement: '4117691',
-            alias: 'desktop_newtab_728x90',
-            sizeId: '225'
-          }
-        },
-        {
-          bidder: 'sovrn',
-          params: {
-            tagid: '438918'
-          }
-        },
-        {
-          bidder: 'openx',
-          params: {
-            unit: '538658529',
-            delDomain: 'tabforacause-d.openx.net'
-          }
-        },
-        {
-          bidder: 'brealtime',
-          params: {
-            placementId: '10955287'
-          }
-        },
-        {
-          bidder: 'rhythmone',
-          params: {
-            placementId: '73423'
-          }
-        }
-      ]
-    }]
+    const adUnits = getAdUnits()
 
     const pbjs = getPrebidPbjs()
 
@@ -208,6 +283,8 @@ export default () => {
 
       pbjs.addAdUnits(adUnits)
 
+      // Note: brealtime is automatically aliased by the
+      // AppNexus bid adapter.
       pbjs.bidderSettings = {
         aol: {
         // AOL sends gross CPM.

--- a/web/src/js/ads/prebid/prebidConfig.js
+++ b/web/src/js/ads/prebid/prebidConfig.js
@@ -7,6 +7,7 @@ import {
   CONSENT_MANAGEMENT_TIMEOUT,
   VERTICAL_AD_UNIT_ID,
   VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
   HORIZONTAL_AD_UNIT_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
 } from 'js/ads/adSettings'
@@ -56,15 +57,15 @@ export default () => {
             ct: '460982'
           }
         },
-        {
-          bidder: 'aol',
-          params: {
-            network: '10559.1',
-            placement: '4117692',
-            alias: 'desktop_newtab_300x250',
-            sizeId: '170'
-          }
-        },
+        // {
+        //   bidder: 'aol',
+        //   params: {
+        //     network: '10559.1',
+        //     placement: '4117692',
+        //     alias: 'desktop_newtab_300x250',
+        //     sizeId: '170'
+        //   }
+        // },
         {
           bidder: 'sovrn',
           params: {
@@ -82,6 +83,31 @@ export default () => {
           bidder: 'brealtime',
           params: {
             placementId: '10955690'
+          }
+        }
+        // {
+        //   bidder: 'rhythmone',
+        //   params: {
+        //     placementId: '73423'
+        //   }
+        // }
+      ]
+    },
+    {
+      code: SECOND_VERTICAL_AD_SLOT_DOM_ID,
+      mediaTypes: {
+        banner: {
+          sizes: getVerticalAdSizes()
+        }
+      },
+      bids: [
+        {
+          bidder: 'aol',
+          params: {
+            network: '10559.1',
+            placement: '4117692',
+            alias: 'desktop_newtab_300x250',
+            sizeId: '170'
           }
         },
         {

--- a/web/src/js/ads/prebid/prebidConfig.js
+++ b/web/src/js/ads/prebid/prebidConfig.js
@@ -156,30 +156,15 @@ const getAdUnits = () => {
         }
       },
       {
-        bidder: 'pulsepoint',
+        bidder: 'brealtime',
         params: {
-          cf: '300X250',
-          cp: '560174',
-          ct: '460982'
+          placementId: '10955690'
         }
       },
       {
         bidder: 'sovrn',
         params: {
           tagid: '438916'
-        }
-      },
-      {
-        bidder: 'openx',
-        params: {
-          unit: '538658529',
-          delDomain: 'tabforacause-d.openx.net'
-        }
-      },
-      {
-        bidder: 'brealtime',
-        params: {
-          placementId: '10955690'
         }
       }
     ]
@@ -208,6 +193,21 @@ const getAdUnits = () => {
         bidder: 'rhythmone',
         params: {
           placementId: '73423'
+        }
+      },
+      {
+        bidder: 'pulsepoint',
+        params: {
+          cf: '300X250',
+          cp: '560174',
+          ct: '460982'
+        }
+      },
+      {
+        bidder: 'openx',
+        params: {
+          unit: '538658529',
+          delDomain: 'tabforacause-d.openx.net'
         }
       }
     ]

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -36,6 +36,7 @@ import {
 } from 'js/navigation/navigation'
 import {
   VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
 } from 'js/ads/adSettings'
 
@@ -300,6 +301,22 @@ class Dashboard extends React.Component {
           component that's absolutely positioned, then use flex positioning
           for the ads themselves. This will avoid awkward gaps.
         */}
+        <Ad
+          adId={SECOND_VERTICAL_AD_SLOT_DOM_ID}
+          style={{
+            position: 'absolute',
+            bottom: 270,
+            right: 10,
+            minWidth: 300,
+            overflow: 'visible',
+            display: 'block'
+          }}
+          adWrapperStyle={{
+            position: 'absolute',
+            bottom: 0,
+            right: 0
+          }}
+        />
         <Ad
           adId={VERTICAL_AD_SLOT_DOM_ID}
           style={{

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -35,6 +35,7 @@ import {
   loginURL
 } from 'js/navigation/navigation'
 import {
+  getNumberOfAdsToShow,
   VERTICAL_AD_SLOT_DOM_ID,
   SECOND_VERTICAL_AD_SLOT_DOM_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
@@ -52,7 +53,8 @@ class Dashboard extends React.Component {
       // This may be false if the user cleared their storage,
       // which is why we only show the tour to recently-joined
       // users.
-      userAlreadyViewedNewUserTour: localStorageMgr.getItem(STORAGE_NEW_USER_HAS_COMPLETED_TOUR) === 'true'
+      userAlreadyViewedNewUserTour: localStorageMgr.getItem(STORAGE_NEW_USER_HAS_COMPLETED_TOUR) === 'true',
+      numAdsToShow: getNumberOfAdsToShow()
     }
   }
 
@@ -301,54 +303,66 @@ class Dashboard extends React.Component {
           component that's absolutely positioned, then use flex positioning
           for the ads themselves. This will avoid awkward gaps.
         */}
-        <Ad
-          adId={SECOND_VERTICAL_AD_SLOT_DOM_ID}
-          style={{
-            position: 'absolute',
-            bottom: 270,
-            right: 10,
-            minWidth: 300,
-            overflow: 'visible',
-            display: 'block'
-          }}
-          adWrapperStyle={{
-            position: 'absolute',
-            bottom: 0,
-            right: 0
-          }}
-        />
-        <Ad
-          adId={VERTICAL_AD_SLOT_DOM_ID}
-          style={{
-            position: 'absolute',
-            bottom: 10,
-            right: 10,
-            minWidth: 300,
-            overflow: 'visible',
-            display: 'block'
-          }}
-          adWrapperStyle={{
-            position: 'absolute',
-            bottom: 0,
-            right: 0
-          }}
-        />
-        <Ad
-          adId={HORIZONTAL_AD_SLOT_DOM_ID}
-          style={{
-            position: 'absolute',
-            bottom: 10,
-            right: 320,
-            minWidth: 728,
-            overflow: 'visible',
-            display: 'block'
-          }}
-          adWrapperStyle={{
-            position: 'absolute',
-            bottom: 0,
-            right: 0
-          }}
-        />
+        {
+          this.state.numAdsToShow > 2
+            ? <Ad
+              adId={SECOND_VERTICAL_AD_SLOT_DOM_ID}
+              style={{
+                position: 'absolute',
+                bottom: 270,
+                right: 10,
+                minWidth: 300,
+                overflow: 'visible',
+                display: 'block'
+              }}
+              adWrapperStyle={{
+                position: 'absolute',
+                bottom: 0,
+                right: 0
+              }}
+            />
+            : null
+        }
+        {
+          this.state.numAdsToShow > 1
+            ? <Ad
+              adId={VERTICAL_AD_SLOT_DOM_ID}
+              style={{
+                position: 'absolute',
+                bottom: 10,
+                right: 10,
+                minWidth: 300,
+                overflow: 'visible',
+                display: 'block'
+              }}
+              adWrapperStyle={{
+                position: 'absolute',
+                bottom: 0,
+                right: 0
+              }}
+            />
+            : null
+        }
+        {
+          this.state.numAdsToShow > 0
+            ? <Ad
+              adId={HORIZONTAL_AD_SLOT_DOM_ID}
+              style={{
+                position: 'absolute',
+                bottom: 10,
+                right: 320,
+                minWidth: 728,
+                overflow: 'visible',
+                display: 'block'
+              }}
+              adWrapperStyle={{
+                position: 'absolute',
+                bottom: 0,
+                right: 0
+              }}
+            />
+            : null
+        }
         { user && tabId ? <LogTab user={user} tabId={tabId} /> : null }
         { user && tabId ? <LogRevenue user={user} tabId={tabId} /> : null }
         { user ? <LogConsentData user={user} /> : null }

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -27,11 +27,18 @@ import Button from '@material-ui/core/Button'
 import {
   goTo
 } from 'js/navigation/navigation'
+import {
+  getNumberOfAdsToShow,
+  VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
+  HORIZONTAL_AD_SLOT_DOM_ID
+} from 'js/ads/adSettings'
 
 jest.mock('js/analytics/logEvent')
 jest.mock('js/utils/localstorage-mgr')
 jest.mock('js/authentication/user')
 jest.mock('js/navigation/navigation')
+jest.mock('js/ads/adSettings')
 
 const mockNow = '2018-05-15T10:30:00.000'
 
@@ -105,15 +112,56 @@ describe('Dashboard component', () => {
     expect(wrapper.find(CampaignBaseContainer).length).toBe(1)
   })
 
-  it('renders Ad components', () => {
+  it('does not render any ad components when 0 ads are enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(0)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+    expect(wrapper.find(Ad).length).toBe(0)
+  })
+
+  it('renders the expected 1 ad component when 1 ad is enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(1)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+    expect(wrapper.find(Ad).length).toBe(1)
+    const leaderboardAd = wrapper.find(Ad).at(0)
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+  })
+
+  it('renders the expected 2 ad components when 2 ads are enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(2)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+    expect(wrapper.find(Ad).length).toBe(2)
+    const rectangleAd = wrapper.find(Ad).at(0)
+    const leaderboardAd = wrapper.find(Ad).at(1)
+    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+  })
+
+  it('renders the expected 3 ad components when 3 ads are enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(3)
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
     const wrapper = shallow(
       <DashboardComponent {...mockProps} />
     )
     expect(wrapper.find(Ad).length).toBe(3)
+    const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
+    const rectangleAd = wrapper.find(Ad).at(1)
+    const leaderboardAd = wrapper.find(Ad).at(2)
+    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
+    expect(rectangleAdNumberTwo.prop('adId')).toBe(SECOND_VERTICAL_AD_SLOT_DOM_ID)
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
   })
 
   it('the ads have expected IDs matched with their sizes', () => {
+    getNumberOfAdsToShow.mockReturnValue(3)
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
     const wrapper = shallow(
       <DashboardComponent {...mockProps} />
@@ -121,11 +169,11 @@ describe('Dashboard component', () => {
     const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
     const rectangleAd = wrapper.find(Ad).at(1)
     const leaderboardAd = wrapper.find(Ad).at(2)
-    expect(rectangleAd.prop('adId')).toBe('div-gpt-ad-1464385742501-0')
+    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
     expect(rectangleAd.prop('style').minWidth).toBe(300)
-    expect(rectangleAdNumberTwo.prop('adId')).toBe('div-gpt-ad-1539903223131-0')
+    expect(rectangleAdNumberTwo.prop('adId')).toBe(SECOND_VERTICAL_AD_SLOT_DOM_ID)
     expect(rectangleAdNumberTwo.prop('style').minWidth).toBe(300)
-    expect(leaderboardAd.prop('adId')).toBe('div-gpt-ad-1464385677836-0')
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
     expect(leaderboardAd.prop('style').minWidth).toBe(728)
   })
 

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -110,7 +110,7 @@ describe('Dashboard component', () => {
     const wrapper = shallow(
       <DashboardComponent {...mockProps} />
     )
-    expect(wrapper.find(Ad).length).toBe(2)
+    expect(wrapper.find(Ad).length).toBe(3)
   })
 
   it('the ads have expected IDs matched with their sizes', () => {
@@ -118,10 +118,13 @@ describe('Dashboard component', () => {
     const wrapper = shallow(
       <DashboardComponent {...mockProps} />
     )
-    const rectangleAd = wrapper.find(Ad).at(0)
-    const leaderboardAd = wrapper.find(Ad).at(1)
+    const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
+    const rectangleAd = wrapper.find(Ad).at(1)
+    const leaderboardAd = wrapper.find(Ad).at(2)
     expect(rectangleAd.prop('adId')).toBe('div-gpt-ad-1464385742501-0')
     expect(rectangleAd.prop('style').minWidth).toBe(300)
+    expect(rectangleAdNumberTwo.prop('adId')).toBe('div-gpt-ad-1539903223131-0')
+    expect(rectangleAdNumberTwo.prop('style').minWidth).toBe(300)
     expect(leaderboardAd.prop('adId')).toBe('div-gpt-ad-1464385677836-0')
     expect(leaderboardAd.prop('style').minWidth).toBe(728)
   })

--- a/web/src/js/utils/__tests__/feature-flags.test.js
+++ b/web/src/js/utils/__tests__/feature-flags.test.js
@@ -34,4 +34,10 @@ describe('feature flags', () => {
       .isVariousAdSizesEnabled
     expect(isVariousAdSizesEnabled()).toBe(false)
   })
+
+  test('isThirdAdEnabled is true', () => {
+    const isThirdAdEnabled = require('js/utils/feature-flags')
+      .isThirdAdEnabled
+    expect(isThirdAdEnabled()).toBe(true)
+  })
 })

--- a/web/src/js/utils/__tests__/feature-flags.test.js
+++ b/web/src/js/utils/__tests__/feature-flags.test.js
@@ -29,9 +29,9 @@ describe('feature flags', () => {
     expect(isAnonymousUserSignInEnabled()).toBe(false)
   })
 
-  test('isVariousAdSizesEnabled is true', () => {
+  test('isVariousAdSizesEnabled is false', () => {
     const isVariousAdSizesEnabled = require('js/utils/feature-flags')
       .isVariousAdSizesEnabled
-    expect(isVariousAdSizesEnabled()).toBe(true)
+    expect(isVariousAdSizesEnabled()).toBe(false)
   })
 })

--- a/web/src/js/utils/__tests__/feature-flags.test.js
+++ b/web/src/js/utils/__tests__/feature-flags.test.js
@@ -35,9 +35,9 @@ describe('feature flags', () => {
     expect(isVariousAdSizesEnabled()).toBe(false)
   })
 
-  test('isThirdAdEnabled is true', () => {
+  test('isThirdAdEnabled is false', () => {
     const isThirdAdEnabled = require('js/utils/feature-flags')
       .isThirdAdEnabled
-    expect(isThirdAdEnabled()).toBe(true)
+    expect(isThirdAdEnabled()).toBe(false)
   })
 })

--- a/web/src/js/utils/feature-flags.js
+++ b/web/src/js/utils/feature-flags.js
@@ -7,4 +7,4 @@ export const isAnonymousUserSignInEnabled = () => {
 }
 
 // @experiment-various-ad-sizes
-export const isVariousAdSizesEnabled = () => true
+export const isVariousAdSizesEnabled = () => false

--- a/web/src/js/utils/feature-flags.js
+++ b/web/src/js/utils/feature-flags.js
@@ -8,3 +8,6 @@ export const isAnonymousUserSignInEnabled = () => {
 
 // @experiment-various-ad-sizes
 export const isVariousAdSizesEnabled = () => false
+
+// @experiment-third-ad
+export const isThirdAdEnabled = () => true

--- a/web/src/js/utils/feature-flags.js
+++ b/web/src/js/utils/feature-flags.js
@@ -10,4 +10,4 @@ export const isAnonymousUserSignInEnabled = () => {
 export const isVariousAdSizesEnabled = () => false
 
 // @experiment-third-ad
-export const isThirdAdEnabled = () => true
+export const isThirdAdEnabled = () => false


### PR DESCRIPTION
* Add support for a 3rd rectangle ad (which is disabled by feature flag)
* Disable the "various ad sizes" test
* Centralize logic for showing a various number of ads