### PR TITLE
Set up the "one ad for new users" experiment

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -214,6 +214,17 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
           THREE_ADS: { value: experimentConfig.thirdAd.THREE_ADS }
         }
       })
+    },
+    oneAdForNewUsers: {
+      type: new GraphQLEnumType({
+        name: 'ExperimentGroupOneAdForNewUsers',
+        description: 'The test of showing only one ad to new users',
+        values: {
+          NONE: { value: experimentConfig.oneAdForNewUsers.NONE },
+          DEFAULT: { value: experimentConfig.oneAdForNewUsers.DEFAULT },
+          ONE_AD_AT_FIRST: { value: experimentConfig.oneAdForNewUsers.ONE_AD_AT_FIRST }
+        }
+      })
     }
   }
 })

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -169,7 +169,10 @@ class User extends BaseModel {
           split-test. This value is assigned on the client so is not trustworthy.`),
       testGroupThirdAd: types.number().integer().allow(null)
         .description(`Which group the user is in for the "three ads" split-test. 
-          This value is assigned on the client so is not trustworthy.`)
+          This value is assigned on the client so is not trustworthy.`),
+      testOneAdForNewUsers: types.number().integer().allow(null)
+        .description(`Which group the user is in for the "one ad for new users"
+          split-test. This value is assigned on the client so is not trustworthy.`)
     }
   }
 

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -50,6 +50,10 @@ const logUserExperimentGroups = async (userContext, userId, experimentGroups = {
     !isNil(validatedGroups.thirdAd) ? {
       testGroupThirdAd: validatedGroups.thirdAd
     }
+      : null,
+    !isNil(validatedGroups.oneAdForNewUsers) ? {
+      testOneAdForNewUsers: validatedGroups.oneAdForNewUsers
+    }
       : null
   )
   try {

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -20,6 +20,12 @@ const experimentConfig = {
     NONE: 0,
     TWO_ADS: 1,
     THREE_ADS: 2
+  },
+  // @experiment-one-ad-for-new-users
+  oneAdForNewUsers: {
+    NONE: 0,
+    DEFAULT: 1,
+    ONE_AD_AT_FIRST: 2
   }
 }
 

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -166,11 +166,19 @@ enum ExperimentGroupAnonSignIn {
   ANONYMOUS_ALLOWED
 }
 
+"""The test of showing only one ad to new users"""
+enum ExperimentGroupOneAdForNewUsers {
+  NONE
+  DEFAULT
+  ONE_AD_AT_FIRST
+}
+
 """The experimental groups to which the user is assigned"""
 input ExperimentGroups {
   anonSignIn: ExperimentGroupAnonSignIn
   variousAdSizes: ExperimentGroupVariousAdSizes
   thirdAd: ExperimentGroupThirdAd
+  oneAdForNewUsers: ExperimentGroupOneAdForNewUsers
 }
 
 """The test of enabling a third ad"""

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -154,6 +154,23 @@ describe('ad settings', () => {
     expect(getNumberOfAdsToShow()).toEqual(2)
   })
 
+  test('[no-three-ads] [one-ad] [unknown-recently-installed] shows 2 ads when the install time is missing', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getBrowserExtensionInstallTime.mockReturnValue(null)
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'twoAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'oneAd'
+        default:
+          return 'none'
+      }
+    })
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(2)
+  })
+
   test('[three-ads] [one-ad] [no-recently-installed] shows 3 ads', () => {
     isThirdAdEnabled.mockReturnValue(true)
     getBrowserExtensionInstallTime

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -1,15 +1,34 @@
 /* eslint-env jest */
 
+import moment from 'moment'
+import MockDate from 'mockdate'
 import {
   isThirdAdEnabled,
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
+  EXPERIMENT_THIRD_AD,
+  EXPERIMENT_ONE_AD_FOR_NEW_USERS,
   getUserExperimentGroup
 } from 'js/utils/experiments'
+import {
+  getBrowserExtensionInstallTime
+} from 'js/utils/local-user-data-mgr'
 
 jest.mock('js/utils/feature-flags')
 jest.mock('js/utils/experiments')
+jest.mock('js/utils/local-user-data-mgr')
+
+const mockNow = '2017-05-19T13:59:58.000Z'
+
+beforeEach(() => {
+  MockDate.set(moment(mockNow))
+  getUserExperimentGroup.mockImplementation(() => 'none')
+})
+
+afterEach(() => {
+  MockDate.reset()
+})
 
 describe('ad settings', () => {
   test('ad IDs and ad slot IDs are as expected', () => {
@@ -27,22 +46,128 @@ describe('ad settings', () => {
     expect(HORIZONTAL_AD_SLOT_DOM_ID).toBe('div-gpt-ad-1464385677836-0')
   })
 
-  test('getNumberOfAdsToShow returns 2 when the "3rd ad" feature is disabled', () => {
+  test('[three-ads] [no-one-ad] [recently-installed] shows 2 ads when the "3rd ad" feature is disabled', () => {
     isThirdAdEnabled.mockReturnValue(false)
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(23, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'threeAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'default'
+        default:
+          return 'none'
+      }
+    })
     const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
     expect(getNumberOfAdsToShow()).toEqual(2)
   })
 
-  test('getNumberOfAdsToShow returns 2 when the "3rd ad" feature is enabled but the user is not in the "3 ad" test group', () => {
-    isThirdAdEnabled.mockReturnValue(false)
-    getUserExperimentGroup.mockReturnValue('twoAds')
-    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
-    expect(getNumberOfAdsToShow()).toEqual(2)
-  })
-
-  test('getNumberOfAdsToShow returns 3 when the "3rd ad" feature is enabled and the user is in the "3 ad" test group', () => {
+  test('[no-three-ads] [no-one-ad] [recently-installed] shows 2 ads', () => {
     isThirdAdEnabled.mockReturnValue(true)
-    getUserExperimentGroup.mockReturnValue('threeAds')
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(23, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'twoAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'default'
+        default:
+          return 'none'
+      }
+    })
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(2)
+  })
+
+  test('[three-ads] [no-one-ad] [recently-installed] shows 3 ads', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(23, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'threeAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'default'
+        default:
+          return 'none'
+      }
+    })
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(3)
+  })
+
+  test('[no-three-ads] [one-ad] [recently-installed] shows 1 ad', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(23, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'twoAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'oneAd'
+        default:
+          return 'none'
+      }
+    })
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(1)
+  })
+
+  test('[three-ads] [one-ad] [recently-installed] shows 1 ad', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(23, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'threeAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'oneAd'
+        default:
+          return 'none'
+      }
+    })
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(1)
+  })
+
+  test('[no-three-ads] [one-ad] [no-recently-installed] shows 2 ads', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(32, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'twoAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'oneAd'
+        default:
+          return 'none'
+      }
+    })
+    const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
+    expect(getNumberOfAdsToShow()).toEqual(2)
+  })
+
+  test('[three-ads] [one-ad] [no-recently-installed] shows 3 ads', () => {
+    isThirdAdEnabled.mockReturnValue(true)
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(32, 'hours'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_THIRD_AD:
+          return 'threeAds'
+        case EXPERIMENT_ONE_AD_FOR_NEW_USERS:
+          return 'oneAd'
+        default:
+          return 'none'
+      }
+    })
     const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
     expect(getNumberOfAdsToShow()).toEqual(3)
   })

--- a/web/src/js/ads/mockDisplayAd.js
+++ b/web/src/js/ads/mockDisplayAd.js
@@ -1,10 +1,22 @@
 
+import {
+  VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
+  HORIZONTAL_AD_SLOT_DOM_ID
+} from 'js/ads/adSettings'
+
 export default function (adId) {
   var mockNetworkDelayMs = 0
   const useMockDelay = false
   if (useMockDelay) {
     mockNetworkDelayMs = Math.random() * (1500 - 900) + 900
   }
+  const mapDOMIdToHeight = {
+    [VERTICAL_AD_SLOT_DOM_ID]: 250,
+    [SECOND_VERTICAL_AD_SLOT_DOM_ID]: 250,
+    [HORIZONTAL_AD_SLOT_DOM_ID]: 90
+  }
+  const height = mapDOMIdToHeight[adId]
 
   // Mock returning an ad.
   setTimeout(() => {
@@ -22,7 +34,7 @@ export default function (adId) {
         #333 40px
       );
       width: 100%;
-      height: 100%;
+      height: ${height}px;
     `)
   }, mockNetworkDelayMs)
 }

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -298,71 +298,79 @@ class Dashboard extends React.Component {
             : null
         }
         { showNewUserTour ? <NewUserTour user={user} /> : null }
-        {/*
-          For dynamic ad sizing, we may want to move ads into a parent
-          component that's absolutely positioned, then use flex positioning
-          for the ads themselves. This will avoid awkward gaps.
-        */}
-        {
-          this.state.numAdsToShow > 2
-            ? <Ad
-              adId={SECOND_VERTICAL_AD_SLOT_DOM_ID}
-              style={{
-                position: 'absolute',
-                bottom: 270,
-                right: 10,
-                minWidth: 300,
-                overflow: 'visible',
-                display: 'block'
-              }}
-              adWrapperStyle={{
-                position: 'absolute',
-                bottom: 0,
-                right: 0
-              }}
-            />
-            : null
-        }
-        {
-          this.state.numAdsToShow > 1
-            ? <Ad
-              adId={VERTICAL_AD_SLOT_DOM_ID}
-              style={{
-                position: 'absolute',
-                bottom: 10,
-                right: 10,
-                minWidth: 300,
-                overflow: 'visible',
-                display: 'block'
-              }}
-              adWrapperStyle={{
-                position: 'absolute',
-                bottom: 0,
-                right: 0
-              }}
-            />
-            : null
-        }
-        {
-          this.state.numAdsToShow > 0
-            ? <Ad
-              adId={HORIZONTAL_AD_SLOT_DOM_ID}
-              style={{
-                position: 'absolute',
-                bottom: 10,
-                right: 320,
-                minWidth: 728,
-                overflow: 'visible',
-                display: 'block'
-              }}
-              adWrapperStyle={{
-                position: 'absolute',
-                bottom: 0,
-                right: 0
-              }}
-            />
-            : null
-        }
+        <div
+          style={{
+            position: 'absolute',
+            overflow: 'visible',
+            display: 'flex',
+            alignItems: 'flex-end',
+            flexDirection: 'row-reverse',
+            bottom: 10,
+            right: 10
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'visible'
+            }}
+          >
+            {
+              this.state.numAdsToShow > 2
+                ? <Ad
+                  adId={SECOND_VERTICAL_AD_SLOT_DOM_ID}
+                  style={{
+                    display: 'flex',
+                    minWidth: 300,
+                    overflow: 'visible'
+                  }}
+                  adWrapperStyle={{
+                    position: 'absolute',
+                    bottom: 0,
+                    right: 0
+                  }}
+                />
+                : null
+            }
+            {
+              this.state.numAdsToShow > 1
+                ? <Ad
+                  adId={VERTICAL_AD_SLOT_DOM_ID}
+                  style={{
+                    display: 'flex',
+                    minWidth: 300,
+                    overflow: 'visible',
+                    marginTop: 10
+                  }}
+                  adWrapperStyle={{
+                    position: 'absolute',
+                    bottom: 0,
+                    right: 0
+                  }}
+                />
+                : null
+            }
+          </div>
+          {
+            this.state.numAdsToShow > 0
+              ? <Ad
+                adId={HORIZONTAL_AD_SLOT_DOM_ID}
+                style={{
+                  display: 'flex',
+                  minWidth: 728,
+                  overflow: 'visible',
+                  marginRight: 10
+                }}
+                adWrapperStyle={{
+                  position: 'absolute',
+                  bottom: 0,
+                  right: 0
+                }}
+              />
+              : null
+          }
+        </div>
         { user && tabId ? <LogTab user={user} tabId={tabId} /> : null }
         { user && tabId ? <LogRevenue user={user} tabId={tabId} /> : null }
         { user ? <LogConsentData user={user} /> : null }

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -343,11 +343,6 @@ class Dashboard extends React.Component {
                     overflow: 'visible',
                     marginTop: 10
                   }}
-                  adWrapperStyle={{
-                    position: 'absolute',
-                    bottom: 0,
-                    right: 0
-                  }}
                 />
                 : null
             }
@@ -361,11 +356,6 @@ class Dashboard extends React.Component {
                   minWidth: 728,
                   overflow: 'visible',
                   marginRight: 10
-                }}
-                adWrapperStyle={{
-                  position: 'absolute',
-                  bottom: 0,
-                  right: 0
                 }}
               />
               : null

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -579,6 +579,11 @@ describe('Actual experiments we are running or will run', () => {
     expect(sortBy(experiments, o => o.name)).toMatchObject([
       // Experiments ordered alphabetically by name
       {
+        name: 'oneAdForNewUsers',
+        active: false,
+        disabled: false
+      },
+      {
         name: 'thirdAd',
         active: false,
         disabled: false

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -102,6 +102,7 @@ const NoneExperimentGroup = createExperimentGroup({
 
 // Add experiment names here as constants.
 export const EXPERIMENT_THIRD_AD = 'thirdAd'
+export const EXPERIMENT_ONE_AD_FOR_NEW_USERS = 'oneAdForNewUsers'
 
 // Add ExperimentGroup objects here to enable new experiments.
 // The "name" value of the experiment must be the same as the
@@ -121,6 +122,22 @@ export const experiments = [
       THREE_ADS: createExperimentGroup({
         value: 'threeAds',
         schemaValue: 'THREE_ADS'
+      })
+    }
+  }),
+  // @experiment-one-ad-for-new-users
+  createExperiment({
+    name: EXPERIMENT_ONE_AD_FOR_NEW_USERS,
+    active: false,
+    disabled: false,
+    groups: {
+      DEFAULT: createExperimentGroup({
+        value: 'default',
+        schemaValue: 'DEFAULT'
+      }),
+      ONE_AD_AT_FIRST: createExperimentGroup({
+        value: 'oneAd',
+        schemaValue: 'ONE_AD_AT_FIRST'
       })
     }
   })


### PR DESCRIPTION
Set up logic for an experiment to show only one ad on the new tab page for the first 24 hours for users who are in an experimental group. After 24 hours, show the default number of ads. The control group will see the default number of ads immediately.