### PR TITLE
Allow unauthenticated users to use search

### DIFF
--- a/graphql/utils/__tests__/dev-tools.test.js
+++ b/graphql/utils/__tests__/dev-tools.test.js
@@ -93,4 +93,26 @@ describe('dev-tools', () => {
     const context = getGraphQLContextFromRequest(minimalRequestObject)
     expect(context).toEqual(expectedContext)
   })
+
+  it('correctly forms GraphQL context from a request object when the user has an Authorization header value of "unauthenticated"', () => {
+    const getGraphQLContextFromRequest = require('../dev-tools').getGraphQLContextFromRequest
+    const minimalRequestObject = {
+      header: (headerName) => {
+        if (headerName === 'Authorization') {
+          return 'unauthenticated'
+        } else {
+          return null
+        }
+      }
+    }
+    const expectedContext = {
+      user: {
+        id: null,
+        email: null,
+        emailVerified: false
+      }
+    }
+    const context = getGraphQLContextFromRequest(minimalRequestObject)
+    expect(context).toEqual(expectedContext)
+  })
 })

--- a/graphql/utils/dev-tools.js
+++ b/graphql/utils/dev-tools.js
@@ -27,15 +27,33 @@ function mockAuthorizer (authorizationToken) {
       email: defaultEmail,
       email_verified: 'true'
     }
-  }
-  const parsedJwt = jwtDecode(authorizationToken)
-  return {
-    id: parsedJwt.sub,
-    // The email and email_verified properties may not exist for
-    // anonymous users.
-    email: parsedJwt.email || null,
-    // The email_verified claim is a string.
-    email_verified: parsedJwt.email_verified ? parsedJwt.email_verified.toString() : 'false'
+
+  // If the request is unauthenticated, allow access but do not
+  // provide any claims.
+  // The client sends the "unauthenticated" placeholder value
+  // because AWS API Gateway's custom authorizers will reject
+  // any request without a token and we want to provide
+  // unauthenticated access to our API.
+  // "If a specified identify source is missing, null, or empty,
+  // API Gateway returns a 401 Unauthorized response without calling
+  // the authorizer Lambda function.”
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html"
+  } else if (authorizationToken === 'unauthenticated') {
+    return {
+      id: null,
+      email: null,
+      email_verified: 'false'
+    }
+  } else {
+    const parsedJwt = jwtDecode(authorizationToken)
+    return {
+      id: parsedJwt.sub,
+      // The email and email_verified properties may not exist for
+      // anonymous users.
+      email: parsedJwt.email || null,
+      // The email_verified claim is a string.
+      email_verified: parsedJwt.email_verified ? parsedJwt.email_verified.toString() : 'false'
+    }
   }
 }
 

--- a/lambda/__mocks__/uuid/v4.js
+++ b/lambda/__mocks__/uuid/v4.js
@@ -1,0 +1,3 @@
+/* eslint-env jest */
+
+module.exports = jest.fn(() => '3ea8049d-861f-4a60-a56d-a61cf73e8b16')

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "dependencies": {
     "aws-sdk": "^2.328.0",
-    "firebase-admin": "^5.5.0"
+    "firebase-admin": "^5.5.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/lambda/src/firebase-authorizer/__tests__/firebase-authorizer.test.js
+++ b/lambda/src/firebase-authorizer/__tests__/firebase-authorizer.test.js
@@ -1,9 +1,10 @@
 /* eslint-env jest */
-
-import * as admin from 'firebase-admin'
 import { cloneDeep } from 'lodash/lang'
 
+jest.mock('uuid/v4')
+
 afterEach(() => {
+  jest.resetModules()
   jest.clearAllMocks()
 })
 
@@ -47,6 +48,7 @@ test('authorization fails when token verification throws an error', (done) => {
   jest.spyOn(console, 'error')
     .mockImplementationOnce(() => {})
 
+  const admin = require('firebase-admin')
   admin.auth.mockImplementation(() => ({
     verifyIdToken: jest.fn(() => {
       return Promise.reject(new Error('Verification failed!'))
@@ -68,6 +70,7 @@ test('authorization fails when token verification throws an error', (done) => {
 test('authorization allows access when a good token is provided (for an authenticated email/password user)', (done) => {
   const decodedToken = cloneDeep(mockDecodedToken)
 
+  const admin = require('firebase-admin')
   admin.auth.mockImplementation(() => ({
     verifyIdToken: jest.fn(() => {
       return Promise.resolve(decodedToken)
@@ -106,6 +109,7 @@ test('authorization allows access when a good token is provided (for an authenti
 test('authorization still allows access when the user\'s email is not verified (for an authenticated email/password user)', (done) => {
   const decodedToken = cloneDeep(mockDecodedToken)
 
+  const admin = require('firebase-admin')
   admin.auth.mockImplementation(() => ({
     verifyIdToken: jest.fn(() => {
       return Promise.resolve(decodedToken)
@@ -142,11 +146,15 @@ test('authorization still allows access when the user\'s email is not verified (
 })
 
 test('authorization denies access when the user does not have an ID', (done) => {
+  const uuid = require('uuid/v4')
+  uuid.mockReturnValue('b919f576-36d7-43a9-8a92-fb978a4c346e')
+
   // Token does not have user ID data
   const decodedToken = cloneDeep(mockDecodedToken)
   delete decodedToken.uid
   delete decodedToken.sub
 
+  const admin = require('firebase-admin')
   admin.auth.mockImplementation(() => ({
     verifyIdToken: jest.fn(() => {
       return Promise.resolve(decodedToken)
@@ -160,7 +168,7 @@ test('authorization denies access when the user does not have an ID', (done) => 
   const context = {}
   const callback = (_, data) => {
     expect(data).toEqual({
-      principalId: undefined,
+      principalId: 'unauthenticated-b919f576-36d7-43a9-8a92-fb978a4c346e',
       policyDocument: {
         Version: '2012-10-17',
         Statement: [
@@ -182,6 +190,7 @@ test('authorization allows access when the user is anonymous (token does not hav
   // Token does not have email info
   const decodedToken = cloneDeep(mockDecodedTokenAnonymousUser)
 
+  const admin = require('firebase-admin')
   admin.auth.mockImplementation(() => ({
     verifyIdToken: jest.fn(() => {
       return Promise.resolve(decodedToken)
@@ -218,6 +227,8 @@ test('authorization allows access when the user is anonymous (token does not hav
 })
 
 test('authorization allows access with no claims when the user has a placeholder "unauthenticated" Authorization header value', (done) => {
+  const uuid = require('uuid/v4')
+  uuid.mockReturnValue('b919f576-36d7-43a9-8a92-fb978a4c346e')
   const checkUserAuthorization = require('../firebase-authorizer').checkUserAuthorization
   const event = {
     authorizationToken: 'unauthenticated',
@@ -227,7 +238,7 @@ test('authorization allows access with no claims when the user has a placeholder
   const callback = (err, data) => {
     expect(err).toBeNull()
     expect(data).toEqual({
-      principalId: null,
+      principalId: 'unauthenticated-b919f576-36d7-43a9-8a92-fb978a4c346e',
       policyDocument: {
         Version: '2012-10-17',
         Statement: [

--- a/lambda/src/firebase-authorizer/__tests__/firebase-authorizer.test.js
+++ b/lambda/src/firebase-authorizer/__tests__/firebase-authorizer.test.js
@@ -217,10 +217,10 @@ test('authorization allows access when the user is anonymous (token does not hav
   checkUserAuthorization(event, context, callback)
 })
 
-test('authorization allows access with no claims when when no token is provided', (done) => {
+test('authorization allows access with no claims when the user has a placeholder "unauthenticated" Authorization header value', (done) => {
   const checkUserAuthorization = require('../firebase-authorizer').checkUserAuthorization
   const event = {
-    authorizationToken: null,
+    authorizationToken: 'unauthenticated',
     methodArn: 'arn:execute-api:blah:blah'
   }
   const context = {}

--- a/lambda/src/firebase-authorizer/firebase-authorizer.js
+++ b/lambda/src/firebase-authorizer/firebase-authorizer.js
@@ -46,9 +46,17 @@ const generatePolicy = function (user, allow, resource) {
 function checkUserAuthorization (event, context, callback) {
   const token = event.authorizationToken
 
-  // With no authorization token, allow access but do not
+  // If the request is unauthenticated, allow access but do not
   // provide any claims.
-  if (!token) {
+  // The client sends the "unauthenticated" placeholder value
+  // because AWS API Gateway's custom authorizers will reject
+  // any request without a token and we want to provide
+  // unauthenticated access to our API.
+  // "If a specified identify source is missing, null, or empty,
+  // API Gateway returns a 401 Unauthorized response without calling
+  // the authorizer Lambda function.”
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html"
+  if (token === 'unauthenticated') {
     const user = {
       uid: null,
       email: null,

--- a/lambda/src/firebase-authorizer/firebase-authorizer.js
+++ b/lambda/src/firebase-authorizer/firebase-authorizer.js
@@ -2,6 +2,7 @@
 
 import * as admin from 'firebase-admin'
 import AWS from 'aws-sdk'
+import uuid from 'uuid/v4'
 
 const encryptedFirebasePrivateKey = process.env['FIREBASE_PRIVATE_KEY']
 let decryptedFirebasePrivateKey = ''
@@ -19,8 +20,16 @@ let decryptedFirebasePrivateKey = ''
  * @returns {object} The AWS policy
  */
 const generatePolicy = function (user, allow, resource) {
+  // AWS might use the principal ID for caching (though I could not
+  // find documentation to confirm this). Though I can't think of
+  // a clear security risk from setting a static principal ID for all
+  // unauthenticated users, let's be cautious and generate unique
+  // IDs for every request.
+  // Related unanswered question:
+  // https://stackoverflow.com/q/48762730
+  const principalId = user.uid || `unauthenticated-${uuid()}`
   return {
-    principalId: user.uid,
+    principalId: principalId,
     policyDocument: {
       Version: '2012-10-17',
       Statement: [

--- a/web/src/js/components/Search/SearchView.js
+++ b/web/src/js/components/Search/SearchView.js
@@ -1,6 +1,7 @@
 /* global graphql */
 
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import environment from 'js/relay-env'
 import SearchPageContainer from 'js/components/Search/SearchPageContainer'
@@ -77,7 +78,13 @@ class SearchView extends React.Component {
   }
 }
 
-// TODO: add PropTypes (location)
+SearchView.propTypes = {
+  location: PropTypes.shape({
+    search: PropTypes.string.isRequired
+  })
+}
+
+SearchView.defaultProps = {}
 
 export default withUserId({
   renderIfNoUser: true

--- a/web/src/js/components/Search/__tests__/SearchView.test.js
+++ b/web/src/js/components/Search/__tests__/SearchView.test.js
@@ -9,7 +9,7 @@ import {
 jest.mock('react-relay')
 jest.mock('js/components/General/withUserId')
 jest.mock('js/analytics/logEvent')
-jest.mock('js/components/Search/SearchContainer')
+jest.mock('js/components/Search/SearchPageContainer')
 
 afterEach(() => {
   jest.resetModules()
@@ -86,7 +86,7 @@ describe('SearchView', () => {
         }}
       />
     )
-    const SearchContainer = require('js/components/Search/SearchContainer').default
+    const SearchContainer = require('js/components/Search/SearchPageContainer').default
     const searchPageContainer = wrapper.find(SearchContainer)
     expect(searchPageContainer.prop('app')).toEqual(fakeProps.app)
     expect(searchPageContainer.prop('user')).toEqual(fakeProps.user)

--- a/web/src/js/relay-env.js
+++ b/web/src/js/relay-env.js
@@ -22,9 +22,16 @@ async function fetchQuery (
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     }
-    if (userToken) {
-      headers['Authorization'] = userToken
-    }
+
+    // If the user does not have a token, send a placeholder value.
+    // We do this because AWS API Gateway's custom authorizers will
+    // reject any request without a token and we want to provide
+    // unauthenticated access to our API.
+    // "If a specified identify source is missing, null, or empty,
+    // API Gateway returns a 401 Unauthorized response without calling
+    // the authorizer Lambda function.”
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html"
+    headers['Authorization'] = userToken || 'unauthenticated'
 
     return fetch(`//${process.env.GRAPHQL_ENDPOINT}`, {
       method: 'POST',


### PR DESCRIPTION
**Note:** this PR should include a handful of commits I recently pushed to master on accident.

* Change our authorizer Lambda function to allow requests with a placeholder "unauthenticated" value for the Authorization header. This authorizes unauthenticated requests to our GraphQL endpoint.  We use a placeholder string for the header value because API Gateway otherwise [automatically rejects the request](https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html"): "If a specified identify source is missing, null, or empty, API Gateway returns a 401 Unauthorized response without calling the authorizer Lambda function."
* Change our GraphQL authorization logic to allow null user IDs
* Make the `withUserId` higher-order component able to render components for unauthenticated users who don't have an ID
* Create different SearchView queries, one for authenticated users and one for unauthenticated users
* In the Lambda service, upgrade Jest and a handful of other dev dependencies
