### PR TITLE
Log Index Exchange revenue if it is the winning bid

### DIFF
--- a/web/src/js/ads/__tests__/ads.test.js
+++ b/web/src/js/ads/__tests__/ads.test.js
@@ -348,6 +348,52 @@ describe('ads script', () => {
     expect(storeAmazonBids).not.toHaveBeenCalled()
   })
 
+  it('calls to mark IX bids as included in the bid for analytics (if IX is included in the auction)', async () => {
+    expect.assertions(1)
+    const {
+      markIndexExchangeBidsAsIncluded,
+    } = require('js/ads/indexExchange/indexExchangeBidder')
+
+    // Mock that IX responds quickly
+    const indexExchangeBidder = require('js/ads/indexExchange/indexExchangeBidder')
+      .default
+    indexExchangeBidder.mockImplementationOnce(() => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve()
+        }, 80)
+      })
+    })
+
+    require('js/ads/ads')
+    jest.advanceTimersByTime(100)
+    await new Promise(resolve => setImmediate(resolve))
+    expect(markIndexExchangeBidsAsIncluded).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call to mark IX bids as included in the bid for analytics (if IX is not included in the auction)', async () => {
+    expect.assertions(1)
+    const {
+      markIndexExchangeBidsAsIncluded,
+    } = require('js/ads/indexExchange/indexExchangeBidder')
+
+    // Mock that IX responds quickly
+    const indexExchangeBidder = require('js/ads/indexExchange/indexExchangeBidder')
+      .default
+    indexExchangeBidder.mockImplementationOnce(() => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve()
+        }, 15e3)
+      })
+    })
+
+    require('js/ads/ads')
+    jest.advanceTimersByTime(3e3)
+    await new Promise(resolve => setImmediate(resolve))
+    expect(markIndexExchangeBidsAsIncluded).not.toHaveBeenCalled()
+  })
+
   it('calls handleAdsLoaded', async () => {
     expect.assertions(1)
     const handleAdsLoaded = require('js/ads/handleAdsLoaded').default

--- a/web/src/js/ads/ads.js
+++ b/web/src/js/ads/ads.js
@@ -1,7 +1,9 @@
 import 'js/ads/prebid/prebid' // Prebid library code
 import adsEnabled from 'js/ads/adsEnabledStatus'
 import amazonBidder, { storeAmazonBids } from 'js/ads/amazon/amazonBidder'
-import indexExchangeBidder from 'js/ads/indexExchange/indexExchangeBidder'
+import indexExchangeBidder, {
+  markIndexExchangeBidsAsIncluded,
+} from 'js/ads/indexExchange/indexExchangeBidder'
 import getAmazonTag from 'js/ads/amazon/getAmazonTag'
 import getGoogleTag from 'js/ads/google/getGoogleTag'
 import setUpGoogleAds from 'js/ads/google/setUpGoogleAds'
@@ -47,6 +49,9 @@ function sendAdserverRequest() {
   // For revenue analytics.
   if (requestManager.bidders[BIDDER_AMAZON]) {
     storeAmazonBids()
+  }
+  if (requestManager.bidders[BIDDER_IX]) {
+    markIndexExchangeBidsAsIncluded()
   }
 
   // Set targeting and make a request to DFP.

--- a/web/src/js/ads/google/__mocks__/getGoogleTag.js
+++ b/web/src/js/ads/google/__mocks__/getGoogleTag.js
@@ -1,5 +1,14 @@
 /* eslint-env jest */
 
+import {
+  VERTICAL_AD_UNIT_ID,
+  VERTICAL_AD_SLOT_DOM_ID,
+  SECOND_VERTICAL_AD_UNIT_ID,
+  SECOND_VERTICAL_AD_SLOT_DOM_ID,
+  HORIZONTAL_AD_UNIT_ID,
+  HORIZONTAL_AD_SLOT_DOM_ID,
+} from 'js/ads/adSettings'
+
 // By default, we run functions in the queue immediately.
 // Call this to disable that.
 export const __disableAutomaticCommandQueueExecution = () => {
@@ -29,18 +38,18 @@ const mockSlots = [
   // Mock ad unit IDs from the adSettings mock.
   // Bottom leaderboard
   MockSlot({
-    adUnitPath: '/99887766/HBTL',
-    slotElementId: 'div-gpt-ad-24682468-0',
+    adUnitPath: HORIZONTAL_AD_UNIT_ID,
+    slotElementId: HORIZONTAL_AD_SLOT_DOM_ID,
   }),
   // First (bottom) rectangle ad
   MockSlot({
-    adUnitPath: '/11223344/HBTR',
-    slotElementId: 'div-gpt-ad-1357913579-0',
+    adUnitPath: VERTICAL_AD_UNIT_ID,
+    slotElementId: VERTICAL_AD_SLOT_DOM_ID,
   }),
   // Second (top) rectangle ad
   MockSlot({
-    adUnitPath: '/44556677/HBTR2',
-    slotElementId: 'div-gpt-ad-11235813-0',
+    adUnitPath: SECOND_VERTICAL_AD_UNIT_ID,
+    slotElementId: SECOND_VERTICAL_AD_SLOT_DOM_ID,
   }),
 ]
 

--- a/web/src/js/ads/google/__mocks__/getGoogleTag.js
+++ b/web/src/js/ads/google/__mocks__/getGoogleTag.js
@@ -19,16 +19,29 @@ export const __setPubadsRefreshMock = mockFunction => {
   mockPubadsRefresh = mockFunction
 }
 
-const MockSlot = adUnitPath => ({
+const MockSlot = ({ adUnitPath, slotElementId }) => ({
   getAdUnitPath: () => adUnitPath,
+  getSlotElementId: () => slotElementId,
   setTargeting: jest.fn(),
 })
 
 const mockSlots = [
   // Mock ad unit IDs from the adSettings mock.
-  MockSlot('/99887766/HBTL'), // bottom leaderboard
-  MockSlot('/11223344/HBTR'), // first (bottom) rectangle ad
-  MockSlot('/44556677/HBTR2'), // second (top) rectangle ad
+  // Bottom leaderboard
+  MockSlot({
+    adUnitPath: '/99887766/HBTL',
+    slotElementId: 'div-gpt-ad-24682468-0',
+  }),
+  // First (bottom) rectangle ad
+  MockSlot({
+    adUnitPath: '/11223344/HBTR',
+    slotElementId: 'div-gpt-ad-1357913579-0',
+  }),
+  // Second (top) rectangle ad
+  MockSlot({
+    adUnitPath: '/44556677/HBTR2',
+    slotElementId: 'div-gpt-ad-11235813-0',
+  }),
 ]
 
 const mockGetSlots = jest.fn(() => {

--- a/web/src/js/ads/indexExchange/__mocks__/indexExchangeBidder.js
+++ b/web/src/js/ads/indexExchange/__mocks__/indexExchangeBidder.js
@@ -1,3 +1,4 @@
 /* eslint-env jest */
 
+export const markIndexExchangeBidsAsIncluded = jest.fn()
 export default jest.fn(() => Promise.resolve())

--- a/web/src/js/ads/indexExchange/__tests__/indexExchangeBidder.test.js
+++ b/web/src/js/ads/indexExchange/__tests__/indexExchangeBidder.test.js
@@ -438,3 +438,18 @@ describe('indexExchangeBidder', () => {
     ])
   })
 })
+
+describe('markIndexExchangeBidsAsIncluded', () => {
+  it('sets the IX bids "includedInAdServerRequest" property to true', () => {
+    const { getTabGlobal } = require('js/utils/utils')
+    const tabGlobal = getTabGlobal()
+    expect(tabGlobal.ads.indexExchangeBids.includedInAdServerRequest).toBe(
+      false
+    )
+    const {
+      markIndexExchangeBidsAsIncluded,
+    } = require('js/ads/indexExchange/indexExchangeBidder')
+    markIndexExchangeBidsAsIncluded()
+    expect(tabGlobal.ads.indexExchangeBids.includedInAdServerRequest).toBe(true)
+  })
+})

--- a/web/src/js/ads/indexExchange/indexExchangeBidder.js
+++ b/web/src/js/ads/indexExchange/indexExchangeBidder.js
@@ -10,9 +10,6 @@ import getGoogleTag from 'js/ads/google/getGoogleTag'
 import logger from 'js/utils/logger'
 import { getTabGlobal } from 'js/utils/utils'
 
-// Save returned bids.
-var indexExchangeBids
-
 /**
  * If there are IX bids, store them in the tabforacause
  * global object for use with analytics. Only do this if the
@@ -84,15 +81,12 @@ const fetchIndexExchangeDemand = () => {
       // Fetch bid responses from Index Exchange.
       // Note: the current request is to a casalemedia URL.
       ixTag.retrieveDemand(IXSlots, demand => {
-        // console.log('Index Exchange: demand', demand)
-        // Store the demand so we can log it in analytics if needed.
-        indexExchangeBids = demand
-
         // Set adserver targeting for any returned demand.
         // IX demand should set the IOM and ix_id parameters.
         try {
           if (demand && demand.slot) {
             const googletag = getGoogleTag()
+            const tabGlobal = getTabGlobal()
 
             // Loop through defined GAM slots to set any targeting.
             googletag.cmd.push(() => {
@@ -127,6 +121,15 @@ const fetchIndexExchangeDemand = () => {
                       }
                     )
                   })
+
+                  // Store the bids for analytics.
+                  try {
+                    tabGlobal.ads.indexExchangeBids[
+                      googleSlot.getSlotElementId()
+                    ] = IXBidResponseArray
+                  } catch (e) {
+                    logger.error(e)
+                  }
                 })
             })
           }

--- a/web/src/js/ads/indexExchange/indexExchangeBidder.js
+++ b/web/src/js/ads/indexExchange/indexExchangeBidder.js
@@ -11,20 +11,14 @@ import logger from 'js/utils/logger'
 import { getTabGlobal } from 'js/utils/utils'
 
 /**
- * If there are IX bids, store them in the tabforacause
- * global object for use with analytics. Only do this if the
- * bids return early enough to be included in the ad server
- request; otherwise, the bids are not meaningful.
+ * Mark that the Index Exchange bids were returned in time
+ * to be included in the ad server request.
  * @return {undefined}
  */
-export const storeIndexExchangeBids = () => {
-  // Bid object structure:
-  // {
-  //
-  // }
+export const markIndexExchangeBidsAsIncluded = () => {
   try {
     const tabGlobal = getTabGlobal()
-    console.log(indexExchangeBids, tabGlobal)
+    tabGlobal.ads.indexExchangeBids.includedInAdServerRequest = true
   } catch (e) {
     logger.error(e)
   }

--- a/web/src/js/ads/indexExchange/indexExchangeBidder.js
+++ b/web/src/js/ads/indexExchange/indexExchangeBidder.js
@@ -8,6 +8,30 @@ import {
 } from 'js/ads/adSettings'
 import getGoogleTag from 'js/ads/google/getGoogleTag'
 import logger from 'js/utils/logger'
+import { getTabGlobal } from 'js/utils/utils'
+
+// Save returned bids.
+var indexExchangeBids
+
+/**
+ * If there are IX bids, store them in the tabforacause
+ * global object for use with analytics. Only do this if the
+ * bids return early enough to be included in the ad server
+ request; otherwise, the bids are not meaningful.
+ * @return {undefined}
+ */
+export const storeIndexExchangeBids = () => {
+  // Bid object structure:
+  // {
+  //
+  // }
+  try {
+    const tabGlobal = getTabGlobal()
+    console.log(indexExchangeBids, tabGlobal)
+  } catch (e) {
+    logger.error(e)
+  }
+}
 
 /**
  * Return a promise that resolves when the Index Exchange bid
@@ -61,6 +85,8 @@ const fetchIndexExchangeDemand = () => {
       // Note: the current request is to a casalemedia URL.
       ixTag.retrieveDemand(IXSlots, demand => {
         // console.log('Index Exchange: demand', demand)
+        // Store the demand so we can log it in analytics if needed.
+        indexExchangeBids = demand
 
         // Set adserver targeting for any returned demand.
         // IX demand should set the IOM and ix_id parameters.

--- a/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
@@ -90,6 +90,9 @@ describe('LogRevenueComponent', function() {
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
 
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
+
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
     const mockUserId = 'abcdefghijklmno'
@@ -146,6 +149,9 @@ describe('LogRevenueComponent', function() {
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
 
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
+
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
     const mockUserId = 'abcdefghijklmno'
@@ -179,6 +185,9 @@ describe('LogRevenueComponent', function() {
 
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
+
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
@@ -226,6 +235,9 @@ describe('LogRevenueComponent', function() {
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
 
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
+
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default
     const mockUserId = 'abcdefghijklmno'
@@ -272,6 +284,9 @@ describe('LogRevenueComponent', function() {
 
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
+
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
 
     // We'll run the googletag command queue manually.
     __disableAutomaticCommandQueueExecution()
@@ -335,6 +350,9 @@ describe('LogRevenueComponent', function() {
 
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
+
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
 
     // We'll run the googletag command queue manually.
     __disableAutomaticCommandQueueExecution()
@@ -590,6 +608,9 @@ describe('LogRevenueComponent', function() {
 
     // Mock no Amazon bids
     tabGlobal.ads.amazonBids = {}
+
+    // Mock no Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {}
 
     const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
       .default

--- a/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
@@ -207,7 +207,7 @@ describe('LogRevenueComponent', function() {
     expect(LogUserRevenueMutation).not.toHaveBeenCalled()
   })
 
-  it('rounds excessively long decimals in revenue value', () => {
+  it('rounds excessively long decimals in Prebid revenue value', () => {
     // Mark an ad slot as loaded
     const slotId = 'abc-123'
     const adUnitCode = '/some/ad-unit/'
@@ -445,7 +445,7 @@ describe('LogRevenueComponent', function() {
     expect(LogUserRevenueMutation).toHaveBeenCalledWith(
       mockRelayEnvironment,
       mockUserId,
-      null,
+      0,
       '132435',
       null,
       {
@@ -577,6 +577,675 @@ describe('LogRevenueComponent', function() {
       0.00231,
       '132435',
       '728x90',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('logs Index Exchange revenue when there are no other bids', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids for the slot
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 730,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0073,
+      '132435',
+      '728x90',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('selects the highest-value Index Exchange revenue, if there are multiple IX bids', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids for the slot
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 730,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 120,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 990, // winning bid
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0099,
+      '132435',
+      '728x90',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('does not log Index Exchange revenue when the IX bids did not return in time for the auction', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids for the slot
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: false, // is not part of the auction
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 730,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).not.toHaveBeenCalled()
+  })
+
+  it('rounds excessively long decimals in the Index Exchange revenue value', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids for the slot
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 120.1234567890123456789,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.00120123456789,
+      '132435',
+      '728x90',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('passes a null ad size if the Index Exchange size value does not exist', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids for the slot
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 310,
+          adm: '',
+          size: null, // ad size is missing
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0031,
+      '132435',
+      null,
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('passes a null ad size if the Index Exchange size value is an array with more than two values', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids for the slot
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 310,
+          adm: '',
+          size: [728, 90, 2008], // ad size is malformed
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0031,
+      '132435',
+      null,
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('logs the Index Exchange revenue and ad size when it is higher than the Prebid revenue', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    window.pbjs.getHighestCpmBids.mockReturnValue([
+      {
+        cpm: 1.2,
+        size: '300x250',
+        // ... other bid info exists here
+      },
+    ])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 730,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0073,
+      '132435',
+      '728x90',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('logs the Prebid revenue and ad size when it is higher than the Index Exchange revenue', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    window.pbjs.getHighestCpmBids.mockReturnValue([
+      {
+        cpm: 12.8,
+        size: '300x250',
+        // ... other bid info exists here
+      },
+    ])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 730,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0128,
+      '132435',
+      '300x250',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('logs the Prebid revenue and ad size when the Index Exchange bid is missing revenue data', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    window.pbjs.getHighestCpmBids.mockReturnValue([
+      {
+        cpm: 12.8,
+        size: '300x250',
+        // ... other bid info exists here
+      },
+    ])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: null, // this is unexpected
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0128,
+      '132435',
+      '300x250',
+      null,
+      null,
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('logs the Prebid revenue when the Index Exchange slot is missing any bid data', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    window.pbjs.getHighestCpmBids.mockReturnValue([
+      {
+        cpm: 12.8,
+        size: '300x250',
+        // ... other bid info exists here
+      },
+    ])
+
+    // Mock no Amazon bids
+    tabGlobal.ads.amazonBids = {}
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      // Missing slot data
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0.0128,
+      '132435',
+      '300x250',
       null,
       null,
       tabId,

--- a/web/src/js/utils/__tests__/utils.test.js
+++ b/web/src/js/utils/__tests__/utils.test.js
@@ -273,6 +273,7 @@ describe('getTabGlobal', () => {
     const { getTabGlobal } = require('js/utils/utils')
     expect(Object.keys(getTabGlobal().ads).sort()).toEqual([
       'amazonBids',
+      'indexExchangeBids',
       'slotsAlreadyLoggedRevenue',
       'slotsLoaded',
       'slotsRendered',

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -262,6 +262,15 @@ export const getTabGlobal = () => {
       // Value: bid object
       amazonBids: {},
 
+      // Bids returned from Index Exchange.
+      // Key: slot element ID
+      // Value: bid object
+      indexExchangeBids: {
+        // Whether the bids were returned in time to be part
+        // of the request to our ad server.
+        includedInAdServerRequest: false,
+      },
+
       // Objects from googletag's "slotRenderEnded" event. This event fires
       // before the "slotOnload" event; i.e., before the actual creative loads.
       // Key: slot ID


### PR DESCRIPTION
This PR improves revenue logging to include the highest Index Exchange bids for a slot. If the winning Index Exchange bid is higher than the winning Prebid bid, we log that revenue value.