### PR TITLE
Set up "ad explanation" experiment

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -225,6 +225,17 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
           ONE_AD_AT_FIRST: { value: experimentConfig.oneAdForNewUsers.ONE_AD_AT_FIRST }
         }
       })
+    },
+    adExplanation: {
+      type: new GraphQLEnumType({
+        name: 'ExperimentGroupAdExplanation',
+        description: 'The test of showing an explanation of why there are ads',
+        values: {
+          NONE: { value: experimentConfig.adExplanation.NONE },
+          DEFAULT: { value: experimentConfig.adExplanation.DEFAULT },
+          SHOW_EXPLANATION: { value: experimentConfig.adExplanation.SHOW_EXPLANATION }
+        }
+      })
     }
   }
 })

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -172,7 +172,10 @@ class User extends BaseModel {
           This value is assigned on the client so is not trustworthy.`),
       testOneAdForNewUsers: types.number().integer().allow(null)
         .description(`Which group the user is in for the "one ad for new users"
-          split-test. This value is assigned on the client so is not trustworthy.`)
+          split-test. This value is assigned on the client so is not trustworthy.`),
+      testAdExplanation: types.number().integer().allow(null)
+        .description(`Which group the user is in for the "ad explanation" split-test.
+          This value is assigned on the client so is not trustworthy.`)
     }
   }
 

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -54,6 +54,10 @@ const logUserExperimentGroups = async (userContext, userId, experimentGroups = {
     !isNil(validatedGroups.oneAdForNewUsers) ? {
       testOneAdForNewUsers: validatedGroups.oneAdForNewUsers
     }
+      : null,
+    !isNil(validatedGroups.adExplanation) ? {
+      testAdExplanation: validatedGroups.adExplanation
+    }
       : null
   )
   try {

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -26,6 +26,12 @@ const experimentConfig = {
     NONE: 0,
     DEFAULT: 1,
     ONE_AD_AT_FIRST: 2
+  },
+  // @experiment-ad-explanation
+  adExplanation: {
+    NONE: 0,
+    DEFAULT: 1,
+    SHOW_EXPLANATION: 2
   }
 }
 

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -159,6 +159,13 @@ enum EncodedRevenueValueTypeEnum {
   AMAZON_CPM
 }
 
+"""The test of showing an explanation of why there are ads"""
+enum ExperimentGroupAdExplanation {
+  NONE
+  DEFAULT
+  SHOW_EXPLANATION
+}
+
 """The test of allowing anonymous user authentication"""
 enum ExperimentGroupAnonSignIn {
   NONE
@@ -179,6 +186,7 @@ input ExperimentGroups {
   variousAdSizes: ExperimentGroupVariousAdSizes
   thirdAd: ExperimentGroupThirdAd
   oneAdForNewUsers: ExperimentGroupOneAdForNewUsers
+  adExplanation: ExperimentGroupAdExplanation
 }
 
 """The test of enabling a third ad"""

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -7,6 +7,7 @@ import {
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
+  EXPERIMENT_AD_EXPLANATION,
   EXPERIMENT_THIRD_AD,
   EXPERIMENT_ONE_AD_FOR_NEW_USERS,
   getUserExperimentGroup
@@ -46,6 +47,8 @@ describe('ad settings', () => {
     expect(HORIZONTAL_AD_SLOT_DOM_ID).toBe('div-gpt-ad-1464385677836-0')
   })
 
+  // @experiment-third-ad
+  // @experiment-one-ad-for-new-users
   test('[three-ads] [no-one-ad] [recently-installed] shows 2 ads when the "3rd ad" feature is disabled', () => {
     isThirdAdEnabled.mockReturnValue(false)
     getBrowserExtensionInstallTime
@@ -187,6 +190,81 @@ describe('ad settings', () => {
     })
     const getNumberOfAdsToShow = require('js/ads/adSettings').getNumberOfAdsToShow
     expect(getNumberOfAdsToShow()).toEqual(3)
+  })
+
+  // @experiment-ad-explanation
+  test('[no-ad-explanation] [no-recently-installed] shouldShowOneAd returns false', () => {
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(10, 'days'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'default'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(false)
+  })
+
+  test('[no-ad-explanation] [recently-installed] shouldShowOneAd returns false', () => {
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(12, 'seconds'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'default'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(false)
+  })
+
+  test('[ad-explanation] [no-recently-installed] shouldShowOneAd returns false', () => {
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(10, 'days'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'explanation'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(false)
+  })
+
+  test('[ad-explanation] [unknown-recently-installed] shouldShowOneAd returns false', () => {
+    getBrowserExtensionInstallTime.mockReturnValue(null)
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'explanation'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(false)
+  })
+
+  test('[ad-explanation] [recently-installed] shouldShowOneAd returns true', () => {
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(12, 'seconds'))
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'explanation'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(true)
   })
 
   test('getVerticalAdSizes returns the expected ad sizes when various ad sizes are disabled', () => {

--- a/web/src/js/ads/__tests__/adSettings.test.js
+++ b/web/src/js/ads/__tests__/adSettings.test.js
@@ -13,7 +13,8 @@ import {
   getUserExperimentGroup
 } from 'js/utils/experiments'
 import {
-  getBrowserExtensionInstallTime
+  getBrowserExtensionInstallTime,
+  hasUserDismissedAdExplanation
 } from 'js/utils/local-user-data-mgr'
 
 jest.mock('js/utils/feature-flags')
@@ -265,6 +266,38 @@ describe('ad settings', () => {
     })
     const { shouldShowAdExplanation } = require('js/ads/adSettings')
     expect(shouldShowAdExplanation()).toEqual(true)
+  })
+
+  test('[ad-explanation] [recently-installed] [no-dismissed] shouldShowOneAd returns true', () => {
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(12, 'seconds'))
+    hasUserDismissedAdExplanation.mockReturnValue(false)
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'explanation'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(true)
+  })
+
+  test('[ad-explanation] [recently-installed] [dismissed] shouldShowOneAd returns false', () => {
+    getBrowserExtensionInstallTime
+      .mockReturnValue(moment(mockNow).subtract(12, 'seconds'))
+    hasUserDismissedAdExplanation.mockReturnValue(true)
+    getUserExperimentGroup.mockImplementation(experimentName => {
+      switch (experimentName) {
+        case EXPERIMENT_AD_EXPLANATION:
+          return 'explanation'
+        default:
+          return 'none'
+      }
+    })
+    const { shouldShowAdExplanation } = require('js/ads/adSettings')
+    expect(shouldShowAdExplanation()).toEqual(false)
   })
 
   test('getVerticalAdSizes returns the expected ad sizes when various ad sizes are disabled', () => {

--- a/web/src/js/ads/adSettings.js
+++ b/web/src/js/ads/adSettings.js
@@ -12,7 +12,8 @@ import {
   getUserExperimentGroup
 } from 'js/utils/experiments'
 import {
-  getBrowserExtensionInstallTime
+  getBrowserExtensionInstallTime,
+  hasUserDismissedAdExplanation
 } from 'js/utils/local-user-data-mgr'
 
 // Time to wait for the entire ad auction before
@@ -56,7 +57,11 @@ export const shouldShowAdExplanation = () => {
     getUserExperimentGroup(EXPERIMENT_AD_EXPLANATION) ===
     getExperimentGroups(EXPERIMENT_AD_EXPLANATION).SHOW_EXPLANATION
   )
-  return !!(joinedRecently && userInExperimentalGroup)
+  return !!(
+    joinedRecently &&
+    userInExperimentalGroup &&
+    !hasUserDismissedAdExplanation()
+  )
 }
 
 /**

--- a/web/src/js/ads/adSettings.js
+++ b/web/src/js/ads/adSettings.js
@@ -5,6 +5,7 @@ import {
   isVariousAdSizesEnabled
 } from 'js/utils/feature-flags'
 import {
+  EXPERIMENT_AD_EXPLANATION,
   EXPERIMENT_THIRD_AD,
   EXPERIMENT_ONE_AD_FOR_NEW_USERS,
   getExperimentGroups,
@@ -39,6 +40,24 @@ export const SECOND_VERTICAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1539903223131-0'
 // it is tall. Historically, the bottom long leaderboard ad.
 export const HORIZONTAL_AD_UNIT_ID = '/43865596/HBTL'
 export const HORIZONTAL_AD_SLOT_DOM_ID = 'div-gpt-ad-1464385677836-0'
+
+/**
+ * Determine if we should show the explanation that the ads raise
+ * money for charity. We'll show it for users in the "ad explanation"
+ * experimental group for the first X hours after they join.
+ * @return {Boolean} Whether to show one ad.
+ */
+export const shouldShowAdExplanation = () => {
+  const hoursToShow = 4
+  const installTime = getBrowserExtensionInstallTime()
+  const joinedRecently = !!installTime &&
+    moment().diff(installTime, 'hours') < hoursToShow
+  const userInExperimentalGroup = (
+    getUserExperimentGroup(EXPERIMENT_AD_EXPLANATION) ===
+    getExperimentGroups(EXPERIMENT_AD_EXPLANATION).SHOW_EXPLANATION
+  )
+  return !!(joinedRecently && userInExperimentalGroup)
+}
 
 /**
  * Determine if we should show only one ad. We'll show one ad for

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -38,6 +38,7 @@ import {
 } from 'js/navigation/navigation'
 import {
   getNumberOfAdsToShow,
+  shouldShowAdExplanation,
   VERTICAL_AD_SLOT_DOM_ID,
   SECOND_VERTICAL_AD_SLOT_DOM_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
@@ -57,7 +58,7 @@ class Dashboard extends React.Component {
       // users.
       userAlreadyViewedNewUserTour: localStorageMgr.getItem(STORAGE_NEW_USER_HAS_COMPLETED_TOUR) === 'true',
       numAdsToShow: getNumberOfAdsToShow(),
-      showAdExplanation: true
+      showAdExplanation: shouldShowAdExplanation()
     }
   }
 

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -17,7 +17,9 @@ import LogRevenue from 'js/components/Dashboard/LogRevenueContainer'
 import LogConsentData from 'js/components/Dashboard/LogConsentDataContainer'
 import LogAccountCreation from 'js/components/Dashboard/LogAccountCreationContainer'
 import CircleIcon from 'material-ui/svg-icons/image/lens'
+import HeartIcon from 'material-ui/svg-icons/action/favorite'
 import {
+  primaryColor,
   dashboardIconInactiveColor,
   dashboardIconActiveColor
 } from 'js/theme/default'
@@ -54,7 +56,8 @@ class Dashboard extends React.Component {
       // which is why we only show the tour to recently-joined
       // users.
       userAlreadyViewedNewUserTour: localStorageMgr.getItem(STORAGE_NEW_USER_HAS_COMPLETED_TOUR) === 'true',
-      numAdsToShow: getNumberOfAdsToShow()
+      numAdsToShow: getNumberOfAdsToShow(),
+      showAdExplanation: true
     }
   }
 
@@ -354,21 +357,80 @@ class Dashboard extends React.Component {
           </div>
           {
             this.state.numAdsToShow > 0
-              ? <Ad
-                adId={HORIZONTAL_AD_SLOT_DOM_ID}
-                style={{
-                  display: 'flex',
-                  minWidth: 728,
-                  overflow: 'visible',
-                  marginRight: 10
-                }}
-                adWrapperStyle={{
-                  position: 'absolute',
-                  bottom: 0,
-                  right: 0
-                }}
-              />
-              : null
+              ? (
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflow: 'visible',
+                    marginRight: 10
+                  }}
+                >
+                  { (this.state.showAdExplanation && user)
+                    ? (
+                      <FadeInDashboardAnimation>
+                        <div
+                          data-test-id={'ad-explanation'}
+                          style={{
+                            display: 'inline-block',
+                            float: 'right'
+                          }}
+                        >
+                          <Paper>
+                            <div
+                              style={{
+                                display: 'flex',
+                                padding: '6px 14px',
+                                marginBottom: 10,
+                                alignItems: 'center',
+                                background: dashboardIconInactiveColor
+                              }}
+                            >
+                              <HeartIcon
+                                color={primaryColor}
+                                style={{
+                                  width: 24,
+                                  height: 24,
+                                  marginRight: 14
+                                }}
+                              />
+                              <Typography variant={'body1'}>
+                                Did you know? The ads here are raising money for charity.
+                              </Typography>
+                              <Button
+                                color={'primary'}
+                                style={{
+                                  marginLeft: 10,
+                                  marginRight: 10
+                                }}
+                                onClick={() => {
+                                  // TODO
+                                  console.log('TODO: log that the user saw this')
+                                }}
+                              >
+                              Got it
+                              </Button>
+                            </div>
+                          </Paper>
+                        </div>
+                      </FadeInDashboardAnimation>
+                    )
+                    : null
+                  }
+                  <Ad
+                    adId={HORIZONTAL_AD_SLOT_DOM_ID}
+                    style={{
+                      overflow: 'visible',
+                      minWidth: 728
+                    }}
+                    adWrapperStyle={{
+                      position: 'absolute',
+                      bottom: 0,
+                      right: 0
+                    }}
+                  />
+                </div>
+              ) : null
           }
         </div>
         { user && tabId ? <LogTab user={user} tabId={tabId} /> : null }

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -31,6 +31,9 @@ import CloseIcon from 'material-ui/svg-icons/navigation/close'
 import NewUserTour from 'js/components/Dashboard/NewUserTourContainer'
 import { getCurrentUser } from 'js/authentication/user'
 import localStorageMgr from 'js/utils/localstorage-mgr'
+import {
+  setUserDismissedAdExplanation
+} from 'js/utils/local-user-data-mgr'
 import { STORAGE_NEW_USER_HAS_COMPLETED_TOUR } from 'js/constants'
 import {
   goTo,
@@ -395,8 +398,10 @@ class Dashboard extends React.Component {
                                   marginRight: 10
                                 }}
                                 onClick={() => {
-                                  // TODO
-                                  console.log('TODO: log that the user saw this')
+                                  setUserDismissedAdExplanation()
+                                  this.setState({
+                                    showAdExplanation: false
+                                  })
                                 }}
                               >
                               Got it

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -391,7 +391,7 @@ class Dashboard extends React.Component {
                               <Button
                                 color={'primary'}
                                 style={{
-                                  marginLeft: 10,
+                                  marginLeft: 20,
                                   marginRight: 10
                                 }}
                                 onClick={() => {

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -29,16 +29,21 @@ import {
 } from 'js/navigation/navigation'
 import {
   getNumberOfAdsToShow,
+  shouldShowAdExplanation,
   VERTICAL_AD_SLOT_DOM_ID,
   SECOND_VERTICAL_AD_SLOT_DOM_ID,
   HORIZONTAL_AD_SLOT_DOM_ID
 } from 'js/ads/adSettings'
+import {
+  setUserDismissedAdExplanation
+} from 'js/utils/local-user-data-mgr'
 
 jest.mock('js/analytics/logEvent')
 jest.mock('js/utils/localstorage-mgr')
 jest.mock('js/authentication/user')
 jest.mock('js/navigation/navigation')
 jest.mock('js/ads/adSettings')
+jest.mock('js/utils/local-user-data-mgr')
 
 const mockNow = '2018-05-15T10:30:00.000'
 
@@ -473,6 +478,37 @@ describe('Dashboard component', () => {
 
     expect(
       wrapper.find('[data-test-id="anon-sign-in-prompt-dashboard"]').length
+    ).toBe(0)
+  })
+
+  it('the ad explanation disappears when clicking to dismiss it', () => {
+    shouldShowAdExplanation.mockReturnValue(true)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+    const button = wrapper
+      .find('[data-test-id="ad-explanation"]')
+      .find(Button)
+    button.simulate('click')
+    expect(setUserDismissedAdExplanation).toHaveBeenCalled()
+    expect(wrapper
+      .find('[data-test-id="ad-explanation"]')
+      .find(Button)
+      .length
+    ).toBe(0)
+  })
+
+  it('the ad explanation does not render when we should not show it', () => {
+    shouldShowAdExplanation.mockReturnValue(false)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent').default
+    const wrapper = shallow(
+      <DashboardComponent {...mockProps} />
+    )
+    expect(wrapper
+      .find('[data-test-id="ad-explanation"]')
+      .find(Button)
+      .length
     ).toBe(0)
   })
 })

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -59,6 +59,7 @@ export const STORAGE_NEW_CONSENT_DATA_EXISTS = 'tab.consentData.newConsentDataEx
 export const STORAGE_NEW_USER_HAS_COMPLETED_TOUR = 'tab.newUser.hasCompletedTour'
 export const STORAGE_EXTENSION_INSTALL_ID = 'tab.newUser.extensionInstallId'
 export const STORAGE_APPROX_EXTENSION_INSTALL_TIME = 'tab.newUser.approxInstallTime'
+export const STORAGE_DISMISSED_AD_EXPLANATION = 'tab.newUser.dismissedAdExplanation'
 
 // tab.experiments: values related to split-testing features
 // We may assign other values to localStorage with the tab.experiments.*

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -579,6 +579,11 @@ describe('Actual experiments we are running or will run', () => {
     expect(sortBy(experiments, o => o.name)).toMatchObject([
       // Experiments ordered alphabetically by name
       {
+        name: 'adExplanation',
+        active: false,
+        disabled: false
+      },
+      {
         name: 'oneAdForNewUsers',
         active: false,
         disabled: false

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -164,4 +164,21 @@ describe('local user data manager', () => {
     const installTime = getBrowserExtensionInstallTime()
     expect(installTime).toBeNull()
   })
+
+  // setUserDismissedAdExplanation method
+  it('sets the extension install time timestamp in localStorage', () => {
+    const { setUserDismissedAdExplanation } = require('js/utils/local-user-data-mgr')
+    setUserDismissedAdExplanation()
+    expect(localStorageMgr.setItem)
+      .toHaveBeenCalledWith('tab.newUser.dismissedAdExplanation', 'true')
+  })
+
+  // hasUserDismissedAdExplanation
+  it('gets the extension install date from localStorage', () => {
+    localStorageMgr.setItem('tab.newUser.dismissedAdExplanation', 'true')
+    const { hasUserDismissedAdExplanation } = require('js/utils/local-user-data-mgr')
+    expect(hasUserDismissedAdExplanation()).toBe(true)
+    localStorageMgr.setItem('tab.newUser.dismissedAdExplanation', 'blah')
+    expect(hasUserDismissedAdExplanation()).toBe(false)
+  })
 })

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -103,6 +103,7 @@ const NoneExperimentGroup = createExperimentGroup({
 // Add experiment names here as constants.
 export const EXPERIMENT_THIRD_AD = 'thirdAd'
 export const EXPERIMENT_ONE_AD_FOR_NEW_USERS = 'oneAdForNewUsers'
+export const EXPERIMENT_AD_EXPLANATION = 'adExplanation'
 
 // Add ExperimentGroup objects here to enable new experiments.
 // The "name" value of the experiment must be the same as the
@@ -138,6 +139,22 @@ export const experiments = [
       ONE_AD_AT_FIRST: createExperimentGroup({
         value: 'oneAd',
         schemaValue: 'ONE_AD_AT_FIRST'
+      })
+    }
+  }),
+  // @experiment-ad-explanation
+  createExperiment({
+    name: EXPERIMENT_AD_EXPLANATION,
+    active: true,
+    disabled: false,
+    groups: {
+      DEFAULT: createExperimentGroup({
+        value: 'default',
+        schemaValue: 'DEFAULT'
+      }),
+      SHOW_EXPLANATION: createExperimentGroup({
+        value: 'explanation',
+        schemaValue: 'SHOW_EXPLANATION'
       })
     }
   })

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -145,7 +145,7 @@ export const experiments = [
   // @experiment-ad-explanation
   createExperiment({
     name: EXPERIMENT_AD_EXPLANATION,
-    active: true,
+    active: false,
     disabled: false,
     groups: {
       DEFAULT: createExperimentGroup({

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -3,6 +3,7 @@ import moment from 'moment'
 import uuid from 'uuid/v4'
 import localStorageMgr from 'js/utils/localstorage-mgr'
 import {
+  STORAGE_DISMISSED_AD_EXPLANATION,
   STORAGE_EXTENSION_INSTALL_ID,
   STORAGE_APPROX_EXTENSION_INSTALL_TIME,
   STORAGE_TABS_RECENT_DAY_COUNT,
@@ -144,4 +145,21 @@ export const getBrowserExtensionInstallTime = () => {
     return null
   }
   return time
+}
+
+/**
+ * Marks that the user has dismissed the ad explanation.
+ * @returns {undefined}
+ */
+export const setUserDismissedAdExplanation = () => {
+  localStorageMgr.setItem(STORAGE_DISMISSED_AD_EXPLANATION, 'true')
+}
+
+/**
+ * Gets whether the user has dismissed the ad explanation.
+ * @returns {Boolean} Whether the user has dismissed the ad
+ *   explanation.
+ */
+export const hasUserDismissedAdExplanation = () => {
+  return localStorageMgr.getItem(STORAGE_DISMISSED_AD_EXPLANATION) === 'true'
 }


### PR DESCRIPTION
Set up an experiment in which we show new users a message that the ads are raising money for charity. The message appears above the leaderboard ad and will remain for 4 hours after the user joins unless the user dismisses it.