### PR TITLE
Clean up "get current user" functions

### DIFF
--- a/web/__mocks__/firebase/app.js
+++ b/web/__mocks__/firebase/app.js
@@ -8,6 +8,8 @@ const firebaseApp = jest.genMockFromModule('firebase')
 // By default, return no user.
 var firebaseUser = null
 
+var onAuthStateChangedUnsubscribeFunction = jest.fn()
+
 // By default, do not immediately return a user from
 // onAuthStateChanged.
 var immediatelyReturnAuthUser = false
@@ -27,8 +29,11 @@ const authMock = {
     // was set with __setFirebaseUser. This makes
     // async testing a little easier.
     if (immediatelyReturnAuthUser) {
-      callback(firebaseUser)
+      setTimeout(() => {
+        callback(firebaseUser)
+      }, 1)
     }
+    return onAuthStateChangedUnsubscribeFunction
   }),
   signInAnonymously: jest.fn(() => {
     // Should resolve into a non-null Firebase user credential.
@@ -73,6 +78,10 @@ firebaseApp.auth = FirebaseAuthMock
 firebaseApp.__setFirebaseUser = user => {
   immediatelyReturnAuthUser = true
   firebaseUser = user
+}
+
+firebaseApp.__setOnAuthStateChangeUnsubscribeFunction = unsubscribeFunc => {
+  onAuthStateChangedUnsubscribeFunction = unsubscribeFunc
 }
 
 /**

--- a/web/src/js/authentication/__mocks__/user.js
+++ b/web/src/js/authentication/__mocks__/user.js
@@ -12,17 +12,15 @@ authUserMock.formatUser = authUserActual.formatUser
 // Store callbacks for onAuthStateChanged so we can manually
 // call them when changing the user state.
 var onAuthStateChangedCallbacks = []
-authUserMock.getCurrentUserListener = jest.fn(() => ({
-  onAuthStateChanged: callback => {
-    onAuthStateChangedCallbacks.push(callback)
+authUserMock.onAuthStateChanged = jest.fn(callback => {
+  onAuthStateChangedCallbacks.push(callback)
 
-    // Return a function to unregister the callback as
-    // Firebase auth does.
-    return () => {
-      unregisterAuthStateListener(callback)
-    }
-  },
-}))
+  // Return a function to unregister the callback as
+  // Firebase auth does.
+  return () => {
+    unregisterAuthStateListener(callback)
+  }
+})
 
 authUserMock.signInAnonymously = jest.fn(() => {
   const mockAnonUserObj = {
@@ -53,14 +51,13 @@ const unregisterAuthStateListener = listenerFunc => {
 
 /**
  * Call all registered callbacks for the getCurrentUserListener
- * with a Firebase user object.
- * @param {Object} firebaseUser - An object resembling a Firebase
- *   user object
+ * with our auth user object.
+ * @param {Object} authUser - Our auth user object
  * @return {function} A function to unsubscribe the listener
  */
-authUserMock.__triggerAuthStateChange = firebaseUser => {
+authUserMock.__triggerAuthStateChange = authUser => {
   onAuthStateChangedCallbacks.forEach(cb => {
-    cb(firebaseUser)
+    cb(authUser)
   })
 }
 

--- a/web/src/js/authentication/__tests__/user.test.js
+++ b/web/src/js/authentication/__tests__/user.test.js
@@ -124,6 +124,61 @@ describe('getCurrentUser tests', () => {
       emailVerified: true,
     })
   })
+
+  it('unsubscribes the Firebase onAuthStateChanged listener after using it once', done => {
+    expect.assertions(1)
+
+    // formatUser gets the username from localStorage.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
+    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'RGates')
+
+    const {
+      __setOnAuthStateChangeUnsubscribeFunction,
+      __setFirebaseUser,
+    } = require('firebase/app')
+
+    const mockAuthUnsubscribeFunc = jest.fn(() => {
+      expect(true).toBe(true)
+      done()
+    })
+    __setOnAuthStateChangeUnsubscribeFunction(mockAuthUnsubscribeFunc)
+    __setFirebaseUser({
+      uid: 'xyz987',
+      email: 'foo@example.com',
+      isAnonymous: false,
+      emailVerified: true,
+      getIdToken: jest.fn(() => 'fake-token-123'),
+    })
+
+    const getCurrentUser = require('js/authentication/user').getCurrentUser
+    getCurrentUser()
+  })
+
+  it('does not throw if the Firebase onAuthStateChanged unsubscribe function is not a function for some reason', async () => {
+    expect.assertions(0)
+
+    // formatUser gets the username from localStorage.
+    const localStorageMgr = require('js/utils/localstorage-mgr').default
+    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'RGates')
+
+    const {
+      __setOnAuthStateChangeUnsubscribeFunction,
+      __setFirebaseUser,
+    } = require('firebase/app')
+
+    const mockAuthUnsubscribeFunc = undefined
+    __setOnAuthStateChangeUnsubscribeFunction(mockAuthUnsubscribeFunc)
+    __setFirebaseUser({
+      uid: 'xyz987',
+      email: 'foo@example.com',
+      isAnonymous: false,
+      emailVerified: true,
+      getIdToken: jest.fn(() => 'fake-token-123'),
+    })
+
+    const getCurrentUser = require('js/authentication/user').getCurrentUser
+    await getCurrentUser()
+  })
 })
 
 describe('getCurrentUserListener tests', () => {

--- a/web/src/js/authentication/__tests__/user.test.js
+++ b/web/src/js/authentication/__tests__/user.test.js
@@ -21,23 +21,27 @@ afterEach(() => {
   jest.resetModules()
 })
 
-describe('authentication user module tests', () => {
-  test('getUsername fetches the username from localStorage', () => {
+describe('getUsername tests', () => {
+  it('fetches the username from localStorage', () => {
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'BobMIII')
     const getUsername = require('js/authentication/user').getUsername
     expect(getUsername()).toBe('BobMIII')
   })
+})
 
-  test('setUsernameInLocalStorage works as expected', () => {
+describe('setUsername tests', () => {
+  it('works as expected', () => {
     const setUsernameInLocalStorage = require('js/authentication/user')
       .setUsernameInLocalStorage
     setUsernameInLocalStorage('MichaelC')
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     expect(localStorageMgr.getItem(STORAGE_KEY_USERNAME)).toBe('MichaelC')
   })
+})
 
-  test('formatUser works as expected', () => {
+describe('formatUser tests', () => {
+  it('works as expected', () => {
     // formatUser gets the username from localStorage.
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'PaulM')
@@ -58,8 +62,10 @@ describe('authentication user module tests', () => {
       emailVerified: true,
     })
   })
+})
 
-  test('getCurrentUser returns a user when one exists', async () => {
+describe('getCurrentUser tests', () => {
+  it('returns a user when one exists', async () => {
     expect.assertions(1)
 
     // formatUser gets the username from localStorage.
@@ -86,7 +92,7 @@ describe('authentication user module tests', () => {
     })
   })
 
-  test('getCurrentUser returns null when a user does not exist', async () => {
+  it('returns null when a user does not exist', async () => {
     expect.assertions(1)
 
     const __setFirebaseUser = require('firebase/app').__setFirebaseUser
@@ -97,7 +103,7 @@ describe('authentication user module tests', () => {
     expect(currentUser).toBeNull()
   })
 
-  test('getCurrentUser returns a mock user when using mock authentication in development', async () => {
+  it('returns a mock user when using mock authentication in development', async () => {
     expect.assertions(1)
 
     // formatUser gets the username from localStorage.
@@ -118,8 +124,10 @@ describe('authentication user module tests', () => {
       emailVerified: true,
     })
   })
+})
 
-  test('getCurrentUserListener calls listeners with the Firebase user object when the auth state changes', done => {
+describe('getCurrentUserListener tests', () => {
+  it('calls listeners with the Firebase user object when the auth state changes', done => {
     const getCurrentUserListener = require('js/authentication/user')
       .getCurrentUserListener
     getCurrentUserListener().onAuthStateChanged(currentUser => {
@@ -144,7 +152,7 @@ describe('authentication user module tests', () => {
     })
   })
 
-  test('getCurrentUserListener returns a mock user when using mock authentication in development', done => {
+  it('returns a mock user when using mock authentication in development', done => {
     // Set development env vars.
     process.env.REACT_APP_MOCK_DEV_AUTHENTICATION = 'true'
     process.env.NODE_ENV = 'development'
@@ -162,8 +170,10 @@ describe('authentication user module tests', () => {
       done()
     })
   })
+})
 
-  test('getUserToken returns a token when a user exists', async () => {
+describe('getUserToken tests', () => {
+  it('returns a token when a user exists', async () => {
     expect.assertions(1)
 
     const __setFirebaseUser = require('firebase/app').__setFirebaseUser
@@ -180,7 +190,7 @@ describe('authentication user module tests', () => {
     expect(token).toEqual('fake-token-123')
   })
 
-  test('getUserToken returns null when there is no user', async () => {
+  it('returns null when there is no user', async () => {
     expect.assertions(1)
 
     const __setFirebaseUser = require('firebase/app').__setFirebaseUser
@@ -190,16 +200,20 @@ describe('authentication user module tests', () => {
     const token = await getUserToken()
     expect(token).toBeNull()
   })
+})
 
-  test("logout calls Firebase's sign out method", async () => {
+describe('logout tests', () => {
+  it("calls Firebase's sign out method", async () => {
     expect.assertions(1)
     const firebase = require('firebase/app')
     const logout = require('js/authentication/user').logout
     await logout()
     expect(firebase.auth().signOut).toHaveBeenCalledTimes(1)
   })
+})
 
-  test('getUserToken forces a refetch when called with forceRefetch=true', async () => {
+describe('getUserToken tests', () => {
+  it('forces a refetch when called with forceRefetch=true', async () => {
     expect.assertions(1)
 
     const __setFirebaseUser = require('firebase/app').__setFirebaseUser
@@ -217,7 +231,7 @@ describe('authentication user module tests', () => {
     expect(mockFirebaseGetIdToken).toHaveBeenCalledWith(true)
   })
 
-  test('getUserToken does not force a refetch by default', async () => {
+  it('does not force a refetch by default', async () => {
     expect.assertions(1)
 
     const __setFirebaseUser = require('firebase/app').__setFirebaseUser
@@ -235,7 +249,7 @@ describe('authentication user module tests', () => {
     expect(mockFirebaseGetIdToken).toHaveBeenCalledWith(undefined)
   })
 
-  test('removes some localStorage items on logout', async () => {
+  it('removes some localStorage items on logout', async () => {
     expect.assertions(14)
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     const logout = require('js/authentication/user').logout
@@ -279,8 +293,10 @@ describe('authentication user module tests', () => {
     )
     expect(localStorageMgr.removeItem).toHaveBeenCalledTimes(13)
   })
+})
 
-  test('sendVerificationEmail works as expected', async () => {
+describe('sendVerificationEmail tests', () => {
+  it('works as expected', async () => {
     expect.assertions(3)
     const mockSendEmailVerification = jest.fn(() => Promise.resolve())
 
@@ -306,7 +322,7 @@ describe('authentication user module tests', () => {
     expect(response).toBe(true)
   })
 
-  test('sendVerificationEmail fails if no user exists', async () => {
+  it('fails if no user exists', async () => {
     expect.assertions(2)
     const mockSendEmailVerification = jest.fn(() => Promise.resolve())
 
@@ -323,7 +339,7 @@ describe('authentication user module tests', () => {
     expect(response).toBe(false)
   })
 
-  test('sendVerificationEmail fails gracefully if Firebase throws an error when sending an email', async () => {
+  it('fails gracefully if Firebase throws an error when sending an email', async () => {
     expect.assertions(1)
 
     // Mock an error
@@ -350,8 +366,10 @@ describe('authentication user module tests', () => {
     const response = await sendVerificationEmail()
     expect(response).toBe(false)
   })
+})
 
-  test('signInAnonymously works as expected', async () => {
+describe('signInAnonymously tests', () => {
+  it('works as expected', async () => {
     expect.assertions(1)
 
     // formatUser gets the username from localStorage.
@@ -377,8 +395,10 @@ describe('authentication user module tests', () => {
       username: 'SomeUsername',
     })
   })
+})
 
-  test('reloadUser works as expected when the user exists', async () => {
+describe('reloadUser tests', () => {
+  it('works as expected when the user exists', async () => {
     expect.assertions(1)
 
     // formatUser gets the username from localStorage.
@@ -401,7 +421,7 @@ describe('authentication user module tests', () => {
     expect(mockReload).toHaveBeenCalledTimes(1)
   })
 
-  test('reloadUser does not error when the user does not exist', async () => {
+  it('does not error when the user does not exist', async () => {
     expect.assertions(1)
 
     // formatUser gets the username from localStorage.

--- a/web/src/js/authentication/__tests__/user.test.js
+++ b/web/src/js/authentication/__tests__/user.test.js
@@ -43,30 +43,6 @@ describe('setUsername tests', () => {
   })
 })
 
-describe('formatUser tests', () => {
-  it('works as expected', () => {
-    // formatUser gets the username from localStorage.
-    const localStorageMgr = require('js/utils/localstorage-mgr').default
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'PaulM')
-
-    const formatUser = require('js/authentication/user').formatUser
-    const firebaseUser = {
-      uid: 'abc123',
-      email: 'ostrichcoat@example.com',
-      isAnonymous: false,
-      emailVerified: true,
-      getIdToken: jest.fn(() => 'fake-token-123'),
-    }
-    expect(formatUser(firebaseUser)).toEqual({
-      id: 'abc123',
-      email: 'ostrichcoat@example.com',
-      username: 'PaulM',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-  })
-})
-
 describe('getCurrentUser tests', () => {
   it('returns a user when one exists', async () => {
     expect.assertions(1)
@@ -184,15 +160,14 @@ describe('getCurrentUser tests', () => {
   })
 })
 
-describe('getCurrentUserListener tests', () => {
+describe('onAuthStateChanged tests', () => {
   it('calls listeners with the Firebase user object when the auth state changes', done => {
     // formatUser gets the username from localStorage.
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'DoraSplora')
 
-    const getCurrentUserListener = require('js/authentication/user')
-      .getCurrentUserListener
-    getCurrentUserListener().onAuthStateChanged(currentUser => {
+    const { onAuthStateChanged } = require('js/authentication/user')
+    onAuthStateChanged(currentUser => {
       expect(currentUser).toMatchObject({
         id: 'xyz987',
         email: 'foo@example.com',
@@ -223,9 +198,8 @@ describe('getCurrentUserListener tests', () => {
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'kevin')
 
-    const getCurrentUserListener = require('js/authentication/user')
-      .getCurrentUserListener
-    getCurrentUserListener().onAuthStateChanged(currentUser => {
+    const { onAuthStateChanged } = require('js/authentication/user')
+    onAuthStateChanged(currentUser => {
       expect(currentUser).toMatchObject({
         id: 'abcdefghijklmno',
         email: 'kevin@example.com',

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -133,7 +133,7 @@ export const checkAuthStateAndRedirectIfNeeded = async (
   // User is not logged in.
   if (!user || !user.id) {
     // To reduce noise in user creation stats, only create an anonymous
-    // user if the user recently installed the browser extension.]
+    // user if the user recently installed the browser extension.
     if (shouldCreateAnonymousUser()) {
       // Authenticate the user anonymously.
       try {

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -35,7 +35,7 @@ export const getUsername = () => {
 
 /**
  * Set the username in localStorage.
- * @pararms {string} The user's username
+ * @params {string} The user's username
  */
 export const setUsernameInLocalStorage = username => {
   return localStorageMgr.setItem(STORAGE_KEY_USERNAME, username)
@@ -44,14 +44,14 @@ export const setUsernameInLocalStorage = username => {
 /**
  * Take the user object from our auth service and create
  * the object we'll use in the app.
- * @returns {object} user - The user object for the app.
- * @returns {string} user.id - The user's ID
- * @returns {string} user.email - The user's email
- * @returns {string} user.username - The user's username
- * @returns {boolean} user.isAnonymous - Whether the user is anonymous
- * @returns {boolean} user.emailVerified - Whether the user has verified their email
+ * @returns {Pbject} AuthUser - The user object for the app.
+ * @returns {String} AuthUser.id - The user's ID
+ * @returns {String} AuthUser.email - The user's email
+ * @returns {String} AuthUser.username - The user's username
+ * @returns {Boolean} AuthUser.isAnonymous - Whether the user is anonymous
+ * @returns {Boolean} AuthUser.emailVerified - Whether the user has verified their email
  */
-export const formatUser = authUserObj => {
+const formatUser = authUserObj => {
   return {
     id: authUserObj.uid,
     email: authUserObj.email,
@@ -61,7 +61,10 @@ export const formatUser = authUserObj => {
   }
 }
 
-// TODO: documentation
+/**
+ * Get a mock, pared-down Firebase user for offline development.
+ * @return {Object}
+ */
 const getMockFirebaseUser = () => {
   const userId = 'abcdefghijklmno'
   const email = 'kevin@example.com'
@@ -117,8 +120,8 @@ const getCurrentFirebaseUser = async () => {
 /**
  * Get the current user object. Returns null if the user is not
  * logged in.
- * @returns {Promise<({user}|null)>}  A promise that resolves into either
- *   a user object or null.
+ * @returns {Promise<({AuthUser}|null)>}  A promise that resolves into either
+ *   an AuthUser object or null.
  */
 export const getCurrentUser = async () => {
   try {
@@ -134,27 +137,27 @@ export const getCurrentUser = async () => {
 }
 
 /**
- * TODO
- * @returns {Function}
+ * A function to register a listener for when the user's authentication
+ * state changes between signed in and not signed in.
+ * @return {AuthUser|null} An object representing the authenticated
+ *   user, or null if the user does not exist.
  */
-export const getCurrentUserListener = () => {
-  return {
-    onAuthStateChanged: callback => {
-      const unsubscribe = firebase.auth().onAuthStateChanged(firebaseUser => {
-        let user = null
-        if (shouldMockAuthentication) {
-          // For development only. Return a mock user.
-          user = formatUser(getMockFirebaseUser())
-        } else if (firebaseUser) {
-          user = formatUser(firebaseUser)
-        } else {
-          user = null
-        }
-        callback(user)
-      })
-      return unsubscribe
-    },
-  }
+export const onAuthStateChanged = callback => {
+  // Return the listener unsubscribe function.
+  // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged
+  const unsubscribe = firebase.auth().onAuthStateChanged(firebaseUser => {
+    let user = null
+    if (shouldMockAuthentication) {
+      // For development only. Return a mock user.
+      user = formatUser(getMockFirebaseUser())
+    } else if (firebaseUser) {
+      user = formatUser(firebaseUser)
+    } else {
+      user = null
+    }
+    callback(user)
+  })
+  return unsubscribe
 }
 
 /**

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -93,7 +93,7 @@ const getCurrentFirebaseUser = async () => {
   return new Promise((resolve, reject) => {
     try {
       // https://firebase.google.com/docs/auth/web/manage-users
-      var unsubscribe = firebase.auth().onAuthStateChanged(authUser => {
+      const unsubscribe = firebase.auth().onAuthStateChanged(authUser => {
         if (unsubscribe && typeof unsubscribe === 'function') {
           unsubscribe()
         }

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -93,7 +93,10 @@ const getCurrentFirebaseUser = async () => {
   return new Promise((resolve, reject) => {
     try {
       // https://firebase.google.com/docs/auth/web/manage-users
-      firebase.auth().onAuthStateChanged(authUser => {
+      var unsubscribe = firebase.auth().onAuthStateChanged(authUser => {
+        if (unsubscribe && typeof unsubscribe === 'function') {
+          unsubscribe()
+        }
         if (authUser) {
           resolve(authUser)
         } else {
@@ -110,7 +113,7 @@ const getCurrentFirebaseUser = async () => {
  * Get the current user object. Returns null if the user is not
  * logged in.
  * @returns {Promise<({user}|null)>}  A promise that resolves into either
- *   a user obejct or null.
+ *   a user object or null.
  */
 export const getCurrentUser = async () => {
   try {

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -27,7 +27,7 @@ const shouldMockAuthentication =
 /**
  * Get the username. This uses localStorage, not our user database,
  * so that we can rely on it during the sign up process.
- * @returns {string} The user's username
+ * @return {String} The user's username
  */
 export const getUsername = () => {
   return localStorageMgr.getItem(STORAGE_KEY_USERNAME)
@@ -35,7 +35,7 @@ export const getUsername = () => {
 
 /**
  * Set the username in localStorage.
- * @params {string} The user's username
+ * @params {String} The user's username
  */
 export const setUsernameInLocalStorage = username => {
   return localStorageMgr.setItem(STORAGE_KEY_USERNAME, username)
@@ -44,12 +44,12 @@ export const setUsernameInLocalStorage = username => {
 /**
  * Take the user object from our auth service and create
  * the object we'll use in the app.
- * @returns {Pbject} AuthUser - The user object for the app.
- * @returns {String} AuthUser.id - The user's ID
- * @returns {String} AuthUser.email - The user's email
- * @returns {String} AuthUser.username - The user's username
- * @returns {Boolean} AuthUser.isAnonymous - Whether the user is anonymous
- * @returns {Boolean} AuthUser.emailVerified - Whether the user has verified their email
+ * @return {Object} AuthUser - The user object for the app.
+ * @return {String} AuthUser.id - The user's ID
+ * @return {String} AuthUser.email - The user's email
+ * @return {String} AuthUser.username - The user's username
+ * @return {Boolean} AuthUser.isAnonymous - Whether the user is anonymous
+ * @return {Boolean} AuthUser.emailVerified - Whether the user has verified their email
  */
 const formatUser = authUserObj => {
   return {
@@ -88,7 +88,7 @@ const getMockFirebaseUser = () => {
 
 /**
  * Return the raw Firebase user instance.
- * @returns {user} a Firebase User
+ * @return {Object} a Firebase User
  */
 const getCurrentFirebaseUser = async () => {
   // For development only: optionally mock the user
@@ -120,7 +120,7 @@ const getCurrentFirebaseUser = async () => {
 /**
  * Get the current user object. Returns null if the user is not
  * logged in.
- * @returns {Promise<({AuthUser}|null)>}  A promise that resolves into either
+ * @return {Promise<({AuthUser}|null)>}  A promise that resolves into either
  *   an AuthUser object or null.
  */
 export const getCurrentUser = async () => {
@@ -139,8 +139,11 @@ export const getCurrentUser = async () => {
 /**
  * A function to register a listener for when the user's authentication
  * state changes between signed in and not signed in.
- * @return {AuthUser|null} An object representing the authenticated
- *   user, or null if the user does not exist.
+ * @param {Function} A function register a callback, which is called
+ *   when the user's auth state changes and receives the new AuthUser
+ *   object.
+ * @return {Function} A function that, when called, will to unsubscribe
+ *   the callback from future changes in authentication state.
  */
 export const onAuthStateChanged = callback => {
   // Return the listener unsubscribe function.
@@ -164,7 +167,7 @@ export const onAuthStateChanged = callback => {
  * Get the user's token.
  * @param {Boolean} forceRefresh - Whether to force Firebase to refresh
  *   the token regardless of expiration status.
- * @returns {(string|null)} The token, if the user is authenticated;
+ * @return {(string|null)} The token, if the user is authenticated;
  *   otherwise, null.
  */
 export const getUserToken = async forceRefresh => {
@@ -186,7 +189,7 @@ export const getUserToken = async forceRefresh => {
 
 /**
  * Delete any sensitive localStorage items.
- * @returns {null}
+ * @return {null}
  */
 const clearAuthLocalStorageItems = () => {
   // Currently, removes everything except background settings.
@@ -207,7 +210,7 @@ const clearAuthLocalStorageItems = () => {
 
 /**
  * Log the user out.
- * @returns {Promise<boolean>}  A promise that resolves into a boolean,
+ * @return {Promise<Boolean>}  A promise that resolves into a boolean,
  *   whether or not the logout was successful.
  */
 export const logout = async () => {
@@ -231,8 +234,8 @@ export const logout = async () => {
 
 /**
  * Send a confirmation email to a Firebase user.
- * @param {object} firebaseUser - A Firebase user instance
- * @returns {Promise<boolean>}  A promise that resolves into a boolean,
+ * @param {Object} firebaseUser - A Firebase user instance
+ * @return {Promise<Boolean>}  A promise that resolves into a boolean,
  *   whether or not the email was sent successfully.
  */
 const sendFirebaseVerificationEmail = async firebaseUser => {
@@ -259,7 +262,7 @@ const sendFirebaseVerificationEmail = async firebaseUser => {
 
 /**
  * Send an email for the current user to verify their email address.
- * @returns {Promise<boolean>}  A promise that resolves into a boolean,
+ * @return {Promise<Boolean>}  A promise that resolves into a boolean,
  *   whether or not the email was sent successfully.
  */
 export const sendVerificationEmail = async () => {
@@ -283,7 +286,7 @@ export const sendVerificationEmail = async () => {
 
 /**
  * Sign in a user anonymously and return their user object.
- * @returns {Promise<{user}>} A Promise resolving into the
+ * @return {Promise<{AuthUser}>} A Promise resolving into the
  *   user object.
  */
 export const signInAnonymously = async () => {
@@ -307,7 +310,7 @@ export const signInAnonymously = async () => {
 
 /**
  * Reload the Firebase user data from the server.
- * @returns {Promise<undefined>}
+ * @return {Promise<undefined>}
  */
 export const reloadUser = async () => {
   var user

--- a/web/src/js/components/General/AuthUserComponent.js
+++ b/web/src/js/components/General/AuthUserComponent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { formatUser, getCurrentUserListener } from 'js/authentication/user'
+import { onAuthStateChanged } from 'js/authentication/user'
 import { checkAuthStateAndRedirectIfNeeded } from 'js/authentication/helpers'
 
 // Get the authenticated user and, if the user is authenticated,
@@ -17,21 +17,11 @@ class AuthUserComponent extends React.Component {
   }
 
   componentDidMount() {
-    // Store unsubscribe function.
-    // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged
-    this.authListenerUnsubscribe = getCurrentUserListener()
-      // Note: currently, this callback may be called when a user does not
-      // exist on the server side, and some requests may fail.
-      .onAuthStateChanged(user => {
-        // TODO: roll the formatting functionality into the
-        // listener.
-        if (user) {
-          const formattedUser = formatUser(user)
-          this.checkUserAuth(formattedUser)
-        } else {
-          this.checkUserAuth(user)
-        }
-      })
+    // Note: currently, this callback may be called when a user does not
+    // exist on the server side, and some requests may fail.
+    this.authListenerUnsubscribe = onAuthStateChanged(user => {
+      this.checkUserAuth(user)
+    })
   }
 
   componentWillUnmount() {

--- a/web/src/js/components/General/__tests__/AuthUserComponent.test.js
+++ b/web/src/js/components/General/__tests__/AuthUserComponent.test.js
@@ -11,8 +11,6 @@ import {
   __unregisterAuthStateChangeListeners,
   __triggerAuthStateChange,
 } from 'js/authentication/user'
-import localStorageMgr from 'js/utils/localstorage-mgr'
-import { STORAGE_KEY_USERNAME } from 'js/constants'
 import { flushAllPromises } from 'js/utils/test-utils'
 
 jest.mock('js/authentication/helpers')
@@ -26,9 +24,6 @@ beforeAll(() => {
 
 beforeEach(() => {
   MockDate.set(moment(mockNow))
-
-  // Set the user's username in localStorage.
-  localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
 })
 
 afterEach(() => {
@@ -68,10 +63,10 @@ describe('AuthUser tests', () => {
         <MockChildComponent />
       </AuthUser>
     )
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: 'abc123',
+      id: 'abc123',
       email: 'foo@bar.com',
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: true,
     })
@@ -92,10 +87,10 @@ describe('AuthUser tests', () => {
         <MockChildComponent />
       </AuthUser>
     )
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: 'abc123',
+      id: 'abc123',
       email: null, // no email
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: false,
     })
@@ -116,10 +111,10 @@ describe('AuthUser tests', () => {
         <MockChildComponent />
       </AuthUser>
     )
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: 'abc123',
+      id: 'abc123',
       email: 'foo@bar.com',
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: true,
     })

--- a/web/src/js/components/General/withUserId.js
+++ b/web/src/js/components/General/withUserId.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { getCurrentUserListener } from 'js/authentication/user'
+import { onAuthStateChanged } from 'js/authentication/user'
 
 // https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
 function getDisplayName(WrappedComponent) {
@@ -26,18 +26,16 @@ const withUserId = (options = {}) => WrappedComponent => {
     componentDidMount() {
       // Store unsubscribe function.
       // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged
-      this.authListenerUnsubscribe = getCurrentUserListener().onAuthStateChanged(
-        user => {
-          if (user && user.uid) {
-            this.setState({
-              userId: user.uid,
-            })
-          }
+      this.authListenerUnsubscribe = onAuthStateChanged(user => {
+        if (user && user.id) {
           this.setState({
-            authStateLoaded: true,
+            userId: user.id,
           })
         }
-      )
+        this.setState({
+          authStateLoaded: true,
+        })
+      })
     }
 
     componentWillUnmount() {

--- a/web/src/js/components/General/withUserId.test.js
+++ b/web/src/js/components/General/withUserId.test.js
@@ -8,7 +8,6 @@ import {
   __triggerAuthStateChange,
 } from 'js/authentication/user'
 import { flushAllPromises } from 'js/utils/test-utils'
-import { STORAGE_KEY_USERNAME } from 'js/constants'
 
 jest.mock('js/authentication/user')
 

--- a/web/src/js/components/General/withUserId.test.js
+++ b/web/src/js/components/General/withUserId.test.js
@@ -8,7 +8,6 @@ import {
   __triggerAuthStateChange,
 } from 'js/authentication/user'
 import { flushAllPromises } from 'js/utils/test-utils'
-import localStorageMgr from 'js/utils/localstorage-mgr'
 import { STORAGE_KEY_USERNAME } from 'js/constants'
 
 jest.mock('js/authentication/user')
@@ -43,10 +42,10 @@ describe('withUserId', () => {
     const MockComponent = () => null
     const WrappedComponent = withUserId()(MockComponent)
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: 'abc123',
+      id: 'abc123',
       email: 'foo@bar.com',
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: true,
     })
@@ -61,10 +60,10 @@ describe('withUserId', () => {
     const MockComponent = () => null
     const WrappedComponent = withUserId()(MockComponent)
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: null,
+      id: null,
       email: null,
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: false,
     })
@@ -79,7 +78,6 @@ describe('withUserId', () => {
     const MockComponent = () => null
     const WrappedComponent = withUserId()(MockComponent)
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange(null)
     await flushAllPromises()
     expect(wrapper.find(MockComponent).length).toBe(0)
@@ -97,10 +95,10 @@ describe('withUserId', () => {
     })(MockComponent)
 
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: null,
+      id: null,
       email: null,
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: false,
     })
@@ -120,7 +118,6 @@ describe('withUserId', () => {
     })(MockComponent)
 
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange(null)
     await flushAllPromises()
     expect(wrapper.find(MockComponent).length).toBe(1)
@@ -133,10 +130,10 @@ describe('withUserId', () => {
     const MockComponent = () => null
     const WrappedComponent = withUserId()(MockComponent)
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
     __triggerAuthStateChange({
-      uid: 'abc123',
+      id: 'abc123',
       email: 'foo@bar.com',
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: true,
     })
@@ -158,15 +155,15 @@ describe('withUserId', () => {
     })(MockComponent)
 
     const wrapper = shallow(<WrappedComponent />)
-    localStorageMgr.setItem(STORAGE_KEY_USERNAME, 'SomeUsername')
 
     // Should not yet have rendered children.
     await flushAllPromises()
     expect(wrapper.find(MockComponent).length).toBe(0)
 
     __triggerAuthStateChange({
-      uid: 'abc123',
+      id: 'abc123',
       email: 'foo@bar.com',
+      username: 'SomeUsername',
       isAnonymous: false,
       emailVerified: true,
     })


### PR DESCRIPTION
To manually test auth functionality, make sure:
- New user sign-up flow works
- Returning user sign-up flow works
- Unauthed new tab page redirects to sign-in
- Unauthed search page works as expected
- Authed sign-in page redirects to the dashboard
