### PR TITLE
Log search source

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -704,6 +704,7 @@ const logSearchMutation = mutationWithClientMutationId({
   inputFields: {
     // Note that this is the raw user ID (not the Relay global).
     userId: { type: new GraphQLNonNull(GraphQLString) },
+    source: { type: GraphQLString },
   },
   outputFields: {
     user: {
@@ -711,7 +712,8 @@ const logSearchMutation = mutationWithClientMutationId({
       resolve: user => user,
     },
   },
-  mutateAndGetPayload: ({ userId }, context) => logSearch(context.user, userId),
+  mutateAndGetPayload: ({ userId, ...additionalData }, context) =>
+    logSearch(context.user, userId, additionalData),
 })
 
 /**

--- a/graphql/database/users/logSearch.js
+++ b/graphql/database/users/logSearch.js
@@ -12,9 +12,7 @@ const MAX_DAILY_HEARTS_FROM_SEARCHES = 150
  * @param {string} userId - The user id.
  * @return {Promise<User>} A promise that resolves into a User instance.
  */
-const logSearch = async (userContext, userId) => {
-  // Check if it's a valid tab before incrementing user VC or
-  // the user's valid tab count.
+const logSearch = async (userContext, userId, searchData = {}) => {
   let user
   try {
     user = await UserModel.get(userContext, userId)
@@ -62,9 +60,15 @@ const logSearch = async (userContext, userId) => {
     })
 
     // Log the search for analytics.
+    const validSearchSources = ['self', 'chrome', 'ff', 'tab']
+    const source =
+      searchData.source && validSearchSources.indexOf(searchData.source) > -1
+        ? searchData.source
+        : null
     await UserSearchLogModel.create(userContext, {
       userId,
       timestamp: moment.utc().toISOString(),
+      ...(source && { source }),
     })
   } catch (e) {
     throw e

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -229,6 +229,7 @@ type LogEmailVerifiedMutationPayload {
 
 input LogSearchInput {
   userId: String!
+  source: String
   clientMutationId: String
 }
 

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -128,6 +128,10 @@ class SearchPage extends React.Component {
       modifyURLParams({
         page: 1,
         q: newQuery,
+        src: 'self',
+      })
+      this.setState({
+        searchSource: 'self',
       })
     }
   }

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -58,6 +58,7 @@ class SearchPage extends React.Component {
     this.state = {
       query: '',
       searchFeatureEnabled: isSearchPageEnabled(),
+      searchSource: null,
       searchText: '',
       showPlaceholderText: false,
     }
@@ -81,6 +82,7 @@ class SearchPage extends React.Component {
       query: query,
       page: this.getPageNumberFromSearchString(location.search),
       showPlaceholderText: !isReactSnapClient(),
+      searchSource: parseUrlSearchString(location.search).src || null,
       searchText: query,
     })
   }
@@ -138,7 +140,7 @@ class SearchPage extends React.Component {
 
   render() {
     const { classes } = this.props
-    const { page, query, searchText } = this.state
+    const { page, query, searchSource, searchText } = this.state
     const queryEncoded = query ? encodeURI(query) : ''
     const searchResultsPaddingLeft = 170
     if (!this.state.searchFeatureEnabled) {
@@ -302,6 +304,7 @@ class SearchPage extends React.Component {
                 page: newPageIndex,
               })
             }}
+            searchSource={searchSource}
             style={{
               marginLeft: searchResultsPaddingLeft,
               maxWidth: 600,

--- a/web/src/js/components/Search/SearchResults.js
+++ b/web/src/js/components/Search/SearchResults.js
@@ -181,7 +181,7 @@ class SearchResults extends React.Component {
       })
       return
     }
-    const { page, query } = this.props
+    const { page, query, searchSource } = this.props
     if (!query) {
       return
     }
@@ -193,6 +193,7 @@ class SearchResults extends React.Component {
       if (user && user.id) {
         LogSearchMutation({
           userId: user.id,
+          ...(searchSource && { source: searchSource }),
         })
       }
     })
@@ -362,6 +363,7 @@ SearchResults.propTypes = {
   page: PropTypes.number,
   onPageChange: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
+  searchSource: PropTypes.string,
   style: PropTypes.object,
   theme: PropTypes.object.isRequired,
 }

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -160,7 +160,7 @@ describe('Search page component', () => {
     expect(wrapper.find(Input).prop('value')).toBe('blahblah')
   })
 
-  it('clicking the search button updates the "q" URL parameter and sets the page to 1', () => {
+  it('clicking the search button updates the "q" URL parameter, sets the page to 1, and sets the "src" to "self"', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
     const mockProps = getMockProps()
@@ -178,10 +178,11 @@ describe('Search page component', () => {
     expect(modifyURLParams).toHaveBeenCalledWith({
       q: 'free ice cream',
       page: 1,
+      src: 'self',
     })
   })
 
-  it('hitting enter in the search input updates the "q" URL parameter  and sets the page to 1', () => {
+  it('hitting enter in the search input updates the "q" URL parameter, sets the page to 1, and sets the "src" to "self"', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
     const mockProps = getMockProps()
@@ -197,6 +198,7 @@ describe('Search page component', () => {
     expect(modifyURLParams).toHaveBeenCalledWith({
       q: 'register to vote',
       page: 1,
+      src: 'self',
     })
   })
 
@@ -271,6 +273,23 @@ describe('Search page component', () => {
     mockProps.location.search = '?q=foo'
     const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
     expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
+  })
+
+  it('passes "self" as the "searchSource" the SearchResults component when entering a new search on the page', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = ''
+    const wrapper = mount(<SearchPageComponent {...mockProps} />)
+    expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
+    const searchInput = wrapper
+      .find(Input)
+      .first()
+      .find('input')
+    searchInput
+      .simulate('change', { target: { value: 'register to vote' } })
+      .simulate('keypress', { key: 'Enter' })
+    expect(wrapper.find(SearchResults).prop('searchSource')).toEqual('self')
   })
 
   // This is important for prerendering scripts for search results.

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -244,6 +244,35 @@ describe('Search page component', () => {
     expect(wrapper.find(SearchResults).prop('page')).toBe(12)
   })
 
+  it('passes "1" as the default page number to the SearchResults component when the "page" URL param is not set', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=foo'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResults).prop('page')).toBe(1)
+  })
+
+  it('passes the search source to the SearchResults component when the "page" URL param is set', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=foo&src=some-source'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResults).prop('searchSource')).toEqual(
+      'some-source'
+    )
+  })
+
+  it('passes null as the search source to the SearchResults component when the "src" URL param is not set', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=foo'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
+  })
+
   // This is important for prerendering scripts for search results.
   it('renders the SearchResults component on mount even if there is no query', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')

--- a/web/src/js/components/Search/__tests__/SearchResults.test.js
+++ b/web/src/js/components/Search/__tests__/SearchResults.test.js
@@ -31,6 +31,7 @@ const getMockProps = () => ({
   page: 1,
   onPageChange: jest.fn(),
   query: 'tacos',
+  searchSource: null,
 })
 
 beforeAll(() => {
@@ -955,5 +956,29 @@ describe('SearchResults component', () => {
     shallow(<SearchResults {...mockProps} />).dive()
     await flushAllPromises()
     expect(LogSearchMutation).not.toHaveBeenCalled()
+  })
+
+  it('logs the search source when the prop is provided', async () => {
+    expect.assertions(2)
+
+    getCurrentUser.mockResolvedValue({
+      id: 'abc123xyz789',
+      email: 'example@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    const SearchResults = require('js/components/Search/SearchResults').default
+    const mockProps = getMockProps()
+    mockProps.query = 'foo'
+    mockProps.searchSource = 'somesource'
+    window.searchforacause.search.fetchedOnPageLoad = false
+    shallow(<SearchResults {...mockProps} />).dive()
+    await flushAllPromises()
+    expect(LogSearchMutation).toHaveBeenCalledTimes(1)
+    expect(LogSearchMutation).toHaveBeenCalledWith({
+      userId: 'abc123xyz789',
+      source: 'somesource',
+    })
   })
 })

--- a/web/src/js/mutations/LogSearchMutation.js
+++ b/web/src/js/mutations/LogSearchMutation.js
@@ -18,11 +18,11 @@ const mutation = graphql`
   }
 `
 
-export default ({ userId }) => {
+export default input => {
   return commitMutation(environment, {
     mutation,
     variables: {
-      input: { userId },
+      input: input,
     },
   })
 }

--- a/web/src/js/mutations/__tests__/LogSearchMutation.test.js
+++ b/web/src/js/mutations/__tests__/LogSearchMutation.test.js
@@ -9,6 +9,7 @@ jest.mock('relay-commit-mutation-promise')
 
 const getMockInput = () => ({
   userId: 'abc-123',
+  source: 'ff',
 })
 
 const getMockAdditionalVars = () => ({})


### PR DESCRIPTION
* When logging a search event, pass a "source" value equal to the "src" URL parameter
* Log the source value to UserSearchLog. It will only log valid search values:
  * `chrome`: a search originating from the Chrome browser extension
  * `ff`: a search originating from the Firefox browser extension
  * `self`: a search originating from the search page; i.e. searching again
  * `tab`:  a search originating from the Tab for a Cause new tab page search widget
* When searching from the Search for a Cause page, set the "src" URL parameter value to "self"
* Now, we should update the browser extensions to append the appropriate "src" value