### PR TITLE
Set up the "search intro" experiment

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -278,6 +278,20 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
         },
       }),
     },
+    searchIntro: {
+      type: new GraphQLEnumType({
+        name: 'ExperimentGroupSearchIntro',
+        description:
+          'The test of showing an introduction message to Search for a Cause',
+        values: {
+          NONE: { value: experimentConfig.searchIntro.NONE },
+          NO_INTRO: { value: experimentConfig.searchIntro.NO_INTRO },
+          INTRO_A: {
+            value: experimentConfig.searchIntro.INTRO_A,
+          },
+        },
+      }),
+    },
   },
 })
 

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -58,6 +58,7 @@ import setBackgroundColor from '../database/users/setBackgroundColor'
 import setBackgroundImageDaily from '../database/users/setBackgroundImageDaily'
 import logUserExperimentGroups from '../database/users/logUserExperimentGroups'
 import logUserExperimentActions from '../database/users/logUserExperimentActions'
+import constructExperimentActionsType from '../database/users/constructExperimentActionsType'
 
 import CharityModel from '../database/charities/CharityModel'
 import getCharities from '../database/charities/getCharities'
@@ -296,23 +297,30 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
   },
 })
 
+const experimentActionsFields = {
+  searchIntro: {
+    type: new GraphQLEnumType({
+      name: 'ExperimentActionSearchIntro',
+      description: 'Action taken in response to the "search intro" experiment.',
+      values: {
+        NONE: { value: 0 },
+        DISMISS: { value: 1 },
+        CLICK: { value: 2 },
+      },
+    }),
+  },
+}
+
 const ExperimentActionsType = new GraphQLInputObjectType({
   name: 'ExperimentActions',
   description: 'The actions a user may take in an experiment',
-  fields: {
-    searchIntro: {
-      type: new GraphQLEnumType({
-        name: 'ExperimentActionSearchIntro',
-        description:
-          'Action taken in response to the "search intro" experiment.',
-        values: {
-          NONE: { value: 0 },
-          DISMISS: { value: 1 },
-          CLICK: { value: 2 },
-        },
-      }),
-    },
-  },
+  fields: experimentActionsFields,
+})
+
+const ExperimentActionsOutputType = new GraphQLObjectType({
+  name: 'ExperimentActionsOutput',
+  description: 'The actions a user has taken in an experiment',
+  fields: () => experimentActionsFields,
 })
 
 // TODO: fetch only the fields we need:
@@ -451,6 +459,11 @@ const userType = new GraphQLObjectType({
       type: maxSearchesDayType,
       description: "Info about the user's day of most searches",
       resolve: user => user.maxSearchesDay.maxDay,
+    },
+    experimentActions: {
+      type: ExperimentActionsOutputType,
+      description: 'Actions the user has taken during experiments',
+      resolve: user => constructExperimentActionsType(user),
     },
   }),
   interfaces: [nodeInterface],

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -57,6 +57,7 @@ import setBackgroundImageFromCustomURL from '../database/users/setBackgroundImag
 import setBackgroundColor from '../database/users/setBackgroundColor'
 import setBackgroundImageDaily from '../database/users/setBackgroundImageDaily'
 import logUserExperimentGroups from '../database/users/logUserExperimentGroups'
+import logUserExperimentActions from '../database/users/logUserExperimentActions'
 
 import CharityModel from '../database/charities/CharityModel'
 import getCharities from '../database/charities/getCharities'
@@ -289,6 +290,25 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
           INTRO_A: {
             value: experimentConfig.searchIntro.INTRO_A,
           },
+        },
+      }),
+    },
+  },
+})
+
+const ExperimentActionsType = new GraphQLInputObjectType({
+  name: 'ExperimentActions',
+  description: 'The actions a user may take in an experiment',
+  fields: {
+    searchIntro: {
+      type: new GraphQLEnumType({
+        name: 'ExperimentActionSearchIntro',
+        description:
+          'Action taken in response to the "search intro" experiment.',
+        values: {
+          NONE: { value: 0 },
+          DISMISS: { value: 1 },
+          CLICK: { value: 2 },
         },
       }),
     },
@@ -1154,6 +1174,31 @@ const updateUserExperimentGroupsMutation = mutationWithClientMutationId({
   },
 })
 
+/**
+ * Log action a user takes in an experiment.
+ */
+const logUserExperimentActionsMutation = mutationWithClientMutationId({
+  name: 'LogUserExperimentActions',
+  inputFields: {
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    experimentActions: { type: ExperimentActionsType },
+  },
+  outputFields: {
+    user: {
+      type: userType,
+      resolve: user => user,
+    },
+  },
+  mutateAndGetPayload: ({ userId, experimentActions }, context) => {
+    const userGlobalObj = fromGlobalId(userId)
+    return logUserExperimentActions(
+      context.user,
+      userGlobalObj.id,
+      experimentActions
+    )
+  },
+})
+
 const setUsernameMutation = mutationWithClientMutationId({
   name: 'SetUsername',
   inputFields: {
@@ -1289,6 +1334,7 @@ const mutationType = new GraphQLObjectType({
     createNewUser: createNewUserMutation,
     setUsername: setUsernameMutation,
     updateUserExperimentGroups: updateUserExperimentGroupsMutation,
+    logUserExperimentActions: logUserExperimentActionsMutation,
   }),
 })
 

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -287,6 +287,9 @@ class User extends BaseModel {
         .allow(null)
         .description(`Which group the user is in for the "search intro" split-test.
           This value is assigned on the client so is not trustworthy.`),
+      testGroupSearchIntroJoinedTime: types.string().isoDate()
+        .description(`The time the user was assigned a group for the "search intro"
+          split-test.`),
     }
   }
 

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -281,6 +281,12 @@ class User extends BaseModel {
         .allow(null)
         .description(`Which group the user is in for the "ad explanation" split-test.
           This value is assigned on the client so is not trustworthy.`),
+      testGroupSearchIntro: types
+        .number()
+        .integer()
+        .allow(null)
+        .description(`Which group the user is in for the "search intro" split-test.
+          This value is assigned on the client so is not trustworthy.`),
     }
   }
 

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -290,6 +290,18 @@ class User extends BaseModel {
       testGroupSearchIntroJoinedTime: types.string().isoDate()
         .description(`The time the user was assigned a group for the "search intro"
           split-test.`),
+      testSearchIntroAction: types
+        .number()
+        .integer()
+        .allow(null)
+        .description(
+          `Any action the user took for the "search intro" split-test.
+           0 = no action, 1 = dismissed, 2 = clicked to try Search for a Cause.
+          `
+        ),
+      testSearchIntroActionTime: types.string().isoDate()
+        .description(`The time the user made the action (testSearchIntroAction)
+          for the "search intro" split-test.`),
     }
   }
 

--- a/graphql/database/users/__tests__/constructExperimentActionsType.test.js
+++ b/graphql/database/users/__tests__/constructExperimentActionsType.test.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+
+describe('constructExperimentActionsType', () => {
+  it('returns the expected value for searchIntro', () => {
+    const constructExperimentActionsType = require('../constructExperimentActionsType')
+      .default
+    expect(
+      constructExperimentActionsType({
+        testSearchIntroAction: 2,
+      })
+    ).toMatchObject({
+      searchIntro: 2,
+    })
+  })
+})

--- a/graphql/database/users/__tests__/logUserExperimentActions.test.js
+++ b/graphql/database/users/__tests__/logUserExperimentActions.test.js
@@ -8,7 +8,6 @@ import {
   mockDate,
   setMockDBResponse,
 } from '../../test-utils'
-import { getValidatedExperimentGroups } from '../../../utils/experiments'
 
 jest.mock('../../databaseClient')
 jest.mock('../../../utils/experiments')
@@ -25,31 +24,29 @@ afterAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  getValidatedExperimentGroups.mockReturnValue({})
 })
 
-describe('logUserExperimentGroups', () => {
+describe('logUserExperimentActions', () => {
   it('sets the testGroupSearchIntro value when it is provided', async () => {
     expect.assertions(1)
 
     const UserModel = require('../UserModel').default
     const updateQuery = jest.spyOn(UserModel, 'update')
 
-    const mockExperimentGroups = {
-      searchIntro: 0,
+    const mockExperimentActions = {
+      searchIntro: 2,
     }
-    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
-    const logUserExperimentGroups = require('../logUserExperimentGroups')
+    const logUserExperimentActions = require('../logUserExperimentActions')
       .default
-    await logUserExperimentGroups(
+    await logUserExperimentActions(
       userContext,
       userContext.id,
-      mockExperimentGroups
+      mockExperimentActions
     )
     expect(updateQuery).toHaveBeenCalledWith(userContext, {
       id: userContext.id,
-      testGroupSearchIntro: 0,
-      testGroupSearchIntroJoinedTime: moment.utc().toISOString(),
+      testSearchIntroAction: 2,
+      testSearchIntroActionTime: moment.utc().toISOString(),
       updated: moment.utc().toISOString(),
     })
   })
@@ -60,14 +57,13 @@ describe('logUserExperimentGroups', () => {
     const UserModel = require('../UserModel').default
     const updateQuery = jest.spyOn(UserModel, 'update')
 
-    const mockExperimentGroups = {}
-    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
-    const logUserExperimentGroups = require('../logUserExperimentGroups')
+    const mockExperimentActions = {}
+    const logUserExperimentActions = require('../logUserExperimentActions')
       .default
-    await logUserExperimentGroups(
+    await logUserExperimentActions(
       userContext,
       userContext.id,
-      mockExperimentGroups
+      mockExperimentActions
     )
     expect(updateQuery).not.toHaveBeenCalled()
   })
@@ -78,14 +74,13 @@ describe('logUserExperimentGroups', () => {
     const UserModel = require('../UserModel').default
     const updateQuery = jest.spyOn(UserModel, 'update')
 
-    const mockExperimentGroups = null
-    getValidatedExperimentGroups.mockReturnValueOnce({}) // Will return an empty object
-    const logUserExperimentGroups = require('../logUserExperimentGroups')
+    const mockExperimentActions = null
+    const logUserExperimentActions = require('../logUserExperimentActions')
       .default
-    await logUserExperimentGroups(
+    await logUserExperimentActions(
       userContext,
       userContext.id,
-      mockExperimentGroups
+      mockExperimentActions
     )
     expect(updateQuery).not.toHaveBeenCalled()
   })
@@ -101,16 +96,15 @@ describe('logUserExperimentGroups', () => {
       Attributes: expectedReturnedUser,
     })
 
-    const mockExperimentGroups = {
+    const mockExperimentActions = {
       searchIntro: 1,
     }
-    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
-    const logUserExperimentGroups = require('../logUserExperimentGroups')
+    const logUserExperimentActions = require('../logUserExperimentActions')
       .default
-    const returnedUser = await logUserExperimentGroups(
+    const returnedUser = await logUserExperimentActions(
       userContext,
       userContext.id,
-      mockExperimentGroups
+      mockExperimentActions
     )
     expect(returnedUser).toEqual(expectedReturnedUser)
   })
@@ -124,43 +118,14 @@ describe('logUserExperimentGroups', () => {
       Item: expectedReturnedUser,
     })
 
-    const mockExperimentGroups = {}
-    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
-    const logUserExperimentGroups = require('../logUserExperimentGroups')
+    const mockExperimentActions = {}
+    const logUserExperimentActions = require('../logUserExperimentActions')
       .default
-    const returnedUser = await logUserExperimentGroups(
+    const returnedUser = await logUserExperimentActions(
       userContext,
       userContext.id,
-      mockExperimentGroups
+      mockExperimentActions
     )
     expect(returnedUser).toEqual(expectedReturnedUser)
-  })
-
-  it('does not save a test group value if it is invalid', async () => {
-    expect.assertions(1)
-
-    const UserModel = require('../UserModel').default
-    const updateQuery = jest.spyOn(UserModel, 'update')
-
-    // Have the validated groups differ from provided.
-    const mockExperimentGroups = {
-      testGroupSearchIntro: 34543543,
-    }
-    getValidatedExperimentGroups.mockReturnValueOnce({
-      testGroupSearchIntro: null,
-    })
-
-    const logUserExperimentGroups = require('../logUserExperimentGroups')
-      .default
-    await logUserExperimentGroups(
-      userContext,
-      userContext.id,
-      mockExperimentGroups
-    )
-    expect(updateQuery).toHaveBeenCalledWith(userContext, {
-      id: userContext.id,
-      // Note: the experiment group is not modified
-      updated: moment.utc().toISOString(),
-    })
   })
 })

--- a/graphql/database/users/__tests__/logUserExperimentGroups.test.js
+++ b/graphql/database/users/__tests__/logUserExperimentGroups.test.js
@@ -97,6 +97,7 @@ describe('logUserExperimentGroups', () => {
     expect(updateQuery).toHaveBeenCalledWith(userContext, {
       id: userContext.id,
       testGroupSearchIntro: 0,
+      testGroupSearchIntroJoinedTime: moment.utc().toISOString(),
       updated: moment.utc().toISOString(),
     })
   })

--- a/graphql/database/users/__tests__/logUserExperimentGroups.test.js
+++ b/graphql/database/users/__tests__/logUserExperimentGroups.test.js
@@ -77,6 +77,30 @@ describe('logUserExperimentGroups', () => {
     })
   })
 
+  it('sets the testGroupSearchIntro value when it is provided', async () => {
+    expect.assertions(1)
+
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+
+    const mockExperimentGroups = {
+      searchIntro: 0,
+    }
+    getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
+    const logUserExperimentGroups = require('../logUserExperimentGroups')
+      .default
+    await logUserExperimentGroups(
+      userContext,
+      userContext.id,
+      mockExperimentGroups
+    )
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      testGroupSearchIntro: 0,
+      updated: moment.utc().toISOString(),
+    })
+  })
+
   it('does not update the item when no experiment groups are provided', async () => {
     expect.assertions(1)
 
@@ -118,14 +142,14 @@ describe('logUserExperimentGroups', () => {
 
     // Mock DB response.
     const expectedReturnedUser = Object.assign({}, getMockUserInstance(), {
-      testGroupAnonSignIn: 1,
+      testGroupSearchIntro: 1,
     })
     setMockDBResponse(DatabaseOperation.UPDATE, {
       Attributes: expectedReturnedUser,
     })
 
     const mockExperimentGroups = {
-      anonSignIn: 1,
+      searchIntro: 1,
     }
     getValidatedExperimentGroups.mockReturnValueOnce(mockExperimentGroups)
     const logUserExperimentGroups = require('../logUserExperimentGroups')
@@ -167,10 +191,10 @@ describe('logUserExperimentGroups', () => {
 
     // Have the validated groups differ from provided.
     const mockExperimentGroups = {
-      anonSignIn: 34543543,
+      testGroupSearchIntro: 34543543,
     }
     getValidatedExperimentGroups.mockReturnValueOnce({
-      anonSignIn: null,
+      testGroupSearchIntro: null,
     })
 
     const logUserExperimentGroups = require('../logUserExperimentGroups')
@@ -182,7 +206,7 @@ describe('logUserExperimentGroups', () => {
     )
     expect(updateQuery).toHaveBeenCalledWith(userContext, {
       id: userContext.id,
-      // Note: testGroupAnonSignIn not modified
+      // Note: the experiment group is not modified
       updated: moment.utc().toISOString(),
     })
   })

--- a/graphql/database/users/constructExperimentActionsType.js
+++ b/graphql/database/users/constructExperimentActionsType.js
@@ -1,0 +1,3 @@
+export default user => ({
+  searchIntro: user.testSearchIntroAction,
+})

--- a/graphql/database/users/logUserExperimentActions.js
+++ b/graphql/database/users/logUserExperimentActions.js
@@ -1,0 +1,53 @@
+import moment from 'moment'
+import { isEmpty, isNil } from 'lodash/lang'
+import UserModel from './UserModel'
+
+/**
+ * Log actions the user takes in response to experiments.
+ * @param {object} userContext - The user authorizer object.
+ * @param {string} userId - The user's ID.
+ * @param {object|null} experimentActions - Any experimental test actions
+ *   that take the shape of the ExperimentActionsType object in our GraphQL
+ *   schema.
+ * @return {Promise<User>}  A promise that resolves into a User instance.
+ */
+const logUserExperimentActions = async (
+  userContext,
+  userId,
+  experimentActions = {}
+) => {
+  let returnedUser
+
+  // If there are no experiment groups to update, simply get and
+  // return the user.
+  if (isEmpty(experimentActions)) {
+    try {
+      returnedUser = await UserModel.get(userContext, userId)
+    } catch (e) {
+      throw e
+    }
+    return returnedUser
+  }
+
+  // Unpack and conditionally update experiment actions.
+  const userDataToUpdate = Object.assign(
+    {
+      id: userId,
+    },
+    // @experiment-search-intro
+    !isNil(experimentActions.searchIntro)
+      ? {
+          testSearchIntroAction: experimentActions.searchIntro,
+          testSearchIntroActionTime: moment.utc().toISOString(),
+        }
+      : null
+  )
+  try {
+    returnedUser = await UserModel.update(userContext, userDataToUpdate)
+  } catch (e) {
+    throw e
+  }
+  return returnedUser
+}
+
+export default logUserExperimentActions

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import { isEmpty, isNil } from 'lodash/lang'
 import UserModel from './UserModel'
 import { getValidatedExperimentGroups } from '../../utils/experiments'
@@ -54,6 +55,7 @@ const logUserExperimentGroups = async (
     !isNil(validatedGroups.searchIntro)
       ? {
           testGroupSearchIntro: validatedGroups.searchIntro,
+          testGroupSearchIntroJoinedTime: moment.utc().toISOString(),
         }
       : null
   )

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -50,6 +50,11 @@ const logUserExperimentGroups = async (
       ? {
           testAdExplanation: validatedGroups.adExplanation,
         }
+      : null,
+    !isNil(validatedGroups.searchIntro)
+      ? {
+          testGroupSearchIntro: validatedGroups.searchIntro,
+        }
       : null
   )
   try {

--- a/graphql/database/users/logUserExperimentGroups.js
+++ b/graphql/database/users/logUserExperimentGroups.js
@@ -42,16 +42,7 @@ const logUserExperimentGroups = async (
       id: userId,
     },
     // Active experiment groups
-    !isNil(validatedGroups.oneAdForNewUsers)
-      ? {
-          testOneAdForNewUsers: validatedGroups.oneAdForNewUsers,
-        }
-      : null,
-    !isNil(validatedGroups.adExplanation)
-      ? {
-          testAdExplanation: validatedGroups.adExplanation,
-        }
-      : null,
+    // @experiment-search-intro
     !isNil(validatedGroups.searchIntro)
       ? {
           testGroupSearchIntro: validatedGroups.searchIntro,

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -32,6 +32,12 @@ const experimentConfig = {
     DEFAULT: 1,
     SHOW_EXPLANATION: 2,
   },
+  // @experiment-search-intro
+  searchIntro: {
+    NONE: 0,
+    NO_INTRO: 1,
+    INTRO_A: 2,
+  },
 }
 
 /**

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -201,6 +201,14 @@ input ExperimentGroups {
   thirdAd: ExperimentGroupThirdAd
   oneAdForNewUsers: ExperimentGroupOneAdForNewUsers
   adExplanation: ExperimentGroupAdExplanation
+  searchIntro: ExperimentGroupSearchIntro
+}
+
+"""The test of showing an introduction message to Search for a Cause"""
+enum ExperimentGroupSearchIntro {
+  NONE
+  NO_INTRO
+  INTRO_A
 }
 
 """The test of enabling a third ad"""

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -173,6 +173,18 @@ enum EncodedRevenueValueTypeEnum {
   AMAZON_CPM
 }
 
+"""The actions a user may take in an experiment"""
+input ExperimentActions {
+  searchIntro: ExperimentActionSearchIntro
+}
+
+"""Action taken in response to the "search intro" experiment."""
+enum ExperimentActionSearchIntro {
+  NONE
+  DISMISS
+  CLICK
+}
+
 """The test of showing an explanation of why there are ads"""
 enum ExperimentGroupAdExplanation {
   NONE
@@ -269,6 +281,17 @@ type LogUserDataConsentPayload {
   clientMutationId: String
 }
 
+input LogUserExperimentActionsInput {
+  userId: String!
+  experimentActions: ExperimentActions
+  clientMutationId: String
+}
+
+type LogUserExperimentActionsPayload {
+  user: User
+  clientMutationId: String
+}
+
 enum LogUserRevenueAggregationOperationEnum {
   MAX
 }
@@ -342,6 +365,7 @@ type Mutation {
   createNewUser(input: CreateNewUserInput!): CreateNewUserPayload
   setUsername(input: SetUsernameInput!): SetUsernamePayload
   updateUserExperimentGroups(input: UpdateUserExperimentGroupsInput!): UpdateUserExperimentGroupsPayload
+  logUserExperimentActions(input: LogUserExperimentActionsInput!): LogUserExperimentActionsPayload
 }
 
 """An object with an ID"""

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -185,6 +185,11 @@ enum ExperimentActionSearchIntro {
   CLICK
 }
 
+"""The actions a user has taken in an experiment"""
+type ExperimentActionsOutput {
+  searchIntro: ExperimentActionSearchIntro
+}
+
 """The test of showing an explanation of why there are ads"""
 enum ExperimentGroupAdExplanation {
   NONE
@@ -608,6 +613,9 @@ type User implements Node {
 
   """Info about the user's day of most searches"""
   maxSearchesDay: MaxSearchesDay
+
+  """Actions the user has taken during experiments"""
+  experimentActions: ExperimentActionsOutput
 }
 
 """Info about a user recruited by a referring user"""

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "@material-ui/icons": "^3.0.1",
     "@material-ui/lab": "^3.0.0-alpha.23",
     "blockadblock": "^3.2.1",
+    "browser-detect": "^0.2.28",
     "firebase": "^5.6.0",
     "hex-to-rgba": "^1.0.2",
     "history": "^4.7.2",

--- a/web/src/js/__mocks__/browser-detect.js
+++ b/web/src/js/__mocks__/browser-detect.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+
+// https://www.npmjs.com/package/browser-detect
+const detectBrowser = jest.fn(() => ({
+  name: 'chrome',
+  version: '58.0.3029',
+  versionNumber: 58.03029,
+  mobile: false,
+  os: 'Windows NT 10.0',
+}))
+
+export default detectBrowser

--- a/web/src/js/components/App/__tests__/App.test.js
+++ b/web/src/js/components/App/__tests__/App.test.js
@@ -7,6 +7,7 @@ import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 import QuantcastChoiceCMP from 'js/components/General/QuantcastChoiceCMP'
 
+jest.mock('js/components/Dashboard/DashboardView')
 jest.mock('js/utils/client-location')
 jest.mock('js/components/General/QuantcastChoiceCMP')
 jest.mock('js/ads/consentManagement')

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -222,7 +222,11 @@ class Dashboard extends React.Component {
               ) : null}
               {// @experiment-search-intro
               searchIntroExperimentGroup ===
-              getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A ? (
+                getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A &&
+              !(
+                user.experimentActions.searchIntro === 'CLICK' ||
+                user.experimentActions.searchIntro === 'DISMISS'
+              ) ? (
                 <Notification
                   data-test-id={'search-intro-a'}
                   title={`Introducing Search for a Cause`}
@@ -466,6 +470,9 @@ class Dashboard extends React.Component {
 Dashboard.propTypes = {
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
+    experimentActions: PropTypes.shape({
+      searchIntro: PropTypes.string,
+    }).isRequired,
     joined: PropTypes.string.isRequired,
     tabs: PropTypes.number.isRequired,
   }),

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -22,12 +22,17 @@ import ErrorMessage from 'js/components/General/ErrorMessage'
 import Notification from 'js/components/Dashboard/NotificationComponent'
 import { getCurrentUser } from 'js/authentication/user'
 import localStorageMgr from 'js/utils/localstorage-mgr'
+import { detectSupportedBrowser } from 'js/utils/detectBrowser'
 import {
   setUserDismissedAdExplanation,
   hasUserDismissedNotificationRecently,
   hasUserDismissedCampaignRecently,
 } from 'js/utils/local-user-data-mgr'
-import { STORAGE_NEW_USER_HAS_COMPLETED_TOUR } from 'js/constants'
+import {
+  CHROME_BROWSER,
+  FIREFOX_BROWSER,
+  STORAGE_NEW_USER_HAS_COMPLETED_TOUR,
+} from 'js/constants'
 import { goTo, loginURL } from 'js/navigation/navigation'
 import {
   getNumberOfAdsToShow,
@@ -81,11 +86,16 @@ class Dashboard extends React.Component {
         EXPERIMENT_SEARCH_INTRO
       ),
       hasUserDismissedCampaignRecently: hasUserDismissedCampaignRecently(),
+      // Let's assume a Chrome browser until we detect it.
+      browser: CHROME_BROWSER,
     }
   }
 
   componentDidMount() {
     this.determineAnonymousStatus()
+    this.setState({
+      browser: detectSupportedBrowser(),
+    })
   }
 
   /**
@@ -123,6 +133,7 @@ class Dashboard extends React.Component {
     // Props will be null on first render.
     const { user, app } = this.props
     const {
+      browser,
       hasUserDismissedCampaignRecently,
       userAlreadyViewedNewUserTour,
       searchIntroExperimentGroup,
@@ -213,9 +224,17 @@ class Dashboard extends React.Component {
                   buttonText={'Try it out'}
                   onClick={() => {
                     console.log('Action button clicked!')
+                    if (browser === CHROME_BROWSER) {
+                      console.log('Go to Chrome Web Store.')
+                    } else if (browser === FIREFOX_BROWSER) {
+                      console.log('Go to Firefox Addons Store.')
+                    } else {
+                      console.log(
+                        'Unsupported browser, but go to Chrome Web Store.'
+                      )
+                    }
                     // TODO:
                     //  - log click
-                    //  - detect browser
                     //  - open link to FF/Chrome extension store
                   }}
                   onDismiss={() => {

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -203,8 +203,9 @@ class Dashboard extends React.Component {
                   message={`
                         Now, you can raise money for charity each time you search! It's the search results you know and love—plus doing good.`}
                   buttonText={'Try it out'}
-                  // TODO: need an onClick
-                  buttonURL={'#'}
+                  onClick={() => {
+                    console.log('Action button clicked!')
+                  }}
                   onDismiss={() => {
                     // TODO: log dismissal
                     this.setState({

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -180,6 +180,7 @@ class Dashboard extends React.Component {
               />
               {this.state.showNotification ? (
                 <Notification
+                  data-test-id={'global-notification'}
                   title={`Vote for the March Charity Spotlight`}
                   message={`
                         Each month this year, we're highlighting a charity chosen by our

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -206,7 +206,6 @@ class Dashboard extends React.Component {
               {searchIntroExperimentGroup ===
               getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A ? (
                 <Notification
-                  // TODO: tests
                   data-test-id={'search-intro-a'}
                   title={`Introducing Search for a Cause`}
                   message={`

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -87,7 +87,6 @@ class Dashboard extends React.Component {
         showGlobalNotification() && !hasUserDismissedNotificationRecently(),
       // Determines what message (if any) we should show to introduce
       // Search for a Cause.
-      // TODO: fetch from server to determine if user has already dismissed the message
       searchIntroExperimentGroup: getUserExperimentGroup(
         EXPERIMENT_SEARCH_INTRO
       ),

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -37,6 +37,11 @@ import {
   HORIZONTAL_AD_SLOT_DOM_ID,
 } from 'js/ads/adSettings'
 import { showGlobalNotification } from 'js/utils/feature-flags'
+import {
+  EXPERIMENT_SEARCH_INTRO,
+  getExperimentGroups,
+  getUserExperimentGroup,
+} from 'js/utils/experiments'
 
 // Include ads code.
 // TODO: load this on mount, making sure the ads code behaves
@@ -73,7 +78,9 @@ class Dashboard extends React.Component {
       // Search for a Cause.
       // TODO: use constants
       // TODO: fetch from server to determine if user has already dismissed the message
-      searchIntroExperimentGroup: 1,
+      searchIntroExperimentGroup: getUserExperimentGroup(
+        EXPERIMENT_SEARCH_INTRO
+      ),
       hasUserDismissedCampaignRecently: hasUserDismissedCampaignRecently(),
     }
   }
@@ -197,7 +204,8 @@ class Dashboard extends React.Component {
                   }}
                 />
               ) : null}
-              {searchIntroExperimentGroup === 1 ? (
+              {searchIntroExperimentGroup ===
+              getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A ? (
                 <Notification
                   title={`Introducing Search for a Cause`}
                   message={`

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -69,6 +69,11 @@ class Dashboard extends React.Component {
       // Whether to show a global announcement.
       showNotification:
         showGlobalNotification() && !hasUserDismissedNotificationRecently(),
+      // Determines what message (if any) we should show to introduce
+      // Search for a Cause.
+      // TODO: use constants
+      // TODO: fetch from server to determine if user has already dismissed the message
+      searchIntroExperimentGroup: 1,
       hasUserDismissedCampaignRecently: hasUserDismissedCampaignRecently(),
     }
   }
@@ -114,6 +119,7 @@ class Dashboard extends React.Component {
     const {
       hasUserDismissedCampaignRecently,
       userAlreadyViewedNewUserTour,
+      searchIntroExperimentGroup,
       tabId,
     } = this.state
     const errorMessage = this.state.errorMessage
@@ -183,6 +189,25 @@ class Dashboard extends React.Component {
                   onDismiss={() => {
                     this.setState({
                       showNotification: false,
+                    })
+                  }}
+                  style={{
+                    marginTop: 4,
+                  }}
+                />
+              ) : null}
+              {searchIntroExperimentGroup === 1 ? (
+                <Notification
+                  title={`Introducing Search for a Cause`}
+                  message={`
+                        Now, you can raise money for charity each time you search! It's the search results you know and love—plus doing good.`}
+                  buttonText={'Try it out'}
+                  // TODO: need an onClick
+                  buttonURL={'#'}
+                  onDismiss={() => {
+                    // TODO: log dismissal
+                    this.setState({
+                      searchIntroExperimentGroup: false,
                     })
                   }}
                   style={{

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -52,6 +52,7 @@ import {
   getExperimentGroups,
   getUserExperimentGroup,
 } from 'js/utils/experiments'
+import LogUserExperimentActionsMutation from 'js/mutations/LogUserExperimentActionsMutation'
 
 // Include ads code.
 // TODO: load this on mount, making sure the ads code behaves
@@ -219,7 +220,8 @@ class Dashboard extends React.Component {
                   }}
                 />
               ) : null}
-              {searchIntroExperimentGroup ===
+              {// @experiment-search-intro
+              searchIntroExperimentGroup ===
               getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A ? (
                 <Notification
                   data-test-id={'search-intro-a'}
@@ -227,9 +229,14 @@ class Dashboard extends React.Component {
                   message={`
                         Now, you can raise money for charity each time you search! It's the search results you know and love—plus doing good.`}
                   buttonText={'Try it out'}
-                  onClick={() => {
-                    // TODO:
-                    //  - log click
+                  onClick={async () => {
+                    // Log the click.
+                    await LogUserExperimentActionsMutation({
+                      userId: user.id,
+                      experimentActions: {
+                        [EXPERIMENT_SEARCH_INTRO]: 'CLICK',
+                      },
+                    })
 
                     // Hide the message because we don't want the user to
                     // need to dismiss it after clicking the action, which
@@ -246,8 +253,14 @@ class Dashboard extends React.Component {
                       goTo(searchChromeExtensionPage)
                     }
                   }}
-                  onDismiss={() => {
-                    // TODO: log dismissal
+                  onDismiss={async () => {
+                    // Log the dismissal.
+                    await LogUserExperimentActionsMutation({
+                      userId: user.id,
+                      experimentActions: {
+                        [EXPERIMENT_SEARCH_INTRO]: 'DISMISS',
+                      },
+                    })
                     this.setState({
                       searchIntroExperimentGroup: false,
                     })

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -33,7 +33,12 @@ import {
   FIREFOX_BROWSER,
   STORAGE_NEW_USER_HAS_COMPLETED_TOUR,
 } from 'js/constants'
-import { goTo, loginURL } from 'js/navigation/navigation'
+import {
+  goTo,
+  loginURL,
+  searchChromeExtensionPage,
+  searchFirefoxExtensionPage,
+} from 'js/navigation/navigation'
 import {
   getNumberOfAdsToShow,
   shouldShowAdExplanation,
@@ -223,19 +228,23 @@ class Dashboard extends React.Component {
                         Now, you can raise money for charity each time you search! It's the search results you know and love—plus doing good.`}
                   buttonText={'Try it out'}
                   onClick={() => {
-                    console.log('Action button clicked!')
-                    if (browser === CHROME_BROWSER) {
-                      console.log('Go to Chrome Web Store.')
-                    } else if (browser === FIREFOX_BROWSER) {
-                      console.log('Go to Firefox Addons Store.')
-                    } else {
-                      console.log(
-                        'Unsupported browser, but go to Chrome Web Store.'
-                      )
-                    }
                     // TODO:
                     //  - log click
-                    //  - open link to FF/Chrome extension store
+
+                    // Hide the message because we don't want the user to
+                    // need to dismiss it after clicking the action, which
+                    // would also confuse our test metrics.
+                    this.setState({
+                      searchIntroExperimentGroup: false,
+                    })
+
+                    if (browser === CHROME_BROWSER) {
+                      goTo(searchChromeExtensionPage)
+                    } else if (browser === FIREFOX_BROWSER) {
+                      goTo(searchFirefoxExtensionPage)
+                    } else {
+                      goTo(searchChromeExtensionPage)
+                    }
                   }}
                   onDismiss={() => {
                     // TODO: log dismissal

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -76,7 +76,6 @@ class Dashboard extends React.Component {
         showGlobalNotification() && !hasUserDismissedNotificationRecently(),
       // Determines what message (if any) we should show to introduce
       // Search for a Cause.
-      // TODO: use constants
       // TODO: fetch from server to determine if user has already dismissed the message
       searchIntroExperimentGroup: getUserExperimentGroup(
         EXPERIMENT_SEARCH_INTRO
@@ -207,12 +206,18 @@ class Dashboard extends React.Component {
               {searchIntroExperimentGroup ===
               getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A ? (
                 <Notification
+                  // TODO: tests
+                  data-test-id={'search-intro-a'}
                   title={`Introducing Search for a Cause`}
                   message={`
                         Now, you can raise money for charity each time you search! It's the search results you know and love—plus doing good.`}
                   buttonText={'Try it out'}
                   onClick={() => {
                     console.log('Action button clicked!')
+                    // TODO:
+                    //  - log click
+                    //  - detect browser
+                    //  - open link to FF/Chrome extension store
                   }}
                   onDismiss={() => {
                     // TODO: log dismissal

--- a/web/src/js/components/Dashboard/DashboardContainer.js
+++ b/web/src/js/components/Dashboard/DashboardContainer.js
@@ -13,6 +13,9 @@ export default createFragmentContainer(Dashboard, {
   user: graphql`
     fragment DashboardContainer_user on User {
       id
+      experimentActions {
+        searchIntro
+      }
       joined
       tabs
       ...WidgetsContainer_user

--- a/web/src/js/components/Dashboard/NotificationComponent.js
+++ b/web/src/js/components/Dashboard/NotificationComponent.js
@@ -14,6 +14,7 @@ class Notification extends React.Component {
       message,
       buttonText,
       buttonURL,
+      onClick,
       onDismiss,
     } = this.props
     return (
@@ -74,6 +75,10 @@ class Notification extends React.Component {
                 >
                   <Button color={'primary'}>{buttonText}</Button>
                 </Link>
+              ) : buttonText && onClick ? (
+                <Button onClick={onClick} color={'primary'}>
+                  {buttonText}
+                </Button>
               ) : null}
             </div>
           </span>
@@ -90,6 +95,7 @@ Notification.propTypes = {
   buttonText: PropTypes.string,
   buttonURL: PropTypes.string,
   onDismiss: PropTypes.func,
+  onClick: PropTypes.func,
 }
 
 Notification.defaultProps = {

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -95,6 +95,7 @@ const mockProps = {
     id: 'abc-123',
     joined: '2017-04-10T14:00:00.000',
     tabs: 12,
+    experimentActions: {},
   },
   app: {
     isGlobalCampaignLive: false,
@@ -650,6 +651,39 @@ describe('Dashboard component', () => {
     const elem = wrapper.find('[data-test-id="search-intro-a"]')
     expect(elem.exists()).toBe(true)
     expect(elem.prop('title')).toEqual(`Introducing Search for a Cause`)
+  })
+
+  it('[search-intro-A] does not render the search intro notification when the user has previously clicked it', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('introA')
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.experimentActions.searchIntro = 'CLICK'
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    expect(elem.exists()).toBe(false)
+  })
+
+  it('[search-intro-A] does not render the search intro notification when the user has previously dismissed it', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('introA')
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.experimentActions.searchIntro = 'DISMISS'
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    expect(elem.exists()).toBe(false)
+  })
+
+  it('[search-intro-A] does render the search intro notification if the user has not taken any action', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('introA')
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.experimentActions.searchIntro = 'NONE'
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    expect(elem.exists()).toBe(true)
   })
 
   it('[search-intro-A] hides the search intro when the onClick callback is called', async () => {

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -569,7 +569,7 @@ describe('Dashboard component', () => {
     showGlobalNotification.mockReturnValueOnce(true)
     hasUserDismissedNotificationRecently.mockReturnValueOnce(false)
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Notification).length).toBe(1)
+    expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(1)
   })
 
   it('does not render a notification when one is not live', () => {
@@ -580,7 +580,7 @@ describe('Dashboard component', () => {
     showGlobalNotification.mockReturnValueOnce(false)
     hasUserDismissedNotificationRecently.mockReturnValueOnce(false)
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Notification).length).toBe(0)
+    expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(0)
   })
 
   it('does not render a notification when one is live but the user has dismissed it', () => {
@@ -591,7 +591,7 @@ describe('Dashboard component', () => {
     showGlobalNotification.mockReturnValueOnce(true)
     hasUserDismissedNotificationRecently.mockReturnValueOnce(true)
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Notification).length).toBe(0)
+    expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(0)
   })
 
   it('hides the notification when the onDismiss callback is called', () => {
@@ -604,12 +604,12 @@ describe('Dashboard component', () => {
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
 
     // Notification should be visible.
-    expect(wrapper.find(Notification).length).toBe(1)
+    expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(1)
 
     // Mock that the user dismisses the notification.
-    wrapper.find(Notification).prop('onDismiss')()
+    wrapper.find('[data-test-id="global-notification"]').prop('onDismiss')()
 
     // Notification should be gone.
-    expect(wrapper.find(Notification).length).toBe(0)
+    expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(0)
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -35,13 +35,7 @@ import {
   hasUserDismissedNotificationRecently,
 } from 'js/utils/local-user-data-mgr'
 import { showGlobalNotification } from 'js/utils/feature-flags'
-
-// TODO: test the "search intro" experiment
-// import {
-//   EXPERIMENT_SEARCH_INTRO,
-//   getExperimentGroups,
-//   getUserExperimentGroup,
-// } from 'js/utils/experiments'
+import { getUserExperimentGroup } from 'js/utils/experiments'
 
 jest.mock('js/analytics/logEvent')
 jest.mock('js/utils/localstorage-mgr')
@@ -70,6 +64,7 @@ beforeAll(() => {
 
 afterEach(() => {
   localStorageMgr.clear()
+  getUserExperimentGroup.mockReturnValue('none')
 })
 
 afterAll(() => {
@@ -618,5 +613,23 @@ describe('Dashboard component', () => {
 
     // Notification should be gone.
     expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(0)
+  })
+
+  it('does not render the search intro notification when the user is in the control group', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('none')
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    expect(wrapper.find('[data-test-id="search-intro-a"]').exists()).toBe(false)
+  })
+
+  it('renders the search intro notification when the user is in the experimental group', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('introA')
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    expect(elem.exists()).toBe(true)
+    expect(elem.prop('title')).toEqual(`Introducing Search for a Cause`)
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -80,6 +80,7 @@ beforeEach(() => {
 afterEach(() => {
   localStorageMgr.clear()
   getUserExperimentGroup.mockReturnValue('none')
+  jest.clearAllMocks()
 })
 
 afterAll(() => {
@@ -685,7 +686,7 @@ describe('Dashboard component', () => {
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
     wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
-    expect(goTo).toHaveBeenCalledWith(searchChromeExtensionPage)
+    expect(goTo).toHaveBeenCalledWith(searchFirefoxExtensionPage)
   })
 
   it('[search-intro-A] redirects to the Chrome web store when the user clicks the search intro action button on an unknown/unsupported browser', () => {

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -17,7 +17,6 @@ import LogAccountCreation from 'js/components/Dashboard/LogAccountCreationContai
 import AssignExperimentGroups from 'js/components/Dashboard/AssignExperimentGroupsContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import NewUserTour from 'js/components/Dashboard/NewUserTourContainer'
-import Notification from 'js/components/Dashboard/NotificationComponent'
 import localStorageMgr from 'js/utils/localstorage-mgr'
 import { STORAGE_NEW_USER_HAS_COMPLETED_TOUR } from 'js/constants'
 import { getCurrentUser } from 'js/authentication/user'
@@ -37,6 +36,13 @@ import {
 } from 'js/utils/local-user-data-mgr'
 import { showGlobalNotification } from 'js/utils/feature-flags'
 
+// TODO: test the "search intro" experiment
+// import {
+//   EXPERIMENT_SEARCH_INTRO,
+//   getExperimentGroups,
+//   getUserExperimentGroup,
+// } from 'js/utils/experiments'
+
 jest.mock('js/analytics/logEvent')
 jest.mock('js/utils/localstorage-mgr')
 jest.mock('js/authentication/user')
@@ -44,6 +50,7 @@ jest.mock('js/navigation/navigation')
 jest.mock('js/ads/adSettings')
 jest.mock('js/utils/local-user-data-mgr')
 jest.mock('js/utils/feature-flags')
+jest.mock('js/utils/experiments')
 
 const mockNow = '2018-05-15T10:30:00.000'
 

--- a/web/src/js/components/Dashboard/__tests__/NotificationComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/NotificationComponent.test.js
@@ -14,6 +14,8 @@ const getMockProps = () => ({
   message: 'Here is some additional information.',
   buttonText: 'Click Me',
   buttonURL: 'http://example.com/some-link/',
+  onClick: undefined,
+  onDismiss: undefined,
 })
 
 afterEach(() => {
@@ -57,7 +59,7 @@ describe('Notification component', () => {
     ).toBe(`ABC 123 this is a message`)
   })
 
-  it('displays only the "dismiss" button when an action button is provided', () => {
+  it('displays only the "dismiss" button when no action button is provided', () => {
     const Notification = require('js/components/Dashboard/NotificationComponent')
       .default
     const mockProps = getMockProps()
@@ -105,7 +107,39 @@ describe('Notification component', () => {
     ).toBe('http://example.com')
   })
 
-  it('clicking the "dismiss" button sets the dismiss time in local storage', () => {
+  it('does not create an outbound button link when buttonText is not provided', () => {
+    const Notification = require('js/components/Dashboard/NotificationComponent')
+      .default
+    const mockProps = getMockProps()
+    delete mockProps.buttonText
+    mockProps.buttonURL = 'http://example.com'
+    mockProps.onClick = jest.fn()
+    const wrapper = shallow(<Notification {...mockProps} />)
+    expect(
+      wrapper
+        .find(Link)
+        .first()
+        .exists()
+    ).toBe(false)
+  })
+
+  it('does not create an outbound button link when neither buttonURL nor onClick is provided', () => {
+    const Notification = require('js/components/Dashboard/NotificationComponent')
+      .default
+    const mockProps = getMockProps()
+    delete mockProps.buttonURL
+    delete mockProps.onClick
+    mockProps.buttonText = 'Do the thing'
+    const wrapper = shallow(<Notification {...mockProps} />)
+    expect(
+      wrapper
+        .find(Link)
+        .first()
+        .exists()
+    ).toBe(false)
+  })
+
+  it('sets the dismiss time in local storage when clicking the "dismiss" button', () => {
     const Notification = require('js/components/Dashboard/NotificationComponent')
       .default
     const mockProps = getMockProps()
@@ -117,7 +151,7 @@ describe('Notification component', () => {
     expect(setNotificationDismissTime).toHaveBeenCalled()
   })
 
-  it('clicking the "dismiss" button calls the onDismiss prop', () => {
+  it('calls the onDismiss prop when clicking the "dismiss" button', () => {
     const Notification = require('js/components/Dashboard/NotificationComponent')
       .default
     const mockProps = getMockProps()
@@ -128,5 +162,38 @@ describe('Notification component', () => {
       .first()
       .simulate('click')
     expect(mockProps.onDismiss).toHaveBeenCalled()
+  })
+
+  it('displays two buttons when we provide an action button with "onClick"', () => {
+    const Notification = require('js/components/Dashboard/NotificationComponent')
+      .default
+    const mockProps = getMockProps()
+    delete mockProps.buttonURL
+    mockProps.buttonText = 'Click the button'
+    mockProps.onClick = jest.fn()
+    const wrapper = shallow(<Notification {...mockProps} />)
+    expect(wrapper.find(Button).length).toBe(2)
+    expect(
+      wrapper
+        .find(Button)
+        .at(1)
+        .render()
+        .text()
+    ).toBe(`Click the button`)
+  })
+
+  it('calls the onClick prop when clicking the action button with an onClick prop', () => {
+    const Notification = require('js/components/Dashboard/NotificationComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.buttonText = 'Click the button'
+    delete mockProps.buttonURL
+    mockProps.onClick = jest.fn()
+    const wrapper = shallow(<Notification {...mockProps} />)
+    wrapper
+      .find(Button)
+      .at(1)
+      .simulate('click')
+    expect(mockProps.onClick).toHaveBeenCalled()
   })
 })

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -91,3 +91,10 @@ export const SEARCH_STORAGE_NEW_USER_HAS_DISMISSED_INTRO =
 **/
 
 export const ERROR_USER_DOES_NOT_EXIST = 'USER_DOES_NOT_EXIST'
+
+/**
+  Code constants.
+**/
+export const CHROME_BROWSER = 'chrome'
+export const FIREFOX_BROWSER = 'firefox'
+export const UNSUPPORTED_BROWSER = 'other'

--- a/web/src/js/mutations/LogUserExperimentActionsMutation.js
+++ b/web/src/js/mutations/LogUserExperimentActionsMutation.js
@@ -1,0 +1,24 @@
+import graphql from 'babel-plugin-relay/macro'
+import commitMutation from 'relay-commit-mutation-promise'
+import environment from 'js/relay-env'
+
+const mutation = graphql`
+  mutation LogUserExperimentActionsMutation(
+    $input: LogUserExperimentActionsInput!
+  ) {
+    logUserExperimentActions(input: $input) {
+      user {
+        id
+      }
+    }
+  }
+`
+
+export default input => {
+  return commitMutation(environment, {
+    mutation,
+    variables: {
+      input: input,
+    },
+  })
+}

--- a/web/src/js/mutations/__tests__/LogUserExperimentActionsMutation.test.js
+++ b/web/src/js/mutations/__tests__/LogUserExperimentActionsMutation.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import environment from 'js/relay-env'
+import commitMutation from 'relay-commit-mutation-promise'
+
+jest.mock('js/relay-env')
+jest.mock('react-relay')
+jest.mock('relay-commit-mutation-promise')
+
+const getMockInput = () => ({
+  userId: 'abc-123',
+  experimentActions: {
+    searchIntro: 'DISMISS',
+  },
+})
+
+const getMockAdditionalVars = () => ({})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('LogUserExperimentActionsMutation', () => {
+  it('calls commitMutation with expected values', async () => {
+    expect.assertions(1)
+    const LogUserExperimentActionsMutation = require('../LogUserExperimentActionsMutation')
+      .default
+    const args = getMockInput()
+    await LogUserExperimentActionsMutation(args, getMockAdditionalVars())
+    expect(commitMutation).toHaveBeenCalledWith(environment, {
+      mutation: expect.any(Function),
+      variables: {
+        input: args,
+      },
+    })
+  })
+})

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -107,6 +107,12 @@ export const externalContactUsURL =
 export const facebookPageURL = 'https://www.facebook.com/TabForACause'
 export const twitterPageURL = 'https://twitter.com/TabForACause'
 
+// Browser extension pages
+export const searchFirefoxExtensionPage =
+  'https://addons.mozilla.org/en-US/firefox/addon/search-for-a-cause/'
+export const searchChromeExtensionPage =
+  'https://chrome.google.com/webstore/detail/search-for-a-cause/eeiiknnphladbapfamiamfimnnnodife/'
+
 // TODO: stop using these and replace the existing uses.
 //   They only cause additional complication during testing.
 // CONVENIENCE FUNCTIONS

--- a/web/src/js/utils/__tests__/detectBrowser.test.js
+++ b/web/src/js/utils/__tests__/detectBrowser.test.js
@@ -1,0 +1,93 @@
+/* eslint-env jest */
+
+import {
+  CHROME_BROWSER,
+  FIREFOX_BROWSER,
+  UNSUPPORTED_BROWSER,
+} from 'js/constants'
+
+jest.mock('browser-detect')
+
+const createMockBrowserInfo = (browser = 'chrome', mobile = false) => {
+  return {
+    name: browser,
+    version: '58.0.3029',
+    versionNumber: 58.03029,
+    mobile: mobile,
+    os: 'Windows NT 10.0',
+  }
+}
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('detectBrowser', () => {
+  it('returns "chrome" for desktop Chrome', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(createMockBrowserInfo('chrome', false))
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(CHROME_BROWSER)
+  })
+
+  it('returns "chrome" for mobile Chrome', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(createMockBrowserInfo('chrome', true))
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(CHROME_BROWSER)
+  })
+
+  it('returns "chrome" for desktop chromium', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(
+      createMockBrowserInfo('chromium', false)
+    )
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(CHROME_BROWSER)
+  })
+
+  it('returns "chrome" for "crios" (Chrome on iOS)', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(createMockBrowserInfo('crios', true))
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(CHROME_BROWSER)
+  })
+
+  it('returns "firefox" for desktop Firefox', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(
+      createMockBrowserInfo('firefox', false)
+    )
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(FIREFOX_BROWSER)
+  })
+
+  it('returns "firefox" for mobile Firefox', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(createMockBrowserInfo('firefox', true))
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(FIREFOX_BROWSER)
+  })
+
+  it('returns "other" for desktop Safari', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(createMockBrowserInfo('safari', false))
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(UNSUPPORTED_BROWSER)
+  })
+
+  it('returns "other" for mobile Safari', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(createMockBrowserInfo('safari', true))
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(UNSUPPORTED_BROWSER)
+  })
+
+  it('returns "other" for some unexpected browser name', () => {
+    const browserDetectLib = require('browser-detect').default
+    browserDetectLib.mockReturnValueOnce(
+      createMockBrowserInfo('hypebrowzer2000', false)
+    )
+    const { detectSupportedBrowser } = require('js/utils/detectBrowser')
+    expect(detectSupportedBrowser()).toEqual(UNSUPPORTED_BROWSER)
+  })
+})

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -1177,6 +1177,11 @@ describe('Actual experiments we are running or will run', () => {
       //   active: true,
       //   disabled: false,
       // },
+      {
+        name: 'searchIntro',
+        active: true,
+        disabled: false,
+      },
     ])
   })
 

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -1179,7 +1179,7 @@ describe('Actual experiments we are running or will run', () => {
       // },
       {
         name: 'searchIntro',
-        active: true,
+        active: false,
         disabled: false,
       },
     ])

--- a/web/src/js/utils/detectBrowser.js
+++ b/web/src/js/utils/detectBrowser.js
@@ -1,0 +1,35 @@
+import detectBrowser from 'browser-detect'
+import {
+  CHROME_BROWSER,
+  FIREFOX_BROWSER,
+  UNSUPPORTED_BROWSER,
+} from 'js/constants'
+
+/**
+ * Determines the user's browser. If the browser is one
+ * for which we have a browser extension, return the browser
+ * name; else, return "other".
+ * @return {String} One of "chrome", "firefox", or "other"
+ */
+export const detectSupportedBrowser = () => {
+  const browserInfo = detectBrowser()
+  let browser
+  switch (browserInfo.name) {
+    case 'chrome':
+      browser = CHROME_BROWSER
+      break
+    case 'chromium':
+      browser = CHROME_BROWSER
+      break
+    case 'crios':
+      browser = CHROME_BROWSER
+      break
+    case 'firefox':
+      browser = FIREFOX_BROWSER
+      break
+    default:
+      browser = UNSUPPORTED_BROWSER
+      break
+  }
+  return browser
+}

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -276,8 +276,7 @@ export const _experimentsConfig = [
   // @experiment-search-intro
   createExperiment({
     name: EXPERIMENT_SEARCH_INTRO,
-    // TODO: make inactive before deploy
-    active: true,
+    active: false,
     disabled: false,
     percentageOfExistingUsersInExperiment: 1.0,
     percentageOfNewUsersInExperiment: 100.0,

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -2,7 +2,11 @@ import { filter, find } from 'lodash/collection'
 import { isNil } from 'lodash/lang'
 import localStorageMgr from 'js/utils/localstorage-mgr'
 import { STORAGE_EXPERIMENT_PREFIX } from 'js/constants'
-// import { onlyIncludeNewUsers } from 'js/utils/experimentFilters'
+import {
+  includeIfAnyIsTrue,
+  excludeUsersWhoJoinedWithin,
+  onlyIncludeNewUsers,
+} from 'js/utils/experimentFilters'
 import environment from 'js/relay-env'
 import UpdateUserExperimentGroupsMutation from 'js/mutations/UpdateUserExperimentGroupsMutation'
 
@@ -245,6 +249,7 @@ const NoneExperimentGroup = createExperimentGroup({
 export const EXPERIMENT_THIRD_AD = 'thirdAd'
 export const EXPERIMENT_ONE_AD_FOR_NEW_USERS = 'oneAdForNewUsers'
 export const EXPERIMENT_AD_EXPLANATION = 'adExplanation'
+export const EXPERIMENT_SEARCH_INTRO = 'searchIntro'
 
 // Add ExperimentGroup objects here to enable new experiments.
 // The "name" value of the experiment must be the same as the
@@ -268,6 +273,33 @@ export const _experimentsConfig = [
   //     }),
   //   },
   // }),
+  // @experiment-search-intro
+  createExperiment({
+    name: EXPERIMENT_SEARCH_INTRO,
+    // TODO: make inactive before deploy
+    active: true,
+    disabled: false,
+    percentageOfExistingUsersInExperiment: 1.0,
+    percentageOfNewUsersInExperiment: 100.0,
+    filters: [
+      // In this test, include brand new users and users
+      // who joined more than 2 months ago.
+      includeIfAnyIsTrue([
+        onlyIncludeNewUsers,
+        excludeUsersWhoJoinedWithin(2, 'months'),
+      ]),
+    ],
+    groups: {
+      NO_INTRO: createExperimentGroup({
+        value: 'noIntro',
+        schemaValue: 'NO_INTRO',
+      }),
+      INTRO_A: createExperimentGroup({
+        value: 'introA',
+        schemaValue: 'INTRO_A',
+      }),
+    },
+  }),
 ]
 
 // We do this to be able to modify the experiments

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3247,6 +3247,13 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-detect@^0.2.28:
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/browser-detect/-/browser-detect-0.2.28.tgz#5688fc22f638390614ebea4646483403fb20ebfb"
+  integrity sha512-KeWGHqYQmHDkCFG2dIiX/2wFUgqevbw/rd6wNi9N6rZbaSJFtG5kel0HtprRwCGp8sqpQP79LzDJXf/WCx4WAw==
+  dependencies:
+    core-js "^2.5.7"
+
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"


### PR DESCRIPTION
* Create an experiment to show an notification about Search for a Cause
* Detect the client browser so we can send the user to the appropriate extension store when they click
* Log when a user joins their experiment group so we can add people on a rolling basis
* Log whether a user dismisses or clicks through the notification, and hide the notification when they do