### PR TITLE
Set up third ad experiment

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -203,6 +203,17 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
           VARIOUS: { value: experimentConfig.variousAdSizes.VARIOUS }
         }
       })
+    },
+    thirdAd: {
+      type: new GraphQLEnumType({
+        name: 'ExperimentGroupThirdAd',
+        description: 'The test of enabling a third ad',
+        values: {
+          NONE: { value: experimentConfig.thirdAd.NONE },
+          TWO_ADS: { value: experimentConfig.thirdAd.TWO_ADS },
+          THREE_ADS: { value: experimentConfig.thirdAd.THREE_ADS }
+        }
+      })
     }
   }
 })

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -166,7 +166,10 @@ class User extends BaseModel {
           split-test. This value is assigned on the client so is not trustworthy.`),
       testGroupVariousAdSizes: types.number().integer().allow(null)
         .description(`Which group the user is in for the "various ad sizes"
-          split-test. This value is assigned on the client so is not trustworthy.`)
+          split-test. This value is assigned on the client so is not trustworthy.`),
+      testGroupThirdAd: types.number().integer().allow(null)
+        .description(`Which group the user is in for the "three ads" split-test. 
+          This value is assigned on the client so is not trustworthy.`)
     }
   }
 

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -46,6 +46,10 @@ const logUserExperimentGroups = async (userContext, userId, experimentGroups = {
     !isNil(validatedGroups.variousAdSizes) ? {
       testGroupVariousAdSizes: validatedGroups.variousAdSizes
     }
+      : null,
+    !isNil(validatedGroups.thirdAd) ? {
+      testGroupThirdAd: validatedGroups.thirdAd
+    }
       : null
   )
   try {

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -14,6 +14,12 @@ const experimentConfig = {
     NONE: 0,
     STANDARD: 1,
     VARIOUS: 2
+  },
+  // @experiment-third-ad
+  thirdAd: {
+    NONE: 0,
+    TWO_ADS: 1,
+    THREE_ADS: 2
   }
 }
 

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -170,6 +170,14 @@ enum ExperimentGroupAnonSignIn {
 input ExperimentGroups {
   anonSignIn: ExperimentGroupAnonSignIn
   variousAdSizes: ExperimentGroupVariousAdSizes
+  thirdAd: ExperimentGroupThirdAd
+}
+
+"""The test of enabling a third ad"""
+enum ExperimentGroupThirdAd {
+  NONE
+  TWO_ADS
+  THREE_ADS
 }
 
 """The test of enabling many different ad sizes"""

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -4,8 +4,12 @@ import {
   isThirdAdEnabled,
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
+import {
+  getUserExperimentGroup
+} from 'js/utils/experiments'
 
 jest.mock('js/utils/feature-flags')
+jest.mock('js/utils/experiments')
 
 describe('ad settings', () => {
   test('ad IDs and ad slot IDs are as expected', () => {
@@ -29,8 +33,16 @@ describe('ad settings', () => {
     expect(getNumberOfAdsToShow()).toEqual(2)
   })
 
-  test('getNumberOfAdsToShow returns 3 when the "3rd ad" feature is enabled', () => {
+  test('getNumberOfAdsToShow returns 2 when the "3rd ad" feature is enabled but the user is not in the "3 ad" test group', () => {
+    isThirdAdEnabled.mockReturnValue(false)
+    getUserExperimentGroup.mockReturnValue('twoAds')
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(2)
+  })
+
+  test('getNumberOfAdsToShow returns 3 when the "3rd ad" feature is enabled and the user is in the "3 ad" test group', () => {
     isThirdAdEnabled.mockReturnValue(true)
+    getUserExperimentGroup.mockReturnValue('threeAds')
     const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
     expect(getNumberOfAdsToShow()).toEqual(3)
   })

--- a/web/src/js/ads/adSettings.js
+++ b/web/src/js/ads/adSettings.js
@@ -3,6 +3,11 @@ import {
   isThirdAdEnabled,
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
+import {
+  EXPERIMENT_THIRD_AD,
+  getExperimentGroups,
+  getUserExperimentGroup
+} from 'js/utils/experiments'
 
 // Time to wait for the entire ad auction before
 // calling the ad server.
@@ -35,7 +40,11 @@ export const HORIZONTAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385677836-0'
  * @return {Number} The number of ads
  */
 export const getNumberOfAdsToShow = () => {
-  return isThirdAdEnabled() ? 3 : 2
+  const userInThreeAdTestGroup = (
+    getUserExperimentGroup(EXPERIMENT_THIRD_AD) ===
+    getExperimentGroups(EXPERIMENT_THIRD_AD).THREE_ADS
+  )
+  return (userInThreeAdTestGroup && isThirdAdEnabled()) ? 3 : 2
 }
 
 /**

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -61,6 +61,9 @@ export const STORAGE_EXTENSION_INSTALL_ID = 'tab.newUser.extensionInstallId'
 export const STORAGE_APPROX_EXTENSION_INSTALL_TIME = 'tab.newUser.approxInstallTime'
 
 // tab.experiments: values related to split-testing features
+// We may assign other values to localStorage with the tab.experiments.*
+// prefix in experiments.js.
+export const STORAGE_EXPERIMENT_PREFIX = 'tab.experiments'
 export const STORAGE_EXPERIMENT_ANON_USER = 'tab.experiments.anonUser'
 export const STORAGE_EXPERIMENT_VARIOUS_AD_SIZES = 'tab.experiments.variousAdSizes'
 

--- a/web/src/js/utils/__mocks__/experiments.js
+++ b/web/src/js/utils/__mocks__/experiments.js
@@ -1,0 +1,8 @@
+/* eslint-env jest */
+
+// Only mock some specific functions.
+const experimentsActual = require.requireActual('js/utils/experiments')
+experimentsActual.getUserExperimentGroup = jest.fn(() => 'none')
+experimentsActual.assignUserToTestGroups = jest.fn()
+experimentsActual.getUserTestGroupsForMutation = jest.fn(() => {})
+module.exports = experimentsActual

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -56,7 +56,7 @@ describe('Experiment and ExperimentGroup objects', () => {
         })
       }
     })
-    expect(experiment.getTestGroup()).toEqual('none')
+    expect(experiment.getTestGroup().value).toEqual('none')
   })
 
   test('returns the experiment test group when the experiment is not disabled', () => {
@@ -80,7 +80,7 @@ describe('Experiment and ExperimentGroup objects', () => {
         })
       }
     })
-    expect(experiment.getTestGroup()).toEqual('newThing')
+    expect(experiment.getTestGroup().value).toEqual('newThing')
   })
 
   test('returns the "none" test group when the experiment value in local storage is invalid', () => {
@@ -104,7 +104,7 @@ describe('Experiment and ExperimentGroup objects', () => {
         })
       }
     })
-    expect(experiment.getTestGroup()).toEqual('none')
+    expect(experiment.getTestGroup().value).toEqual('none')
   })
 
   test('does not assign the user to a test group when the experiment is inactive', () => {
@@ -479,6 +479,65 @@ describe('Main experiments functionality', () => {
     expect(experimentsExports.getUserExperimentGroup('exampleTest')).toBe('hi')
     expect(experimentsExports.getUserExperimentGroup('someTest')).toBe('none')
     expect(experimentsExports.getUserExperimentGroup('fooTest')).toBe('sameOld')
+  })
+
+  test('getUserTestGroupsForMutation returns the expected values for all tests (even inactive tests)', () => {
+    const experimentsExports = require('js/utils/experiments')
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'exampleTest',
+        active: true,
+        disabled: false,
+        groups: {
+          SOMETHING: experimentsExports.createExperimentGroup({
+            value: 'hi',
+            schemaValue: 'SOMETHING'
+          }),
+          ANOTHER_THING: experimentsExports.createExperimentGroup({
+            value: 'bye',
+            schemaValue: 'ANOTHER_THING'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'someTest',
+        active: false,
+        disabled: false,
+        groups: {
+          GROUP_A: experimentsExports.createExperimentGroup({
+            value: 'groupA',
+            schemaValue: 'THE_A_GROUP'
+          }),
+          GROUP_B: experimentsExports.createExperimentGroup({
+            value: 'groupB',
+            schemaValue: 'THE_B_GROUP'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: false,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+    experimentsExports.assignUserToTestGroups()
+    const userGroupsForMutation = experimentsExports.getUserTestGroupsForMutation()
+    expect(userGroupsForMutation).toEqual({
+      exampleTest: 'SOMETHING',
+      someTest: 'NONE',
+      fooTest: 'THE_CONTROL'
+    })
   })
 })
 

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import {
+import localStorageMgr, {
   __mockClear
 } from 'js/utils/localstorage-mgr'
 
@@ -12,7 +12,202 @@ afterEach(() => {
 })
 
 describe('experiments', () => {
-  /* Tests for all experiments */
+  /* Tests for the Experiment and ExperimentGroup objects */
+
+  test('createExperiment returns an object with expected shape', () => {
+    const createExperiment = require('js/utils/experiments').createExperiment
+    const experiment = createExperiment({
+      name: 'fooTest'
+    })
+    expect(experiment).toMatchObject({
+      name: 'fooTest',
+      active: false,
+      disabled: false,
+      groups: {
+        NONE: {
+          value: 'none',
+          schemaValue: 'NONE'
+        }
+      },
+      localStorageKey: 'tab.experiments.fooTest',
+
+      saveTestGroupToLocalStorage: expect.any(Function),
+      assignTestGroup: expect.any(Function),
+      getTestGroup: expect.any(Function)
+    })
+  })
+
+  test('returns the "none" test group when the experiment is disabled', () => {
+    const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
+
+    // Mock that the user is assigned to an experiment group.
+    localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
+
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: true,
+      disabled: true,
+      groups: {
+        MY_CONTROL_GROUP: createExperimentGroup({
+          value: 'sameOld',
+          schemaValue: 'THE_CONTROL'
+        }),
+        FUN_EXPERIMENT: createExperimentGroup({
+          value: 'newThing',
+          schemaValue: 'EXPERIMENT'
+        })
+      }
+    })
+    expect(experiment.getTestGroup()).toEqual('none')
+  })
+
+  test('returns the experiment test group when the experiment is not disabled', () => {
+    const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
+
+    // Mock that the user is assigned to an experimental group.
+    localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
+
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: true,
+      disabled: false,
+      groups: {
+        MY_CONTROL_GROUP: createExperimentGroup({
+          value: 'sameOld',
+          schemaValue: 'THE_CONTROL'
+        }),
+        FUN_EXPERIMENT: createExperimentGroup({
+          value: 'newThing',
+          schemaValue: 'EXPERIMENT'
+        })
+      }
+    })
+    expect(experiment.getTestGroup()).toEqual('newThing')
+  })
+
+  test('returns the "none" test group when the experiment value in local storage is invalid', () => {
+    const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
+
+    // Invalid local storage value
+    localStorageMgr.setItem('tab.experiments.fooTest', 'not-a-valid-group')
+
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: true,
+      disabled: false,
+      groups: {
+        MY_CONTROL_GROUP: createExperimentGroup({
+          value: 'sameOld',
+          schemaValue: 'THE_CONTROL'
+        }),
+        FUN_EXPERIMENT: createExperimentGroup({
+          value: 'newThing',
+          schemaValue: 'EXPERIMENT'
+        })
+      }
+    })
+    expect(experiment.getTestGroup()).toEqual('none')
+  })
+
+  test('does not assign the user to a test group when the experiment is inactive', () => {
+    const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: false,
+      disabled: false,
+      groups: {
+        MY_CONTROL_GROUP: createExperimentGroup({
+          value: 'sameOld',
+          schemaValue: 'THE_CONTROL'
+        }),
+        FUN_EXPERIMENT: createExperimentGroup({
+          value: 'newThing',
+          schemaValue: 'EXPERIMENT'
+        })
+      }
+    })
+
+    // Control for randomness.
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+
+    experiment.assignTestGroup()
+    expect(localStorageMgr.setItem).not.toHaveBeenCalled()
+  })
+
+  test('saves a test group to local storage when assigning a test group', () => {
+    const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: true,
+      disabled: false,
+      groups: {
+        MY_CONTROL_GROUP: createExperimentGroup({
+          value: 'sameOld',
+          schemaValue: 'THE_CONTROL'
+        }),
+        FUN_EXPERIMENT: createExperimentGroup({
+          value: 'newThing',
+          schemaValue: 'EXPERIMENT'
+        })
+      }
+    })
+
+    // Control for randomness.
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+
+    experiment.assignTestGroup()
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.experiments.fooTest', 'sameOld')
+  })
+
+  test('selects from all the test groups when assigning the user to a test group', () => {
+    const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: true,
+      disabled: false,
+      groups: {
+        MY_CONTROL_GROUP: createExperimentGroup({
+          value: 'sameOld',
+          schemaValue: 'THE_CONTROL'
+        }),
+        FUN_EXPERIMENT: createExperimentGroup({
+          value: 'newThing',
+          schemaValue: 'EXPERIMENT'
+        }),
+        CRAZY_EXPERIMENT: createExperimentGroup({
+          value: 'crazyThing',
+          schemaValue: 'WOWOWOW'
+        })
+      }
+    })
+
+    // Control for randomness, picking the last group value.
+    jest.spyOn(Math, 'random').mockReturnValue(0.99)
+
+    experiment.assignTestGroup()
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.experiments.fooTest', 'crazyThing')
+  })
+
+  test('assigns the "none" test group when there are no other groups', () => {
+    const { createExperiment } = require('js/utils/experiments')
+    const experiment = createExperiment({
+      name: 'fooTest',
+      active: true,
+      disabled: false,
+      groups: {}
+    })
+
+    // Control for randomness.
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+
+    experiment.assignTestGroup()
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.experiments.fooTest', 'none')
+  })
+
+  /* Tests for active experiments */
 
   test('assignUserToTestGroups saves the user\'s test groups to localStorage', () => {
     // // Control for randomness.

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -344,6 +344,79 @@ describe('experiments', () => {
       .toBe('none')
   })
 
+  test('getExperimentGroups returns the expected values', () => {
+    const experimentsExports = require('js/utils/experiments')
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'exampleTest',
+        active: true,
+        disabled: false,
+        groups: {
+          SOMETHING: experimentsExports.createExperimentGroup({
+            value: 'hi',
+            schemaValue: 'SOMETHING'
+          }),
+          ANOTHER_THING: experimentsExports.createExperimentGroup({
+            value: 'bye',
+            schemaValue: 'ANOTHER_THING'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: true,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    expect(experimentsExports.getExperimentGroups('fooTest'))
+      .toEqual({
+        MY_CONTROL_GROUP: 'sameOld',
+        FUN_EXPERIMENT: 'newThing',
+        NONE: 'none'
+      })
+    expect(experimentsExports.getExperimentGroups('exampleTest'))
+      .toEqual({
+        SOMETHING: 'hi',
+        ANOTHER_THING: 'bye',
+        NONE: 'none'
+      })
+  })
+
+  test('getExperimentGroups returns only the "none" group when the experiment does not exist', () => {
+    const experimentsExports = require('js/utils/experiments')
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: true,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    expect(experimentsExports.getExperimentGroups('thisExperimentDoesNotExist'))
+      .toEqual({
+        NONE: 'none'
+      })
+  })
+
   /* Tests for actual experiments */
 
   test('assignUserToTestGroups saves the user\'s test groups to localStorage', () => {

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -38,6 +38,25 @@ describe('Experiment and ExperimentGroup objects', () => {
     })
   })
 
+  test('createExperiment throws if a name is not provided', () => {
+    const createExperiment = require('js/utils/experiments').createExperiment
+    expect(() => {
+      createExperiment({
+        active: true
+      })
+    }).toThrow()
+  })
+
+  test('createExperimentGroup throws if missing a required key', () => {
+    const { createExperimentGroup } = require('js/utils/experiments')
+    expect(() => {
+      createExperimentGroup({
+        // Missing "value" key
+        schemaValue: 'blah'
+      })
+    }).toThrow()
+  })
+
   test('returns the "none" test group when the experiment is disabled', () => {
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
 
@@ -214,8 +233,6 @@ describe('Experiment and ExperimentGroup objects', () => {
     expect(localStorageMgr.setItem)
       .toHaveBeenCalledWith('tab.experiments.fooTest', 'none')
   })
-
-  // TODO: test validation throws
 })
 
 /* Test core functionality with fake experiments */

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -64,7 +64,7 @@ describe('experiments', () => {
   test('returns the experiment test group when the experiment is not disabled', () => {
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
 
-    // Mock that the user is assigned to an experimental group.
+    // Mock that the user is assigned to an experiment group.
     localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
 
     const experiment = createExperiment({
@@ -207,7 +207,144 @@ describe('experiments', () => {
       .toHaveBeenCalledWith('tab.experiments.fooTest', 'none')
   })
 
-  /* Tests for active experiments */
+  // TODO: test validation throws
+
+  /* Test functionality for fake experiments */
+
+  test('getUserExperimentGroup returns the expected value', () => {
+    const experimentsExports = require('js/utils/experiments')
+
+    // Mock that the user is assigned to an experiment group.
+    localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
+
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'exampleTest',
+        active: true,
+        disabled: false,
+        groups: {
+          SOMETHING: experimentsExports.createExperimentGroup({
+            value: 'hi',
+            schemaValue: 'SOMETHING'
+          }),
+          ANOTHER_THING: experimentsExports.createExperimentGroup({
+            value: 'bye',
+            schemaValue: 'ANOTHER_THING'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: false,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    expect(experimentsExports.getUserExperimentGroup('fooTest'))
+      .toBe('newThing')
+  })
+
+  test('getUserExperimentGroup returns "none" when the experiment does not exist', () => {
+    const experimentsExports = require('js/utils/experiments')
+
+    // Mock that the user is assigned to an experiment group.
+    localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
+
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'exampleTest',
+        active: true,
+        disabled: false,
+        groups: {
+          SOMETHING: experimentsExports.createExperimentGroup({
+            value: 'hi',
+            schemaValue: 'SOMETHING'
+          }),
+          ANOTHER_THING: experimentsExports.createExperimentGroup({
+            value: 'bye',
+            schemaValue: 'ANOTHER_THING'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: false,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    expect(experimentsExports.getUserExperimentGroup('someNonexistentTest'))
+      .toBe('none')
+  })
+
+  test('getUserExperimentGroup returns "none" when the experiment is disabled', () => {
+    const experimentsExports = require('js/utils/experiments')
+
+    // Mock that the user is assigned to an experiment group.
+    localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
+
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'exampleTest',
+        active: true,
+        disabled: false,
+        groups: {
+          SOMETHING: experimentsExports.createExperimentGroup({
+            value: 'hi',
+            schemaValue: 'SOMETHING'
+          }),
+          ANOTHER_THING: experimentsExports.createExperimentGroup({
+            value: 'bye',
+            schemaValue: 'ANOTHER_THING'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: true,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    expect(experimentsExports.getUserExperimentGroup('fooTest'))
+      .toBe('none')
+  })
+
+  test('getUserExperimentGroup returns "none" when there are no experiments', () => {
+    const experimentsExports = require('js/utils/experiments')
+    experimentsExports.experiments = []
+    expect(experimentsExports.getUserExperimentGroup('anOldTestWeRemoved'))
+      .toBe('none')
+  })
+
+  /* Tests for actual experiments */
 
   test('assignUserToTestGroups saves the user\'s test groups to localStorage', () => {
     // // Control for randomness.

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -10,10 +10,8 @@ afterEach(() => {
   __mockClear()
   jest.clearAllMocks()
 })
-
-describe('experiments', () => {
-  /* Tests for the Experiment and ExperimentGroup objects */
-
+/* Tests for the Experiment and ExperimentGroup objects */
+describe('Experiment and ExperimentGroup objects', () => {
   test('createExperiment returns an object with expected shape', () => {
     const createExperiment = require('js/utils/experiments').createExperiment
     const experiment = createExperiment({
@@ -208,9 +206,10 @@ describe('experiments', () => {
   })
 
   // TODO: test validation throws
+})
 
-  /* Test functionality for fake experiments */
-
+/* Test core functionality with fake experiments */
+describe('Main experiments functionality', () => {
   test('getUserExperimentGroup returns the expected value', () => {
     const experimentsExports = require('js/utils/experiments')
 
@@ -416,9 +415,10 @@ describe('experiments', () => {
         NONE: 'none'
       })
   })
+})
 
-  /* Tests for actual experiments */
-
+/* Tests for actual experiments */
+describe('Actual experiments we are running or will run', () => {
   test('assignUserToTestGroups saves the user\'s test groups to localStorage', () => {
     // // Control for randomness.
     // jest.spyOn(Math, 'random').mockReturnValue(0)

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -415,6 +415,71 @@ describe('Main experiments functionality', () => {
         NONE: 'none'
       })
   })
+
+  test('assignUserToTestGroups assigns the user to all active tests but not inactive tests', () => {
+    const experimentsExports = require('js/utils/experiments')
+    experimentsExports.experiments = [
+      experimentsExports.createExperiment({
+        name: 'exampleTest',
+        active: true,
+        disabled: false,
+        groups: {
+          SOMETHING: experimentsExports.createExperimentGroup({
+            value: 'hi',
+            schemaValue: 'SOMETHING'
+          }),
+          ANOTHER_THING: experimentsExports.createExperimentGroup({
+            value: 'bye',
+            schemaValue: 'ANOTHER_THING'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'someTest',
+        active: false,
+        disabled: false,
+        groups: {
+          GROUP_A: experimentsExports.createExperimentGroup({
+            value: 'groupA',
+            schemaValue: 'THE_A_GROUP'
+          }),
+          GROUP_B: experimentsExports.createExperimentGroup({
+            value: 'groupB',
+            schemaValue: 'THE_B_GROUP'
+          })
+        }
+      }),
+      experimentsExports.createExperiment({
+        name: 'fooTest',
+        active: true,
+        disabled: false,
+        groups: {
+          MY_CONTROL_GROUP: experimentsExports.createExperimentGroup({
+            value: 'sameOld',
+            schemaValue: 'THE_CONTROL'
+          }),
+          FUN_EXPERIMENT: experimentsExports.createExperimentGroup({
+            value: 'newThing',
+            schemaValue: 'EXPERIMENT'
+          })
+        }
+      })
+    ]
+    jest.spyOn(Math, 'random').mockReturnValue(0)
+    experimentsExports.assignUserToTestGroups()
+
+    // Should store test group in localStorage.
+    expect(localStorageMgr.setItem).toHaveBeenCalledTimes(2)
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.experiments.exampleTest', 'hi')
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.experiments.fooTest', 'sameOld')
+
+    // Should return the assigned test groups.
+    expect(experimentsExports.getUserExperimentGroup('exampleTest')).toBe('hi')
+    expect(experimentsExports.getUserExperimentGroup('someTest')).toBe('none')
+    expect(experimentsExports.getUserExperimentGroup('fooTest')).toBe('sameOld')
+  })
 })
 
 /* Tests for actual experiments */

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -1,14 +1,17 @@
 /* eslint-env jest */
-
-import localStorageMgr, {
-  __mockClear
-} from 'js/utils/localstorage-mgr'
+import {
+  forEach,
+  sortBy
+} from 'lodash/collection'
+import { isPlainObject } from 'lodash/lang'
 
 jest.mock('js/utils/localstorage-mgr')
 jest.mock('js/utils/feature-flags')
 afterEach(() => {
+  const { __mockClear } = require('js/utils/localstorage-mgr')
   __mockClear()
   jest.clearAllMocks()
+  jest.resetModules()
 })
 /* Tests for the Experiment and ExperimentGroup objects */
 describe('Experiment and ExperimentGroup objects', () => {
@@ -39,6 +42,7 @@ describe('Experiment and ExperimentGroup objects', () => {
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
 
     // Mock that the user is assigned to an experiment group.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
 
     const experiment = createExperiment({
@@ -63,6 +67,7 @@ describe('Experiment and ExperimentGroup objects', () => {
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
 
     // Mock that the user is assigned to an experiment group.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
 
     const experiment = createExperiment({
@@ -87,6 +92,7 @@ describe('Experiment and ExperimentGroup objects', () => {
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
 
     // Invalid local storage value
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem('tab.experiments.fooTest', 'not-a-valid-group')
 
     const experiment = createExperiment({
@@ -108,6 +114,7 @@ describe('Experiment and ExperimentGroup objects', () => {
   })
 
   test('does not assign the user to a test group when the experiment is inactive', () => {
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
     const experiment = createExperiment({
       name: 'fooTest',
@@ -133,6 +140,7 @@ describe('Experiment and ExperimentGroup objects', () => {
   })
 
   test('saves a test group to local storage when assigning a test group', () => {
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
     const experiment = createExperiment({
       name: 'fooTest',
@@ -159,6 +167,7 @@ describe('Experiment and ExperimentGroup objects', () => {
   })
 
   test('selects from all the test groups when assigning the user to a test group', () => {
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     const { createExperiment, createExperimentGroup } = require('js/utils/experiments')
     const experiment = createExperiment({
       name: 'fooTest',
@@ -189,6 +198,7 @@ describe('Experiment and ExperimentGroup objects', () => {
   })
 
   test('assigns the "none" test group when there are no other groups', () => {
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     const { createExperiment } = require('js/utils/experiments')
     const experiment = createExperiment({
       name: 'fooTest',
@@ -214,6 +224,7 @@ describe('Main experiments functionality', () => {
     const experimentsExports = require('js/utils/experiments')
 
     // Mock that the user is assigned to an experiment group.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
 
     experimentsExports.experiments = [
@@ -256,6 +267,7 @@ describe('Main experiments functionality', () => {
     const experimentsExports = require('js/utils/experiments')
 
     // Mock that the user is assigned to an experiment group.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
 
     experimentsExports.experiments = [
@@ -298,6 +310,7 @@ describe('Main experiments functionality', () => {
     const experimentsExports = require('js/utils/experiments')
 
     // Mock that the user is assigned to an experiment group.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem('tab.experiments.fooTest', 'newThing')
 
     experimentsExports.experiments = [
@@ -417,6 +430,7 @@ describe('Main experiments functionality', () => {
   })
 
   test('assignUserToTestGroups assigns the user to all active tests but not inactive tests', () => {
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
     const experimentsExports = require('js/utils/experiments')
     experimentsExports.experiments = [
       experimentsExports.createExperiment({
@@ -543,14 +557,25 @@ describe('Main experiments functionality', () => {
 
 /* Tests for actual experiments */
 describe('Actual experiments we are running or will run', () => {
-  test('assignUserToTestGroups saves the user\'s test groups to localStorage', () => {
-    // // Control for randomness.
-    // jest.spyOn(Math, 'random').mockReturnValue(0)
+  test('experiments match expected', () => {
+    const experiments = require('js/utils/experiments').experiments
+    expect(sortBy(experiments, o => o.name)).toMatchObject([
+      // Experiments ordered alphabetically by name
+      {
+        name: 'thirdAd',
+        active: false,
+        disabled: false
+      }
+    ])
+  })
 
-    const assignUserToTestGroups = require('js/utils/experiments').assignUserToTestGroups
-    assignUserToTestGroups()
-
-    // Placeholder while we do not have any active tests.
-    expect(true).toBe(true)
+  test('the experiments have valid groups object structure', () => {
+    const experiments = require('js/utils/experiments').experiments
+    experiments.forEach(exp => {
+      forEach(exp.groups, group => {
+        expect(isPlainObject(group)).toBe(true)
+        expect(Object.keys(group)).toEqual(['value', 'schemaValue'])
+      })
+    })
   })
 })

--- a/web/src/js/utils/__tests__/feature-flags.test.js
+++ b/web/src/js/utils/__tests__/feature-flags.test.js
@@ -13,9 +13,9 @@ describe('feature flags', () => {
     expect(isVariousAdSizesEnabled()).toBe(false)
   })
 
-  test('isThirdAdEnabled is false', () => {
+  test('isThirdAdEnabled is true', () => {
     const isThirdAdEnabled = require('js/utils/feature-flags')
       .isThirdAdEnabled
-    expect(isThirdAdEnabled()).toBe(false)
+    expect(isThirdAdEnabled()).toBe(true)
   })
 })

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -1,5 +1,9 @@
 
-import { filter, find, map } from 'lodash/collection'
+import {
+  filter,
+  find,
+  map
+} from 'lodash/collection'
 import localStorageMgr from 'js/utils/localstorage-mgr'
 import {
   STORAGE_EXPERIMENT_PREFIX
@@ -100,7 +104,23 @@ const NoneExperimentGroup = createExperimentGroup({
 // The "name" value of the experiment must be the same as the
 // field name of the GraphQL ExperimentGroup field name for
 // this test.
-export const experiments = []
+export const experiments = [
+  createExperiment({
+    name: 'thirdAd',
+    active: false,
+    disabled: false,
+    groups: {
+      TWO_ADS: createExperimentGroup({
+        value: 'twoAds',
+        schemaValue: 'TWO_ADS'
+      }),
+      THREE_ADS: createExperimentGroup({
+        value: 'threeAds',
+        schemaValue: 'THREE_ADS'
+      })
+    }
+  })
+]
 
 // We do this to be able to modify the experiments
 // variable during testing while keeping it in this file.

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -1,4 +1,104 @@
 
+import { filter, map, some } from 'lodash/collection'
+import localStorageMgr from 'js/utils/localstorage-mgr'
+import {
+  STORAGE_EXPERIMENT_PREFIX
+} from 'js/constants'
+
+const noneGroupKey = 'NONE'
+const noneGroupValue = 'none'
+const noneGroupSchemaValue = 'NONE'
+
+export const createExperiment = ({ name, active = false, disabled = false, groups }) => {
+  if (!name) {
+    throw new Error('An experiment must have a unique "name" value.')
+  }
+  return {
+    // A unique code (without spaces) for this experiment
+    name,
+    // If true, we will assign users a group in the experiment. If false,
+    // we will not assign users to any group.
+    active,
+    // If true, we will always return the "none" test group when getting
+    // the user's experiment group, even if the user is assigned to
+    // another group. This should effectively disable the effects of the
+    // experiment.
+    disabled,
+    // The different experiment groups the user could be assigned to.
+    groups: Object.assign({}, groups, {
+      [noneGroupKey]: createExperimentGroup({
+        value: noneGroupValue,
+        schemaValue: noneGroupSchemaValue
+      })
+    }),
+    localStorageKey: `${STORAGE_EXPERIMENT_PREFIX}.${name}`,
+    saveTestGroupToLocalStorage: function (testGroupValue) {
+      localStorageMgr.setItem(this.localStorageKey, testGroupValue)
+    },
+    // Assign the user to an experiment group.
+    assignTestGroup: function () {
+      if (!this.active) {
+        return
+      }
+
+      // Filter out the "none" group.
+      const experimentGroups = filter(this.groups, groupObj => groupObj.value !== noneGroupValue)
+
+      // If there aren't any test groups, just save the "none" value.
+      if (!experimentGroups.length) {
+        this.saveTestGroupToLocalStorage(this.groups.NONE.value)
+      }
+
+      // There's an equal chance of being assigned to any group,
+      // excepting the "none" group.
+      const groupValues = map(experimentGroups, groupObj => groupObj.value)
+      const testGroup = groupValues[Math.floor(Math.random() * groupValues.length)]
+      this.saveTestGroupToLocalStorage(testGroup)
+    },
+    // Return the value of the user's assigned experiment group,
+    // or 'none' if the user is not assigned to one.
+    getTestGroup: function () {
+      // If the test is disabled, return the "none" group value.
+      if (this.disabled) {
+        return this.groups.NONE.value
+      }
+
+      // Get the user's group from localStorage. If it's not one of
+      // the valid group values, return the "none" group value.
+      const groupVal = localStorageMgr.getItem(this.localStorageKey)
+      const isValidGroup = some(this.groups, { value: groupVal })
+      if (!isValidGroup) {
+        return this.groups.NONE.value
+      }
+      return groupVal
+    }
+  }
+}
+
+/**
+ * Return an object representing an experiment group the user could be
+ * assigned to.
+ * @param {Object} experimentGroupConfig
+ * @param {string} experimentGroupConfig.value - The string value we'll
+ *   use when representing the user's group.
+ * @param {string} experimentGroupConfig.schemaValue - The string value
+ *   we'll send to the server-side. It should match the GraphQL enum
+ *   value of the experiment group.
+ *   use when representing the user's group.
+ * @return {Object} An object representing the experiment group
+ */
+export const createExperimentGroup = ({ value, schemaValue }) => {
+  if (!(value && schemaValue)) {
+    throw new Error('An experiment group must have values for the "value" and "schemaValue" keys.')
+  }
+  return {
+    value,
+    schemaValue
+  }
+}
+
+// const experiments = []
+
 /**
  * Assigns the user to test groups for all active tests.
  * @returns {undefined}

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -164,7 +164,14 @@ export const getUserExperimentGroup = experimentName => {
  * Assigns the user to test groups for all active tests.
  * @returns {undefined}
  */
-export const assignUserToTestGroups = () => {}
+export const assignUserToTestGroups = () => {
+  const exps = getExperiments()
+  exps.forEach(experiment => {
+    if (experiment.active) {
+      experiment.assignTestGroup()
+    }
+  })
+}
 
 /**
  * Returns an object with a key for each active experiment. Each

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -1,5 +1,5 @@
 
-import { filter, map, some } from 'lodash/collection'
+import { filter, find, map, some } from 'lodash/collection'
 import localStorageMgr from 'js/utils/localstorage-mgr'
 import {
   STORAGE_EXPERIMENT_PREFIX
@@ -97,7 +97,33 @@ export const createExperimentGroup = ({ value, schemaValue }) => {
   }
 }
 
-// const experiments = []
+export const experiments = []
+
+// We do this to be able to modify the experiments
+// variable during testing while keeping it in this file.
+// https://github.com/facebook/jest/issues/936#issuecomment-214939935
+const getExperiments = () => exports.experiments
+
+/**
+ * Get the user's assigned group value for an experiment.
+ * If the experiment does not exist or is disabled, this
+ * will return 'none'.
+ * @returns {String} The value of the user's group for this
+ *   experiment.
+ */
+export const getUserExperimentGroup = experimentName => {
+  if (!experimentName) {
+    throw new Error('Must provide an experiment name.')
+  }
+  const exps = getExperiments()
+  const exp = find(exps, { name: experimentName })
+
+  // If there's no experiment with this name, return 'none'.
+  if (!exp) {
+    return noneGroupValue
+  }
+  return exp.getTestGroup()
+}
 
 /**
  * Assigns the user to test groups for all active tests.

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -108,6 +108,7 @@ export const EXPERIMENT_THIRD_AD = 'thirdAd'
 // field name of the GraphQL ExperimentGroup field name for
 // this test.
 export const experiments = [
+  // @experiment-third-ad
   createExperiment({
     name: EXPERIMENT_THIRD_AD,
     active: false,

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -100,13 +100,16 @@ const NoneExperimentGroup = createExperimentGroup({
   schemaValue: 'NONE'
 })
 
+// Add experiment names here as constants.
+export const EXPERIMENT_THIRD_AD = 'thirdAd'
+
 // Add ExperimentGroup objects here to enable new experiments.
 // The "name" value of the experiment must be the same as the
 // field name of the GraphQL ExperimentGroup field name for
 // this test.
 export const experiments = [
   createExperiment({
-    name: 'thirdAd',
+    name: EXPERIMENT_THIRD_AD,
     active: false,
     disabled: false,
     groups: {

--- a/web/src/js/utils/feature-flags.js
+++ b/web/src/js/utils/feature-flags.js
@@ -4,4 +4,4 @@ export const isAnonymousUserSignInEnabled = () => false
 export const isVariousAdSizesEnabled = () => false
 
 // @experiment-third-ad
-export const isThirdAdEnabled = () => false
+export const isThirdAdEnabled = () => true


### PR DESCRIPTION
* Add an (inactive) experiment to test a third ad on the new tab page
* Enable the third ad feature, because it's now gated behind the test group
* Refactor the client-side experiment logic to make it easier to add new experiments