### PR TITLE
Show "unable to search" when an ad blocker is enabled

### DIFF
--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -393,6 +393,7 @@ class SearchPage extends React.Component {
                 page: newPageIndex,
               })
             }}
+            isAdBlockerEnabled={isAdBlockerEnabled}
             searchSource={searchSource}
             style={{
               marginLeft: searchResultsPaddingLeft,

--- a/web/src/js/components/Search/SearchResults.js
+++ b/web/src/js/components/Search/SearchResults.js
@@ -234,7 +234,14 @@ class SearchResults extends React.Component {
   }
 
   render() {
-    const { classes, page, query, style, theme } = this.props
+    const {
+      classes,
+      isAdBlockerEnabled,
+      page,
+      query,
+      style,
+      theme,
+    } = this.props
 
     // Include 8 pages total, 4 lower and 4 higher when possible.
     // Page 9999 is the maximum, so stop there.
@@ -253,7 +260,9 @@ class SearchResults extends React.Component {
             // Min height prevents visibly shifting content below,
             // like the footer.
             minHeight:
-              this.state.noSearchResults || this.state.unexpectedSearchError
+              this.state.noSearchResults ||
+              this.state.unexpectedSearchError ||
+              isAdBlockerEnabled
                 ? 0
                 : 1200,
           },
@@ -272,7 +281,7 @@ class SearchResults extends React.Component {
             <span style={{ fontWeight: 'bold' }}>{query}</span>
           </Typography>
         ) : null}
-        {this.state.unexpectedSearchError ? (
+        {this.state.unexpectedSearchError || isAdBlockerEnabled ? (
           <Typography variant={'body1'} gutterBottom>
             Unable to search at this time.
           </Typography>
@@ -304,7 +313,9 @@ class SearchResults extends React.Component {
           className={classes.paginationContainer}
           style={{
             display:
-              this.state.noSearchResults || this.state.unexpectedSearchError
+              this.state.noSearchResults ||
+              this.state.unexpectedSearchError ||
+              isAdBlockerEnabled
                 ? 'none'
                 : 'block',
           }}
@@ -359,6 +370,7 @@ class SearchResults extends React.Component {
 }
 
 SearchResults.propTypes = {
+  isAdBlockerEnabled: PropTypes.bool.isRequired,
   query: PropTypes.string,
   page: PropTypes.number,
   onPageChange: PropTypes.func.isRequired,
@@ -369,6 +381,7 @@ SearchResults.propTypes = {
 }
 
 SearchResults.defaultProps = {
+  isAdBlockerEnabled: false,
   page: 1,
   style: {},
 }

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -257,6 +257,28 @@ describe('Search page component', () => {
     expect(wrapper.find(SearchResults).prop('page')).toBe(12)
   })
 
+  it('passes "isAdBlockerEnabled = false" to the SearchResults component', async () => {
+    expect.assertions(1)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectAdblocker.mockResolvedValue(false)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    await flushAllPromises()
+    expect(wrapper.find(SearchResults).prop('isAdBlockerEnabled')).toBe(false)
+  })
+
+  it('passes "isAdBlockerEnabled = true" to the SearchResults component', async () => {
+    expect.assertions(1)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectAdblocker.mockResolvedValue(true)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    await flushAllPromises()
+    expect(wrapper.find(SearchResults).prop('isAdBlockerEnabled')).toBe(true)
+  })
+
   it('passes "1" as the default page number to the SearchResults component when the "page" URL param is not set', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default

--- a/web/src/js/components/Search/__tests__/SearchResults.test.js
+++ b/web/src/js/components/Search/__tests__/SearchResults.test.js
@@ -319,6 +319,18 @@ describe('SearchResults component', () => {
     expect(wrapper.get(0).props.style.minHeight).toBe(0)
   })
 
+  it('removes the a min-height from the results container if ad ad blocker is enabled (because it may block the search request entirely)', () => {
+    const SearchResults = require('js/components/Search/SearchResults').default
+    const mockProps = getMockProps()
+    mockProps.isAdBlockerEnabled = true
+    const wrapper = shallow(<SearchResults {...mockProps} />).dive()
+    const query = 'this search will be blocked'
+    wrapper.setProps({
+      query: query,
+    })
+    expect(wrapper.get(0).props.style.minHeight).toBe(0)
+  })
+
   it('shows an error message and logs an error when the search errors with "URL_UNREGISTERED"', () => {
     const SearchResults = require('js/components/Search/SearchResults').default
     const mockProps = getMockProps()
@@ -363,6 +375,22 @@ describe('SearchResults component', () => {
         SOMETHING_WE_DID_NOT_SEE_COMING: 1,
       })
     )
+  })
+
+  it('shows an error message when an ad blocker is enabled', () => {
+    const SearchResults = require('js/components/Search/SearchResults').default
+    const mockProps = getMockProps()
+    mockProps.query = 'foo'
+    mockProps.isAdBlockerEnabled = true
+    const wrapper = shallow(<SearchResults {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find(Typography)
+        .filterWhere(
+          n => n.render().text() === 'Unable to search at this time.'
+        )
+        .exists()
+    ).toBe(true)
   })
 
   it('shows an error message and logs an error when the YPA JS throws', () => {
@@ -861,6 +889,17 @@ describe('SearchResults component', () => {
     })
 
     // The pagination container should be hidden now.
+    expect(
+      wrapper.find('[data-test-id="pagination-container"]').prop('style')
+    ).toHaveProperty('display', 'none')
+  })
+
+  it('hides the pagination container when an ad blocker is enabled', () => {
+    const SearchResults = require('js/components/Search/SearchResults').default
+    const mockProps = getMockProps()
+    mockProps.query = 'foo'
+    mockProps.isAdBlockerEnabled = true
+    const wrapper = shallow(<SearchResults {...mockProps} />).dive()
     expect(
       wrapper.find('[data-test-id="pagination-container"]').prop('style')
     ).toHaveProperty('display', 'none')


### PR DESCRIPTION
This is because the ad blocker may block the search request entirely, and we won't know there's an error, which leaves the page with extra scrolling space and a floating pagination element at the bottom.