### PR TITLE
Make campaign less intrusive on skinny screens

### DIFF
--- a/web/src/js/components/Campaign/CampaignBase.js
+++ b/web/src/js/components/Campaign/CampaignBase.js
@@ -21,7 +21,7 @@ class CampaignBase extends React.Component {
     }
     const CAMPAIGN_START_TIME_ISO = '2018-11-26T16:00:00.000Z'
     const CAMPAIGN_END_TIME_ISO = '2018-11-30T22:00:00.000Z'
-    const heartsGoal = 10e6
+    const heartsGoal = 18e6
 
     return (
       <QueryRenderer
@@ -102,6 +102,13 @@ class CampaignBase extends React.Component {
                   gutterBottom
                 >
                   Join us in welcoming GiveDirectly to Tab for a Cause with a cornucopia of Hearts!
+                </Typography>
+                <Typography
+                  variant={'body2'}
+                  gutterBottom
+                >
+                  <span style={{ fontWeight: 'bold' }}>Update: </span>congrats, we passed our original{' '}
+                  goal of 10M Hearts! Let's see if we can hit 18M!
                 </Typography>
               </div>
             </HeartDonationCampaign>

--- a/web/src/js/components/Campaign/HeartDonationCampaignComponent.js
+++ b/web/src/js/components/Campaign/HeartDonationCampaignComponent.js
@@ -28,7 +28,7 @@ class HeartDonationCampaign extends React.Component {
     return (
       <div
         style={{
-          width: 440,
+          width: 480,
           paddingTop: 8,
           paddingBottom: 8,
           paddingLeft: 12,

--- a/web/src/js/components/Campaign/HeartDonationCampaignComponent.js
+++ b/web/src/js/components/Campaign/HeartDonationCampaignComponent.js
@@ -28,7 +28,7 @@ class HeartDonationCampaign extends React.Component {
     return (
       <div
         style={{
-          width: 480,
+          width: 440,
           paddingTop: 8,
           paddingBottom: 8,
           paddingLeft: 12,

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -111,8 +111,8 @@ class Dashboard extends React.Component {
     const errorMessage = this.state.errorMessage
 
     const menuStyle = {
-      position: 'absolute',
-      zIndex: 1,
+      position: 'fixed',
+      zIndex: 10,
       top: 14,
       right: 16,
       display: 'flex',
@@ -153,7 +153,9 @@ class Dashboard extends React.Component {
           right: 0,
           bottom: 0,
           left: 0,
-          overflow: 'hidden'
+          overflowY: 'hidden',
+          // Otherwise, campaigns can cover up bookmarks.
+          minWidth: 1080
         }}
         data-test-id={'app-dashboard-id'}
         key={'dashboard-key'}>

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -154,10 +154,11 @@ class Dashboard extends React.Component {
           bottom: 0,
           left: 0,
           overflowY: 'hidden',
+          overflowX: 'auto',
           // Otherwise, campaigns can cover up bookmarks.
           minWidth: 1080
         }}
-        data-test-id={'app-dashboard-id'}
+        data-test-id={'app-dashboard'}
         key={'dashboard-key'}>
         <UserBackgroundImage user={user} showError={this.showError.bind(this)} />
         { user


### PR DESCRIPTION
* Add a minimum width for the dashboard with horizontal scroll to prevent the campaign from covering the widgets.
* Also, increase the Hearts goal for the GiveDirectly campaign