### PR TITLE
Show "max hearts from searching" message when needed

### DIFF
--- a/web/src/js/components/Dashboard/HeartsComponent.js
+++ b/web/src/js/components/Dashboard/HeartsComponent.js
@@ -49,7 +49,13 @@ class HeartsComponent extends React.Component {
   }
 
   render() {
-    const { app, classes, theme, user } = this.props
+    const {
+      app,
+      classes,
+      showMaxHeartsFromTabsMessage,
+      theme,
+      user,
+    } = this.props
     const { isHovering, isPopoverOpen } = this.state
     const anchorElement = this.anchorElement
 
@@ -117,7 +123,7 @@ class HeartsComponent extends React.Component {
                 }}
                 className={classes.heartIcon}
               />
-              {reachedMaxDailyHeartsFromTabs ? (
+              {showMaxHeartsFromTabsMessage && reachedMaxDailyHeartsFromTabs ? (
                 <CheckmarkIcon
                   style={{
                     color:
@@ -150,7 +156,12 @@ class HeartsComponent extends React.Component {
           }}
         />
         <MaxHeartsDropdownMessageComponent
-          open={reachedMaxDailyHeartsFromTabs && isHovering && !isPopoverOpen}
+          open={
+            showMaxHeartsFromTabsMessage &&
+            reachedMaxDailyHeartsFromTabs &&
+            isHovering &&
+            !isPopoverOpen
+          }
           anchorElement={anchorElement}
         />
       </div>
@@ -166,11 +177,13 @@ HeartsComponent.propTypes = {
     tabsToday: PropTypes.number.isRequired,
     vcCurrent: PropTypes.number.isRequired,
   }),
+  showMaxHeartsFromTabsMessage: PropTypes.bool,
   theme: PropTypes.object.isRequired,
 }
 
 HeartsComponent.defaultProps = {
   classes: {},
+  showMaxHeartsFromTabsMessage: false,
 }
 
 export default withStyles(styles, { withTheme: true })(HeartsComponent)

--- a/web/src/js/components/Dashboard/HeartsComponent.js
+++ b/web/src/js/components/Dashboard/HeartsComponent.js
@@ -163,6 +163,8 @@ class HeartsComponent extends React.Component {
             !isPopoverOpen
           }
           anchorElement={anchorElement}
+          message={`You've earned the maximum Hearts from opening tabs today! You'll be
+          able to earn more Hearts in a few hours.`}
         />
       </div>
     )

--- a/web/src/js/components/Dashboard/HeartsComponent.js
+++ b/web/src/js/components/Dashboard/HeartsComponent.js
@@ -7,7 +7,10 @@ import HeartBorderIcon from '@material-ui/icons/FavoriteBorder'
 import CheckmarkIcon from '@material-ui/icons/Done'
 import Typography from '@material-ui/core/Typography'
 import { commaFormatted } from 'js/utils/utils'
-import { MAX_DAILY_HEARTS_FROM_TABS } from 'js/constants'
+import {
+  MAX_DAILY_HEARTS_FROM_SEARCHES,
+  MAX_DAILY_HEARTS_FROM_TABS,
+} from 'js/constants'
 import HeartsDropdown from 'js/components/Dashboard/HeartsDropdownContainer'
 import MaxHeartsDropdownMessageComponent from 'js/components/Dashboard/MaxHeartsDropdownMessageComponent'
 
@@ -52,6 +55,7 @@ class HeartsComponent extends React.Component {
     const {
       app,
       classes,
+      showMaxHeartsFromSearchesMessage,
       showMaxHeartsFromTabsMessage,
       theme,
       user,
@@ -59,11 +63,12 @@ class HeartsComponent extends React.Component {
     const { isHovering, isPopoverOpen } = this.state
     const anchorElement = this.anchorElement
 
-    // Used to let the user know they aren't earning any more
-    // Hearts from tabs today.
+    // Let the user know they aren't earning any more Hearts from
+    // tabs or searches today.
     const reachedMaxDailyHeartsFromTabs =
       user.tabsToday >= MAX_DAILY_HEARTS_FROM_TABS
-
+    const reachedMaxDailyHeartsFromSearches =
+      user.searchesToday >= MAX_DAILY_HEARTS_FROM_SEARCHES
     return (
       <div>
         <ButtonBase className={classes.buttonBase}>
@@ -123,7 +128,10 @@ class HeartsComponent extends React.Component {
                 }}
                 className={classes.heartIcon}
               />
-              {showMaxHeartsFromTabsMessage && reachedMaxDailyHeartsFromTabs ? (
+              {(showMaxHeartsFromTabsMessage &&
+                reachedMaxDailyHeartsFromTabs) ||
+              (showMaxHeartsFromSearchesMessage &&
+                reachedMaxDailyHeartsFromSearches) ? (
                 <CheckmarkIcon
                   style={{
                     color:
@@ -157,14 +165,22 @@ class HeartsComponent extends React.Component {
         />
         <MaxHeartsDropdownMessageComponent
           open={
-            showMaxHeartsFromTabsMessage &&
-            reachedMaxDailyHeartsFromTabs &&
+            ((showMaxHeartsFromTabsMessage && reachedMaxDailyHeartsFromTabs) ||
+              (showMaxHeartsFromSearchesMessage &&
+                reachedMaxDailyHeartsFromSearches)) &&
             isHovering &&
             !isPopoverOpen
           }
           anchorElement={anchorElement}
-          message={`You've earned the maximum Hearts from opening tabs today! You'll be
-          able to earn more Hearts in a few hours.`}
+          message={
+            reachedMaxDailyHeartsFromTabs && reachedMaxDailyHeartsFromSearches
+              ? `You've earned the maximum Hearts for now. You'll be able to earn more Hearts in a while.`
+              : reachedMaxDailyHeartsFromTabs
+              ? `You've earned the maximum Hearts from opening tabs today! You'll be able to earn more Hearts in a while.`
+              : reachedMaxDailyHeartsFromSearches
+              ? `You've earned the maximum Hearts from searching today! You'll be able to earn more Hearts in a while.`
+              : `You've earned the maximum Hearts for now.`
+          }
         />
       </div>
     )
@@ -176,15 +192,18 @@ HeartsComponent.displayName = 'HeartsComponent'
 HeartsComponent.propTypes = {
   classes: PropTypes.object.isRequired,
   user: PropTypes.shape({
+    searchesToday: PropTypes.number.isRequired,
     tabsToday: PropTypes.number.isRequired,
     vcCurrent: PropTypes.number.isRequired,
   }),
+  showMaxHeartsFromSearchesMessage: PropTypes.bool,
   showMaxHeartsFromTabsMessage: PropTypes.bool,
   theme: PropTypes.object.isRequired,
 }
 
 HeartsComponent.defaultProps = {
   classes: {},
+  showMaxHeartsFromSearchesMessage: false,
   showMaxHeartsFromTabsMessage: false,
 }
 

--- a/web/src/js/components/Dashboard/HeartsContainer.js
+++ b/web/src/js/components/Dashboard/HeartsContainer.js
@@ -12,6 +12,7 @@ export default createFragmentContainer(Hearts, {
   user: graphql`
     fragment HeartsContainer_user on User {
       vcCurrent
+      searchesToday
       tabsToday
       ...HeartsDropdownContainer_user
     }

--- a/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
+++ b/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
@@ -4,11 +4,8 @@ import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import DashboardPopover from 'js/components/Dashboard/DashboardPopover'
 
-const styles = {
-  typography: {
-    color: 'white',
-  },
-}
+const styles = {}
+
 const MaxHeartsDropdownMessageComponent = props => {
   const { anchorElement, classes } = props
   return (

--- a/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
+++ b/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
@@ -7,7 +7,7 @@ import DashboardPopover from 'js/components/Dashboard/DashboardPopover'
 const styles = {}
 
 const MaxHeartsDropdownMessageComponent = props => {
-  const { anchorElement } = props
+  const { anchorElement, message } = props
   return (
     <DashboardPopover
       open={props.open}
@@ -23,10 +23,7 @@ const MaxHeartsDropdownMessageComponent = props => {
       }}
     >
       <div style={{ padding: 10, width: 210, textAlign: 'center' }}>
-        <Typography variant={'body2'}>
-          You've earned the maximum Hearts from opening tabs today! You'll be
-          able to earn more Hearts in a few hours.
-        </Typography>
+        <Typography variant={'body2'}>{message}</Typography>
       </div>
     </DashboardPopover>
   )
@@ -38,6 +35,7 @@ MaxHeartsDropdownMessageComponent.displayName =
 MaxHeartsDropdownMessageComponent.propTypes = {
   anchorElement: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   classes: PropTypes.object.isRequired,
+  message: PropTypes.string.isRequired,
   open: PropTypes.bool.isRequired,
 }
 

--- a/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
+++ b/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
@@ -19,6 +19,7 @@ const MaxHeartsDropdownMessageComponent = props => {
       // https://github.com/mui-org/material-ui/issues/9893#issuecomment-406891098
       style={{
         pointerEvents: 'none',
+        marginTop: 6,
       }}
     >
       <div style={{ padding: 10, width: 210, textAlign: 'center' }}>

--- a/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
+++ b/web/src/js/components/Dashboard/MaxHeartsDropdownMessageComponent.js
@@ -7,7 +7,7 @@ import DashboardPopover from 'js/components/Dashboard/DashboardPopover'
 const styles = {}
 
 const MaxHeartsDropdownMessageComponent = props => {
-  const { anchorElement, classes } = props
+  const { anchorElement } = props
   return (
     <DashboardPopover
       open={props.open}
@@ -23,7 +23,7 @@ const MaxHeartsDropdownMessageComponent = props => {
       }}
     >
       <div style={{ padding: 10, width: 210, textAlign: 'center' }}>
-        <Typography className={classes.typography} variant={'body2'}>
+        <Typography variant={'body2'}>
           You've earned the maximum Hearts from opening tabs today! You'll be
           able to earn more Hearts in a few hours.
         </Typography>

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -125,7 +125,7 @@ class UserMenu extends React.Component {
               root: classes.circleIcon,
             }}
           />
-          <Hearts app={app} user={user} />
+          <Hearts app={app} user={user} showMaxHeartsFromTabsMessage />
           <SettingsButton isUserAnonymous={isUserAnonymous} />
         </div>
       </MuiThemeProvider>

--- a/web/src/js/components/Dashboard/__tests__/HeartsComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/HeartsComponent.test.js
@@ -14,14 +14,17 @@ import { mountWithHOC } from 'js/utils/test-utils'
 jest.mock('js/components/Dashboard/HeartsDropdownContainer')
 jest.mock('js/components/Dashboard/MaxHeartsDropdownMessageComponent')
 jest.mock('js/constants', () => ({
+  MAX_DAILY_HEARTS_FROM_SEARCHES: 1000,
   MAX_DAILY_HEARTS_FROM_TABS: 1000,
 }))
 
 const getMockProps = () => ({
   user: {
+    searchesToday: 0,
     tabsToday: 31,
     vcCurrent: 482,
   },
+  showMaxHeartsFromSearchesMessage: false,
   showMaxHeartsFromTabsMessage: false,
 })
 
@@ -107,7 +110,37 @@ describe('HeartsComponent', () => {
     expect(wrapper.find(CheckmarkIcon).exists()).toBe(false)
   })
 
-  it('does not show the "max hearts from tabs" dropdown on hover if the user has not maxed out daily hearts from tabs', () => {
+  it('does not show a checkmark in the heart if the user has not maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = true
+    mockProps.user.searchesToday = 999
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    expect(wrapper.find(CheckmarkIcon).exists()).toBe(false)
+  })
+
+  it('shows a checkmark in the heart if the user has maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = true
+    mockProps.user.searchesToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    expect(wrapper.find(CheckmarkIcon).exists()).toBe(true)
+  })
+
+  it('does not show a checkmark in the heart if "showMaxHeartsFromTabsMessage" is false, even when the user has maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = false
+    mockProps.user.searchesToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    expect(wrapper.find(CheckmarkIcon).exists()).toBe(false)
+  })
+
+  it('does not show the "max hearts" dropdown on hover if the user has not maxed out daily hearts from tabs', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
@@ -120,7 +153,7 @@ describe('HeartsComponent', () => {
     )
   })
 
-  it('shows the "max hearts from tabs" dropdown on hover if the user has maxed out daily hearts from tabs', () => {
+  it('shows the "max hearts" dropdown on hover if the user has maxed out daily hearts from tabs', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
@@ -133,7 +166,7 @@ describe('HeartsComponent', () => {
     )
   })
 
-  it('does not show the "max hearts from tabs" dropdown on hover if "showMaxHeartsFromTabsMessage" is false, even when the user has maxed out daily hearts from tabs', () => {
+  it('does not show the "max hearts" dropdown on hover if "showMaxHeartsFromTabsMessage" is false, even when the user has maxed out daily hearts from tabs', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
@@ -146,7 +179,46 @@ describe('HeartsComponent', () => {
     )
   })
 
-  it('does not show the "max hearts from tabs" dropdown if the hearts dropdown is open', () => {
+  it('does not show the "max hearts" dropdown on hover if the user has not maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = true
+    mockProps.user.searchesToday = 999
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(wrapper.find(MaxHeartsDropdownMessageComponent).prop('open')).toBe(
+      false
+    )
+  })
+
+  it('shows the "max hearts" dropdown on hover if the user has maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = true
+    mockProps.user.searchesToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(wrapper.find(MaxHeartsDropdownMessageComponent).prop('open')).toBe(
+      true
+    )
+  })
+
+  it('does not show the "max hearts" dropdown on hover if "showMaxHeartsFromSearchesMessage" is false, even when the user has maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = false
+    mockProps.user.searchesToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(wrapper.find(MaxHeartsDropdownMessageComponent).prop('open')).toBe(
+      false
+    )
+  })
+
+  it('does not show the "max hearts" dropdown if the hearts dropdown is open', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
@@ -162,6 +234,53 @@ describe('HeartsComponent', () => {
       false
     )
     expect(wrapper.find(HeartsDropdown).prop('open')).toBe(true)
+  })
+
+  it('shows the expected "max hearts" message if the user has maxed out daily hearts from tabs', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
+    mockProps.user.tabsToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(
+      wrapper.find(MaxHeartsDropdownMessageComponent).prop('message')
+    ).toBe(
+      `You've earned the maximum Hearts from opening tabs today! You'll be able to earn more Hearts in a while.`
+    )
+  })
+
+  it('shows the expected "max hearts" message if the user has maxed out daily hearts from searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromSearchesMessage = true
+    mockProps.user.searchesToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(
+      wrapper.find(MaxHeartsDropdownMessageComponent).prop('message')
+    ).toBe(
+      `You've earned the maximum Hearts from searching today! You'll be able to earn more Hearts in a while.`
+    )
+  })
+
+  it('shows the expected "max hearts" message if the user has maxed out daily hearts from tabs AND searches', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
+    mockProps.user.tabsToday = 1000
+    mockProps.showMaxHeartsFromSearchesMessage = true
+    mockProps.user.searchesToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(
+      wrapper.find(MaxHeartsDropdownMessageComponent).prop('message')
+    ).toBe(
+      `You've earned the maximum Hearts for now. You'll be able to earn more Hearts in a while.`
+    )
   })
 
   it('uses the MUI h2 Typography variant for the main text (this is important because our nested theme styles the h2 variant)', () => {

--- a/web/src/js/components/Dashboard/__tests__/HeartsComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/HeartsComponent.test.js
@@ -22,6 +22,7 @@ const getMockProps = () => ({
     tabsToday: 31,
     vcCurrent: 482,
   },
+  showMaxHeartsFromTabsMessage: false,
 })
 
 afterEach(() => {
@@ -80,6 +81,7 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 999
     const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
     expect(wrapper.find(CheckmarkIcon).exists()).toBe(false)
@@ -89,15 +91,27 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 1000
     const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
     expect(wrapper.find(CheckmarkIcon).exists()).toBe(true)
+  })
+
+  it('does not show a checkmark in the heart if "showMaxHeartsFromTabsMessage" is false, even when the user has maxed out daily hearts from tabs', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = false
+    mockProps.user.tabsToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    expect(wrapper.find(CheckmarkIcon).exists()).toBe(false)
   })
 
   it('does not show the "max hearts from tabs" dropdown on hover if the user has not maxed out daily hearts from tabs', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 999
     const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
     wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
@@ -110,6 +124,7 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 1000
     const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
     wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
@@ -118,10 +133,24 @@ describe('HeartsComponent', () => {
     )
   })
 
+  it('does not show the "max hearts from tabs" dropdown on hover if "showMaxHeartsFromTabsMessage" is false, even when the user has maxed out daily hearts from tabs', () => {
+    const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = false
+    mockProps.user.tabsToday = 1000
+    const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
+    wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
+    expect(wrapper.find(MaxHeartsDropdownMessageComponent).prop('open')).toBe(
+      false
+    )
+  })
+
   it('does not show the "max hearts from tabs" dropdown if the hearts dropdown is open', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 1000
     const wrapper = shallow(<HeartsComponent {...mockProps} />).dive()
     wrapper.find('[data-tour-id="hearts"]').simulate('mouseenter')
@@ -153,6 +182,7 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     const wrapper = mount(
       <MuiThemeProvider
         theme={{
@@ -313,6 +343,7 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 1001
     const wrapper = mount(
       <MuiThemeProvider
@@ -348,6 +379,7 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 1001
     const wrapper = mount(
       <MuiThemeProvider
@@ -385,6 +417,7 @@ describe('HeartsComponent', () => {
     const HeartsComponent = require('js/components/Dashboard/HeartsComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.showMaxHeartsFromTabsMessage = true
     mockProps.user.tabsToday = 1001
     const wrapper = mount(
       <MuiThemeProvider

--- a/web/src/js/components/Dashboard/__tests__/MaxHeartsDropdownMessageComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/MaxHeartsDropdownMessageComponent.test.js
@@ -9,6 +9,7 @@ jest.mock('js/components/Dashboard/DashboardPopover')
 
 const getMockProps = () => ({
   anchorElement: <div id="foo" />,
+  message: `You've earned the maximum Hearts for now.`,
   open: false,
 })
 
@@ -24,6 +25,7 @@ describe('MaxHeartsDropdownMessageComponent', () => {
     const MaxHeartsDropdownMessageComponent = require('js/components/Dashboard/MaxHeartsDropdownMessageComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.message = `You've earned the maximum Hearts for now :( Try again later`
     const wrapper = shallow(
       <MaxHeartsDropdownMessageComponent {...mockProps} />
     ).dive()
@@ -33,9 +35,7 @@ describe('MaxHeartsDropdownMessageComponent', () => {
         .first()
         .render()
         .text()
-    ).toEqual(
-      "You've earned the maximum Hearts from opening tabs today! You'll be able to earn more Hearts in a few hours."
-    )
+    ).toEqual(`You've earned the maximum Hearts for now :( Try again later`)
   })
 
   it('uses the MUI body2 Typography variant for the main text (this is important because our nested theme styles the body2 variant)', () => {

--- a/web/src/js/components/Dashboard/__tests__/MaxHeartsDropdownMessageComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/MaxHeartsDropdownMessageComponent.test.js
@@ -38,6 +38,21 @@ describe('MaxHeartsDropdownMessageComponent', () => {
     )
   })
 
+  it('uses the MUI body2 Typography variant for the main text (this is important because our nested theme styles the body2 variant)', () => {
+    const MaxHeartsDropdownMessageComponent = require('js/components/Dashboard/MaxHeartsDropdownMessageComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(
+      <MaxHeartsDropdownMessageComponent {...mockProps} />
+    ).dive()
+    expect(
+      wrapper
+        .find(Typography)
+        .first()
+        .prop('variant')
+    ).toEqual('body2')
+  })
+
   it('passes the "open" prop to DashboardPopover', () => {
     const MaxHeartsDropdownMessageComponent = require('js/components/Dashboard/MaxHeartsDropdownMessageComponent')
       .default

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -47,6 +47,15 @@ describe('User menu component', () => {
     expect(wrapper.find(Hearts).exists()).toBe(true)
   })
 
+  it('sets the "showMaxHeartsFromTabsMessage" to true on the Hearts component', () => {
+    const mockProps = getMockProps()
+    mockProps.isUserAnonymous = false
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find(Hearts).prop('showMaxHeartsFromTabsMessage')).toBe(true)
+  })
+
   it('passes the isUserAnonymous prop to the SettingsButton component', () => {
     const mockProps = getMockProps()
     mockProps.isUserAnonymous = false

--- a/web/src/js/components/Search/SearchMenuComponent.js
+++ b/web/src/js/components/Search/SearchMenuComponent.js
@@ -88,7 +88,7 @@ const SearchMenuComponent = props => {
                 root: classes.circleIcon,
               }}
             />
-            <Hearts app={app} user={user} />
+            <Hearts app={app} user={user} showMaxHeartsFromSearchesMessage />
             <SettingsButton isUserAnonymous={false} />
           </div>
         ) : null}

--- a/web/src/js/components/Search/__tests__/SearchMenuComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchMenuComponent.test.js
@@ -74,6 +74,20 @@ describe('SearchMenuComponent', () => {
     expect(wrapper.find(Hearts).exists()).toBe(true)
   })
 
+  it('sets the "showMaxHeartsFromSearchesMessage" to true on the Hearts component', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user = {
+      tabsToday: 123,
+      vcCurrent: 864,
+    }
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find(Hearts).prop('showMaxHeartsFromSearchesMessage')).toBe(
+      true
+    )
+  })
+
   it('does not show the CircleIcon component if there is no user', () => {
     const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
       .default

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -2,6 +2,7 @@
   Configuration
 **/
 
+export const MAX_DAILY_HEARTS_FROM_SEARCHES = 150
 export const MAX_DAILY_HEARTS_FROM_TABS = 150
 
 /**


### PR DESCRIPTION
This PR makes the Hearts component able to show separate messages when the user has earned the maximum daily "hearts from tabs" and when the user has earned the maximum daily "hearts from searches" .