### PR TITLE
Use the tab global from a module

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -127,31 +127,6 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-
-    <% if (process.env.REACT_APP_WHICH_APP === "newtab"){ %>
-    <!--
-      @gladly-customization:
-      Tab for a Cause global variable
-    -->
-    <script type="text/javascript">
-      /* eslint-disable */
-      // Used for handling some communication between disparate parts
-      // of our app (e.g. ads events happening before app code loads).
-      (() => {
-        window.tabforacause = window.tabforacause || {
-          ads: {
-            amazonBids: {},
-            slotsRendered: {},
-            slotsViewable: {},
-            slotsLoaded: {},
-            slotsAlreadyLoggedRevenue: {}
-          },
-          featureFlags: {}
-        }
-      })()
-    </script>
-    <% } %>
-
     <% if (process.env.REACT_APP_WHICH_APP === "search"){ %>
     <!--
       @gladly-customization:

--- a/web/src/js/ads/__tests__/ads.test.js
+++ b/web/src/js/ads/__tests__/ads.test.js
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import { getDefaultTabGlobal } from 'js/utils/test-utils'
 import getGoogleTag, {
   __setPubadsRefreshMock,
 } from 'js/ads/google/getGoogleTag'

--- a/web/src/js/ads/__tests__/ads.test.js
+++ b/web/src/js/ads/__tests__/ads.test.js
@@ -36,9 +36,6 @@ beforeEach(() => {
   delete window.pbjs
   window.pbjs = getPrebidPbjs()
 
-  // Mock tabforacause global
-  window.tabforacause = getDefaultTabGlobal()
-
   // Set up googletag
   delete window.googletag
   window.googletag = getGoogleTag()
@@ -53,7 +50,6 @@ afterAll(() => {
   delete window.googletag
   delete window.apstag
   delete window.pbjs
-  delete window.tabforacause
 })
 
 describe('ads script', () => {

--- a/web/src/js/ads/__tests__/handleAdsLoaded.test.js
+++ b/web/src/js/ads/__tests__/handleAdsLoaded.test.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 
+import { getTabGlobal } from 'js/utils/utils'
 import {
-  getDefaultTabGlobal,
+  deleteTabGlobal,
   mockGoogleTagImpressionViewableData,
   mockGoogleTagSlotOnloadData,
   mockGoogleTagSlotRenderEndedData,
@@ -9,7 +10,6 @@ import {
 
 beforeEach(() => {
   delete window.googletag
-  delete window.tabforacause
 
   // Mock googletag
   const mockAddEventListener = jest.fn()
@@ -20,20 +20,17 @@ beforeEach(() => {
     }),
   }
 
-  // Mock tabforacause global
-  window.tabforacause = getDefaultTabGlobal()
-
   jest.clearAllMocks()
   jest.resetModules()
 })
 
 afterAll(() => {
   delete window.googletag
-  delete window.tabforacause
+  deleteTabGlobal()
 })
 
 describe('handleAdsLoaded', function() {
-  it('adds a slot ID to window.tabforacause\'s "rendered slots" object when GPT\'s "slotRenderEnded" event is fired', () => {
+  it('adds a slot ID to the tab global\'s "rendered slots" object when GPT\'s "slotRenderEnded" event is fired', () => {
     // Mock GPT's pubads addEventListener so we can fake an event
     const googleEventListenerCalls = {}
     window.googletag
@@ -64,23 +61,22 @@ describe('handleAdsLoaded', function() {
     )
 
     // Make sure we've marked the slot as loaded
-    expect(window.tabforacause.ads.slotsRendered[slotId]).toBe(
-      mockSlotRenderEventData
-    )
+    const tabGlobal = getTabGlobal()
+    expect(tabGlobal.ads.slotsRendered[slotId]).toBe(mockSlotRenderEventData)
 
     // Make sure it works multiple times
     const otherSlotId = 'xyz-987'
     const otherMockSlotRenderEventData = mockGoogleTagSlotRenderEndedData(
       otherSlotId
     )
-    expect(window.tabforacause.ads.slotsRendered[otherSlotId]).toBeUndefined()
+    expect(tabGlobal.ads.slotsRendered[otherSlotId]).toBeUndefined()
     slotRenderEndedEventCallback(otherMockSlotRenderEventData)
-    expect(window.tabforacause.ads.slotsRendered[otherSlotId]).toBe(
+    expect(tabGlobal.ads.slotsRendered[otherSlotId]).toBe(
       otherMockSlotRenderEventData
     )
   })
 
-  it('marks a slot as loaded on window.tabforacause\'s "viewable slots" object when GPT\'s "impressionViewable" event is fired', () => {
+  it('marks a slot as loaded on the tab global\'s "viewable slots" object when GPT\'s "impressionViewable" event is fired', () => {
     // Mock GPT's pubads addEventListener so we can fake an event
     const googleEventListenerCalls = {}
     window.googletag
@@ -111,19 +107,20 @@ describe('handleAdsLoaded', function() {
     )
 
     // Make sure we've marked the slot as loaded
-    expect(window.tabforacause.ads.slotsViewable[slotId]).toBe(true)
+    const tabGlobal = getTabGlobal()
+    expect(tabGlobal.ads.slotsViewable[slotId]).toBe(true)
 
     // Make sure it works multiple times
     const otherSlotId = 'xyz-987'
     const otherMockSlotLoadEventData = mockGoogleTagImpressionViewableData(
       otherSlotId
     )
-    expect(window.tabforacause.ads.slotsViewable[otherSlotId]).toBeUndefined()
+    expect(tabGlobal.ads.slotsViewable[otherSlotId]).toBeUndefined()
     slotRenderEndedEventCallback(otherMockSlotLoadEventData)
-    expect(window.tabforacause.ads.slotsViewable[otherSlotId]).toBe(true)
+    expect(tabGlobal.ads.slotsViewable[otherSlotId]).toBe(true)
   })
 
-  it('marks a slot as loaded on window.tabforacause\'s "loaded slots" object when GPT\'s "slotOnload" event is fired', () => {
+  it('marks a slot as loaded on the tab global\'s "loaded slots" object when GPT\'s "slotOnload" event is fired', () => {
     // Mock GPT's pubads addEventListener so we can fake an event
     const googleEventListenerCalls = {}
     window.googletag
@@ -152,13 +149,14 @@ describe('handleAdsLoaded', function() {
     expect(googleEventListenerCalls['slotOnload'][0][0]).toEqual('slotOnload')
 
     // Make sure we've marked the slot as loaded
-    expect(window.tabforacause.ads.slotsLoaded[slotId]).toBe(true)
+    const tabGlobal = getTabGlobal()
+    expect(tabGlobal.ads.slotsLoaded[slotId]).toBe(true)
 
     // Make sure it works multiple times
     const otherSlotId = 'xyz-987'
     const otherMockSlotLoadEventData = mockGoogleTagSlotOnloadData(otherSlotId)
-    expect(window.tabforacause.ads.slotsLoaded[otherSlotId]).toBeUndefined()
+    expect(tabGlobal.ads.slotsLoaded[otherSlotId]).toBeUndefined()
     slotRenderEndedEventCallback(otherMockSlotLoadEventData)
-    expect(window.tabforacause.ads.slotsLoaded[otherSlotId]).toBe(true)
+    expect(tabGlobal.ads.slotsLoaded[otherSlotId]).toBe(true)
   })
 })

--- a/web/src/js/ads/amazon/__tests__/amazonBidder.test.js
+++ b/web/src/js/ads/amazon/__tests__/amazonBidder.test.js
@@ -5,8 +5,9 @@ import getAmazonTag, {
   __runBidsBack,
 } from 'js/ads/amazon/getAmazonTag'
 import getGoogleTag from 'js/ads/google/getGoogleTag'
-import { getDefaultTabGlobal, mockAmazonBidResponse } from 'js/utils/test-utils'
+import { deleteTabGlobal, mockAmazonBidResponse } from 'js/utils/test-utils'
 import { getNumberOfAdsToShow } from 'js/ads/adSettings'
+import { getTabGlobal } from 'js/utils/utils'
 
 jest.mock('js/ads/adSettings')
 jest.mock('js/ads/consentManagement')
@@ -16,9 +17,6 @@ beforeEach(() => {
   // Mock apstag
   delete window.apstag
   window.apstag = getAmazonTag()
-
-  // Mock tabforacause global
-  window.tabforacause = getDefaultTabGlobal()
 
   // Set up googletag
   delete window.googletag
@@ -32,7 +30,7 @@ afterEach(() => {
 afterAll(() => {
   delete window.googletag
   delete window.apstag
-  delete window.tabforacause
+  deleteTabGlobal()
 })
 
 describe('amazonBidder', () => {
@@ -168,21 +166,17 @@ describe('amazonBidder', () => {
     })
     passedCallback([someBid, someOtherBid])
 
+    const tabGlobal = getTabGlobal()
+
     // Should not have stored the bids yet.
-    expect(
-      window.tabforacause.ads.amazonBids['div-gpt-ad-123456789-0']
-    ).toBeUndefined()
-    expect(
-      window.tabforacause.ads.amazonBids['div-gpt-ad-24681357-0']
-    ).toBeUndefined()
+    expect(tabGlobal.ads.amazonBids['div-gpt-ad-123456789-0']).toBeUndefined()
+    expect(tabGlobal.ads.amazonBids['div-gpt-ad-24681357-0']).toBeUndefined()
 
     storeAmazonBids()
 
     // Now should have stored the bids.
-    expect(
-      window.tabforacause.ads.amazonBids['div-gpt-ad-123456789-0']
-    ).toEqual(someBid)
-    expect(window.tabforacause.ads.amazonBids['div-gpt-ad-24681357-0']).toEqual(
+    expect(tabGlobal.ads.amazonBids['div-gpt-ad-123456789-0']).toEqual(someBid)
+    expect(tabGlobal.ads.amazonBids['div-gpt-ad-24681357-0']).toEqual(
       someOtherBid
     )
   })

--- a/web/src/js/ads/amazon/amazonBidder.js
+++ b/web/src/js/ads/amazon/amazonBidder.js
@@ -10,6 +10,7 @@ import {
   HORIZONTAL_AD_SLOT_DOM_ID,
 } from 'js/ads/adSettings'
 import logger from 'js/utils/logger'
+import { getTabGlobal } from 'js/utils/utils'
 
 // Save returned Amazon bids.
 var amazonBids
@@ -31,10 +32,11 @@ export const storeAmazonBids = () => {
   //   size: '0x0',
   //   slotID: 'div-gpt-ad-123456789-0'
   // }
+  const tabGlobal = getTabGlobal()
   try {
     if (amazonBids && amazonBids.length) {
       amazonBids.forEach(bid => {
-        window.tabforacause.ads.amazonBids[bid.slotID] = bid
+        tabGlobal.ads.amazonBids[bid.slotID] = bid
       })
     }
   } catch (e) {

--- a/web/src/js/ads/handleAdsLoaded.js
+++ b/web/src/js/ads/handleAdsLoaded.js
@@ -1,5 +1,6 @@
 import getGoogleTag from 'js/ads/google/getGoogleTag'
 import logger from 'js/utils/logger'
+import { getTabGlobal } from 'js/utils/utils'
 
 // Keep track of what ad slots have loaded. App code loads later and
 // therefore can miss the slot loading event. This gives the app code
@@ -7,17 +8,18 @@ import logger from 'js/utils/logger'
 export default () => {
   try {
     const googletag = getGoogleTag()
+    const tabGlobal = getTabGlobal()
 
     const storeRenderedSlotData = (slotId, eventData) => {
-      window.tabforacause.ads.slotsRendered[slotId] = eventData
+      tabGlobal.ads.slotsRendered[slotId] = eventData
     }
 
     const markSlotAsViewable = slotId => {
-      window.tabforacause.ads.slotsViewable[slotId] = true
+      tabGlobal.ads.slotsViewable[slotId] = true
     }
 
     const markSlotAsLoaded = slotId => {
-      window.tabforacause.ads.slotsLoaded[slotId] = true
+      tabGlobal.ads.slotsLoaded[slotId] = true
     }
 
     googletag.cmd.push(() => {

--- a/web/src/js/ads/indexExchange/__tests__/indexExchangeBidder.test.js
+++ b/web/src/js/ads/indexExchange/__tests__/indexExchangeBidder.test.js
@@ -16,10 +16,6 @@ beforeEach(() => {
     .default
   window.headertag = getIndexExchangeTag()
 
-  // Mock tabforacause global
-  const { getDefaultTabGlobal } = require('js/utils/test-utils')
-  window.tabforacause = getDefaultTabGlobal()
-
   // Set up googletag
   delete window.googletag
   const getGoogleTag = require('js/ads/google/getGoogleTag').default
@@ -32,7 +28,6 @@ afterEach(() => {
 
 afterAll(() => {
   delete window.headertag
-  delete window.tabforacause
   delete window.googletag
 })
 

--- a/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
+++ b/web/src/js/ads/prebid/__tests__/prebidConfig.test.js
@@ -6,7 +6,6 @@ import getPrebidPbjs, {
   __disableAutomaticBidResponses,
   __runBidsBack,
 } from 'js/ads/prebid/getPrebidPbjs'
-import { getDefaultTabGlobal } from 'js/utils/test-utils'
 import {
   getNumberOfAdsToShow,
   getVerticalAdSizes,
@@ -21,8 +20,6 @@ jest.mock('js/ads/prebid/getPrebidPbjs')
 jest.mock('js/utils/client-location')
 
 beforeEach(() => {
-  window.tabforacause = getDefaultTabGlobal()
-
   delete window.pbjs
   window.pbjs = getPrebidPbjs()
 

--- a/web/src/js/components/Dashboard/LogRevenueComponent.js
+++ b/web/src/js/components/Dashboard/LogRevenueComponent.js
@@ -114,8 +114,7 @@ class LogRevenueComponent extends React.Component {
   logRevenueForSlotId(slotId, adUnitCode) {
     try {
       // If we have already logged revenue for this slot, don't log it again
-      // const tabGlobal = getTabGlobal()
-      const tabGlobal = window.tabforacause
+      const tabGlobal = getTabGlobal()
       if (slotId in tabGlobal.ads.slotsAlreadyLoggedRevenue) {
         return
       }

--- a/web/src/js/components/Dashboard/LogRevenueComponent.js
+++ b/web/src/js/components/Dashboard/LogRevenueComponent.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import getGoogleTag from 'js/ads/google/getGoogleTag'
 import getPrebidPbjs from 'js/ads/prebid/getPrebidPbjs'
 import logger from 'js/utils/logger'
+import { getTabGlobal } from 'js/utils/utils'
 
 // Log revenue from ads
 class LogRevenueComponent extends React.Component {
@@ -49,7 +50,8 @@ class LogRevenueComponent extends React.Component {
    * @return {string} encodedAmazonRevenue.encodedValue - The Amazon revenue code
    */
   getEncodedAmazonRevenueForSlot(slotId) {
-    const amazonBids = window.tabforacause.ads.amazonBids
+    const tabGlobal = getTabGlobal()
+    const amazonBids = tabGlobal.ads.amazonBids
     const amazonBidExists =
       // An empty string for either of these means no bid
       get(amazonBids, [slotId, 'amznbid']) &&
@@ -95,7 +97,8 @@ class LogRevenueComponent extends React.Component {
   getSlotRenderEndedDataForSlotId(slotId) {
     var slotRenderEndedData = null
     try {
-      slotRenderEndedData = window.tabforacause.ads.slotsRendered[slotId]
+      const tabGlobal = getTabGlobal()
+      slotRenderEndedData = tabGlobal.ads.slotsRendered[slotId]
     } catch (e) {
       logger.error(e)
     }
@@ -111,11 +114,13 @@ class LogRevenueComponent extends React.Component {
   logRevenueForSlotId(slotId, adUnitCode) {
     try {
       // If we have already logged revenue for this slot, don't log it again
-      if (slotId in window.tabforacause.ads.slotsAlreadyLoggedRevenue) {
+      // const tabGlobal = getTabGlobal()
+      const tabGlobal = window.tabforacause
+      if (slotId in tabGlobal.ads.slotsAlreadyLoggedRevenue) {
         return
       }
       // Mark that we've logged revenue for this slot
-      window.tabforacause.ads.slotsAlreadyLoggedRevenue[slotId] = true
+      tabGlobal.ads.slotsAlreadyLoggedRevenue[slotId] = true
 
       // Get data for the rendered slot
       const slotRenderedData = this.getSlotRenderEndedDataForSlotId(slotId)
@@ -168,7 +173,8 @@ class LogRevenueComponent extends React.Component {
   logRevenueForAlreadyLoadedAds() {
     try {
       // This may be set earlier by ads code (outside of core app code)
-      const slotsLoadedObj = window.tabforacause.ads.slotsRendered
+      const tabGlobal = getTabGlobal()
+      const slotsLoadedObj = tabGlobal.ads.slotsRendered
       if (Object.keys(slotsLoadedObj).length) {
         const self = this
         Object.keys(slotsLoadedObj).forEach(slotId => {
@@ -197,7 +203,8 @@ class LogRevenueComponent extends React.Component {
           const adUnitCode = event.slot.getAdUnitPath()
 
           // Store rendered slot data
-          window.tabforacause.ads.slotsRendered[slotId] = event
+          const tabGlobal = getTabGlobal()
+          tabGlobal.ads.slotsRendered[slotId] = event
           this.logRevenueForSlotId(slotId, adUnitCode)
         } catch (e) {
           logger.error(e)

--- a/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
@@ -3,8 +3,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
+import { getTabGlobal } from 'js/utils/utils'
 import {
-  getDefaultTabGlobal,
+  deleteTabGlobal,
   mockAmazonBidResponse,
   mockGoogleTagSlotRenderEndedData,
 } from 'js/utils/test-utils'
@@ -35,22 +36,15 @@ beforeEach(() => {
   delete window.apstag
   window.apstag = getAmazonTag
 
-  // Mock tabforacause global
-  delete window.tabforacause
-  window.tabforacause = getDefaultTabGlobal()
-
   window.pbjs.getHighestCpmBids.mockReturnValue({})
 })
 
 afterEach(() => {
   jest.clearAllMocks()
-})
-
-afterAll(() => {
   delete window.googletag
   delete window.pbjs
   delete window.apstag
-  delete window.tabforacause
+  deleteTabGlobal()
 })
 
 describe('LogRevenueComponent', function() {
@@ -71,14 +65,17 @@ describe('LogRevenueComponent', function() {
     // Mark an ad slot as loaded
     const slotId = 'my-slot-2468'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered[
-      slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId, adUnitCode, {
-      advertiserId: 132435,
-    })
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
     // We use "slotsViewable" as the measure of ads already loaded
-    // window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    // tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 0.172
@@ -91,7 +88,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
@@ -120,20 +117,21 @@ describe('LogRevenueComponent', function() {
     )
 
     // It should mark this slot as logged
-    expect(window.tabforacause.ads.slotsAlreadyLoggedRevenue[slotId]).toBe(true)
+    expect(tabGlobal.ads.slotsAlreadyLoggedRevenue[slotId]).toBe(true)
   })
 
   it('does not log revenue for slots that have already been logged', () => {
     // Mark an ad slot as loaded
     const slotId = 'abc-123'
-    window.tabforacause.ads.slotsRendered[
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
       slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId)
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mark the ad slot as having already been logged
-    window.tabforacause.ads.slotsAlreadyLoggedRevenue[slotId] = true
+    tabGlobal.ads.slotsAlreadyLoggedRevenue[slotId] = true
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 0.172
@@ -146,7 +144,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
@@ -169,17 +167,18 @@ describe('LogRevenueComponent', function() {
   it('does not throw an error or log revenue if there are not any bids for a slot', () => {
     // Mark an ad slot as loaded
     const slotId = 'abc-123'
-    window.tabforacause.ads.slotsRendered[
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
       slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId)
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock no Prebid bids for the slot
     window.pbjs.getHighestCpmBids.mockReturnValue([])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
@@ -203,13 +202,16 @@ describe('LogRevenueComponent', function() {
     // Mark an ad slot as loaded
     const slotId = 'abc-123'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered[
-      slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId, adUnitCode, {
-      advertiserId: 9876543,
-    })
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 9876543,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 0.1234567890123456789
@@ -222,7 +224,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
@@ -255,7 +257,8 @@ describe('LogRevenueComponent', function() {
   it('after mount, logs revenue when GPT fires a "slot rendered" event', () => {
     const slotId = 'xyz-987'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered = {}
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered = {}
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -268,7 +271,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     // We'll run the googletag command queue manually.
     __disableAutomaticCommandQueueExecution()
@@ -317,7 +320,8 @@ describe('LogRevenueComponent', function() {
   it('defaults to 99 (Google Adsense) DFP Advertiser ID when the advertiser ID does not exist', () => {
     const slotId = 'xyz-987'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered = {}
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered = {}
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -330,7 +334,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     // We'll run the googletag command queue manually.
     __disableAutomaticCommandQueueExecution()
@@ -383,19 +387,22 @@ describe('LogRevenueComponent', function() {
     // Mark an ad slot as loaded
     const slotId = 'my-slot-2468'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered[
-      slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId, adUnitCode, {
-      advertiserId: 132435,
-    })
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock no Prebid bids for the slot
     window.pbjs.getHighestCpmBids.mockReturnValue([])
 
     // Mock an Amazon bid
-    window.tabforacause.ads.amazonBids = {
+    tabGlobal.ads.amazonBids = {
       [slotId]: mockAmazonBidResponse({
         slotID: slotId,
         amznbid: 'a-bid-code',
@@ -438,13 +445,16 @@ describe('LogRevenueComponent', function() {
     // Mark an ad slot as loaded
     const slotId = 'my-slot-2468'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered[
-      slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId, adUnitCode, {
-      advertiserId: 132435,
-    })
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -457,7 +467,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock an Amazon bid
-    window.tabforacause.ads.amazonBids = {
+    tabGlobal.ads.amazonBids = {
       [slotId]: mockAmazonBidResponse({
         slotID: slotId,
         amznbid: 'a-bid-code',
@@ -500,13 +510,16 @@ describe('LogRevenueComponent', function() {
     // Mark an ad slot as loaded
     const slotId = 'my-slot-2468'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered[
-      slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId, adUnitCode, {
-      advertiserId: 132435,
-    })
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -519,7 +532,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock an Amazon bid
-    window.tabforacause.ads.amazonBids = {
+    tabGlobal.ads.amazonBids = {
       [slotId]: mockAmazonBidResponse({
         slotID: slotId,
         amznbid: '', // empty bid
@@ -556,9 +569,10 @@ describe('LogRevenueComponent', function() {
   it('logs a warning, but does not throw an error or log revenue, if slot data is missing', () => {
     // Mark an ad slot as loaded
     const slotId = 'my-slot-2468'
-    window.tabforacause.ads.slotsRendered[slotId] = undefined // Missing slot data
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = undefined // Missing slot data
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock console.warn
     const mockConsoleWarn = jest.fn()
@@ -575,7 +589,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock no Amazon bids
-    window.tabforacause.ads.amazonBids = {}
+    tabGlobal.ads.amazonBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
@@ -601,13 +615,16 @@ describe('LogRevenueComponent', function() {
     // Mark an ad slot as loaded
     const slotId = 'my-slot-2468'
     const adUnitCode = '/some/ad-unit/'
-    window.tabforacause.ads.slotsRendered[
-      slotId
-    ] = mockGoogleTagSlotRenderEndedData(slotId, adUnitCode, {
-      advertiserId: 132435,
-    })
-    window.tabforacause.ads.slotsLoaded[slotId] = true
-    window.tabforacause.ads.slotsViewable[slotId] = true
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
 
     // Mock a Prebid bid value for the slot
     const mockRevenueValue = 2.31
@@ -620,7 +637,7 @@ describe('LogRevenueComponent', function() {
     ])
 
     // Mock an Amazon bid
-    window.tabforacause.ads.amazonBids = {
+    tabGlobal.ads.amazonBids = {
       [slotId]: mockAmazonBidResponse({
         slotID: slotId,
         amznbid: 'a-bid-code',

--- a/web/src/js/utils/__tests__/test-utils.test.js
+++ b/web/src/js/utils/__tests__/test-utils.test.js
@@ -300,3 +300,12 @@ describe('mockIndexExchangeBidResponse', () => {
     ])
   })
 })
+
+describe('deleteTabGlobal', () => {
+  it('deletes window.tabforacause', () => {
+    window.tabforacause = 'foobar'
+    const { deleteTabGlobal } = require('js/utils/test-utils')
+    deleteTabGlobal()
+    expect(window.tabforacause).toBeUndefined()
+  })
+})

--- a/web/src/js/utils/__tests__/utils.test.js
+++ b/web/src/js/utils/__tests__/utils.test.js
@@ -258,3 +258,52 @@ describe('makePromiseCancelable', () => {
       })
   })
 })
+
+describe('getTabGlobal', () => {
+  afterEach(() => {
+    delete window.tabforacause
+  })
+
+  it('returns an object with the expected keys', () => {
+    const { getTabGlobal } = require('js/utils/utils')
+    expect(Object.keys(getTabGlobal()).sort()).toEqual(['ads', 'featureFlags'])
+  })
+
+  it('returns an ads object with the expected keys', () => {
+    const { getTabGlobal } = require('js/utils/utils')
+    expect(Object.keys(getTabGlobal().ads).sort()).toEqual([
+      'amazonBids',
+      'slotsAlreadyLoggedRevenue',
+      'slotsLoaded',
+      'slotsRendered',
+      'slotsViewable',
+    ])
+  })
+
+  it('sets window.tabforacause', () => {
+    delete window.tabforacause
+    expect(window.tabforacause).toBeUndefined()
+    const { getTabGlobal } = require('js/utils/utils')
+    getTabGlobal()
+    expect(window.tabforacause).not.toBeUndefined()
+  })
+
+  it('uses existing window.tabforacause object if one exists', () => {
+    const existingTabGlobal = {
+      ads: {
+        amazonBids: {
+          someThing: 'here',
+        },
+        slotsRendered: {},
+        slotsViewable: {},
+        slotsLoaded: {},
+        slotsAlreadyLoggedRevenue: {},
+      },
+      featureFlags: {},
+    }
+    window.tabforacause = existingTabGlobal
+    const { getTabGlobal } = require('js/utils/utils')
+    const tabGlobal = getTabGlobal()
+    expect(tabGlobal).toBe(existingTabGlobal)
+  })
+})

--- a/web/src/js/utils/test-utils.js
+++ b/web/src/js/utils/test-utils.js
@@ -217,6 +217,14 @@ export const mockIndexExchangeBidResponse = (properties = {}) => {
 }
 
 /**
+ * Delete `window.tabforacause`.
+ * @return {undefined}
+ */
+export const deleteTabGlobal = () => {
+  delete window.tabforacause
+}
+
+/**
  * Return the default starting value of `window.tabforacause`
  * @return {Object}
  */

--- a/web/src/js/utils/test-utils.js
+++ b/web/src/js/utils/test-utils.js
@@ -225,47 +225,6 @@ export const deleteTabGlobal = () => {
 }
 
 /**
- * Return the default starting value of `window.tabforacause`
- * @return {Object}
- */
-export const getDefaultTabGlobal = (properties = {}) => {
-  return {
-    ads: {
-      // Bid objects returned from apstag
-      // Key: slot ID
-      // Value: bid object
-      amazonBids: {},
-
-      // Objects from googletag's "slotRenderEnded" event. This event fires
-      // before the "slotOnload" event; i.e., before the actual creative loads.
-      // Key: slot ID
-      // Value: https://developers.google.com/doubleclick-gpt/reference#googletageventsslotrenderendedevent
-      slotsRendered: {},
-
-      // Marking which slots have fired googletag's "impressionViewable" event.
-      // See:
-      // https://developers.google.com/doubleclick-gpt/reference#googletageventsimpressionviewableevent
-      // Key: slot ID
-      // Value: `true`
-      slotsViewable: {},
-
-      // Marking which slots have fired googletag's "slotOnload" event;
-      // i.e., which slots have loaded creative. See:
-      // https://developers.google.com/doubleclick-gpt/reference#googletag.events.SlotRenderEndedEvent
-      // Key: slot ID
-      // Value: `true`
-      slotsLoaded: {},
-
-      // Marking which slots have had their revenue logged.
-      // Key: slot ID
-      // Value: `true`
-      slotsAlreadyLoggedRevenue: {},
-    },
-    featureFlags: {},
-  }
-}
-
-/**
  * Return the default starting value of `window.searchforacause`
  * @return {Object}
  */

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -247,3 +247,50 @@ export const makePromiseCancelable = promise => {
     },
   }
 }
+
+/**
+ * Get the "window.tabforacause" global variable.
+ * @return {Object}
+ */
+export const getTabGlobal = () => {
+  const tabforacause = window.tabforacause || {
+    ads: {
+      // Bid objects returned from apstag
+      // Key: slot ID
+      // Value: bid object
+      amazonBids: {},
+
+      // Objects from googletag's "slotRenderEnded" event. This event fires
+      // before the "slotOnload" event; i.e., before the actual creative loads.
+      // Key: slot ID
+      // Value: https://developers.google.com/doubleclick-gpt/reference#googletageventsslotrenderendedevent
+      slotsRendered: {},
+
+      // Marking which slots have fired googletag's "impressionViewable" event.
+      // See:
+      // https://developers.google.com/doubleclick-gpt/reference#googletageventsimpressionviewableevent
+      // Key: slot ID
+      // Value: `true`
+      slotsViewable: {},
+
+      // Marking which slots have fired googletag's "slotOnload" event;
+      // i.e., which slots have loaded creative. See:
+      // https://developers.google.com/doubleclick-gpt/reference#googletag.events.SlotRenderEndedEvent
+      // Key: slot ID
+      // Value: `true`
+      slotsLoaded: {},
+
+      // Marking which slots have had their revenue logged.
+      // Key: slot ID
+      // Value: `true`
+      slotsAlreadyLoggedRevenue: {},
+    },
+    featureFlags: {},
+  }
+  // We're not running in global scope, so make sure to
+  // assign to the window.
+  if (!window.tabforacause) {
+    window.tabforacause = tabforacause
+  }
+  return tabforacause
+}

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -250,6 +250,8 @@ export const makePromiseCancelable = promise => {
 
 /**
  * Get the "window.tabforacause" global variable.
+ * Used for handling some communication between disparate parts
+ * of our app (e.g. ads events happening before app code loads).
  * @return {Object}
  */
 export const getTabGlobal = () => {


### PR DESCRIPTION
This ensures it's always defined when used. It addresses "Cannot read property 'ads' of undefined" bugs.