### PR TITLE
Only returned pre-rendered HTML for the search index page

### DIFF
--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -22,34 +22,46 @@ describe('newtab app Lambda@Edge function on origin-request', () => {
     expect(request.uri).toEqual('/search/index.html')
   })
 
-  it('modifies the path for the /newtab URI', () => {
+  it('modifies the path for the /search/ URI with a query string', () => {
     const { handler } = require('../search-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/newtab'
+    event.Records[0].cf.request.uri = '/search/?q=foobar&src=chrome'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const request = callback.mock.calls[0][1]
     expect(request.uri).toEqual('/search/index.html')
   })
 
-  it('modifies the path for the /search/profile/stats/ URI', () => {
+  // In the future, we may want to change this to pre-render
+  // additional pages.
+  it('sends a non-search-page path, /search/foo/?q=blah, to 200.html', () => {
+    const { handler } = require('../search-app-lambda-edge')
+    const event = getMockCloudFrontEventObject()
+    event.Records[0].cf.request.uri = '/search/foo/?q=blah'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const request = callback.mock.calls[0][1]
+    expect(request.uri).toEqual('/search/200.html')
+  })
+
+  it('sends a non-search-page path, /search/profile/stats/, to 200.html', () => {
     const { handler } = require('../search-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.uri = '/search/profile/stats/'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const request = callback.mock.calls[0][1]
-    expect(request.uri).toEqual('/search/index.html')
+    expect(request.uri).toEqual('/search/200.html')
   })
 
-  it('modifies the path for the /search/profile/stats-thing URI', () => {
+  it('sends a non-search-page path, /search/profile/stats-thing, to 200.html', () => {
     const { handler } = require('../search-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.uri = '/search/profile/stats-thing'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const request = callback.mock.calls[0][1]
-    expect(request.uri).toEqual('/search/index.html')
+    expect(request.uri).toEqual('/search/200.html')
   })
 
   it('does not modify the path for the /search/manifest.json URI', () => {

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -11,7 +11,14 @@ const path = require('path')
 exports.handler = (event, context, callback) => {
   const request = event.Records[0].cf.request
   if (!path.extname(request.uri)) {
-    request.uri = '/search/index.html'
+    // Only return a prerendered page for the search page.
+    // In the future, we may want to change this to pre-render
+    // additional pages.
+    if (request.uri.match('^/search/?(?!.*/)')) {
+      request.uri = '/search/index.html'
+    } else {
+      request.uri = '/search/200.html'
+    }
   }
   callback(null, request)
 }


### PR DESCRIPTION
TODO: after deploying this, update the CloudFront references to new edge function versions.