### PR TITLE
Fix a failure to log revenue when Amazon has bids but Prebid/IX don't

### DIFF
--- a/web/src/js/components/Dashboard/LogRevenueComponent.js
+++ b/web/src/js/components/Dashboard/LogRevenueComponent.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { get } from 'lodash/object'
+import { isNil } from 'lodash/lang'
 import LogUserRevenueMutation from 'js/mutations/LogUserRevenueMutation'
 import PropTypes from 'prop-types'
 import getGoogleTag from 'js/ads/google/getGoogleTag'
@@ -212,7 +213,7 @@ class LogRevenueComponent extends React.Component {
         amazonEncodedBid,
         // Only send aggregationOperation value if we have more than one
         // revenue value
-        revenue && amazonEncodedBid ? 'MAX' : null,
+        !isNil(revenue) && !isNil(amazonEncodedBid) ? 'MAX' : null,
         this.props.tabId,
         adUnitCode
       )

--- a/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/LogRevenueComponent.test.js
@@ -453,7 +453,7 @@ describe('LogRevenueComponent', function() {
         encodedValue: 'a-bid-code',
         adSize: '728x90',
       },
-      null,
+      'MAX',
       tabId,
       adUnitCode
     )
@@ -1315,6 +1315,81 @@ describe('LogRevenueComponent', function() {
       mockRelayEnvironment,
       mockUserId,
       0.00231,
+      '132435',
+      '728x90',
+      {
+        encodingType: 'AMAZON_CPM',
+        encodedValue: 'a-bid-code',
+        adSize: '728x90',
+      },
+      'MAX',
+      tabId,
+      adUnitCode
+    )
+  })
+
+  it('logs Amazon revenue when there is an IX bid valued at $0', () => {
+    // Mark an ad slot as loaded
+    const slotId = 'my-slot-2468'
+    const adUnitCode = '/some/ad-unit/'
+    const tabGlobal = getTabGlobal()
+    tabGlobal.ads.slotsRendered[slotId] = mockGoogleTagSlotRenderEndedData(
+      slotId,
+      adUnitCode,
+      {
+        advertiserId: 132435,
+      }
+    )
+    tabGlobal.ads.slotsLoaded[slotId] = true
+    tabGlobal.ads.slotsViewable[slotId] = true
+
+    // Mock no Prebid bids.
+    window.pbjs.getHighestCpmBids.mockReturnValue([])
+
+    // Mock an Amazon bid
+    tabGlobal.ads.amazonBids = {
+      [slotId]: mockAmazonBidResponse({
+        slotID: slotId,
+        amznbid: 'a-bid-code',
+        size: '728x90',
+      }),
+    }
+
+    // Mock some Index Exchange bids
+    tabGlobal.ads.indexExchangeBids = {
+      includedInAdServerRequest: true,
+      [slotId]: [
+        {
+          targeting: {
+            IOM: ['728x90_5000'],
+            ix_id: ['_mBnLnF5V'],
+          },
+          price: 0,
+          adm: '',
+          size: [728, 90],
+          partnerId: 'IndexExchangeHtb',
+        },
+      ],
+    }
+
+    const LogRevenueComponent = require('js/components/Dashboard/LogRevenueComponent')
+      .default
+    const mockUserId = 'abcdefghijklmno'
+    const tabId = '712dca1a-3705-480f-95ff-314be86a2936'
+    const mockRelayEnvironment = {}
+    shallow(
+      <LogRevenueComponent
+        user={{
+          id: mockUserId,
+        }}
+        tabId={tabId}
+        relay={{ environment: mockRelayEnvironment }}
+      />
+    )
+    expect(LogUserRevenueMutation).toHaveBeenCalledWith(
+      mockRelayEnvironment,
+      mockUserId,
+      0,
       '132435',
       '728x90',
       {


### PR DESCRIPTION
When Prebid/IX bids have a value of zero, we should still set the the "aggregationOperation" to "MAX" in the revenue log mutation