### PR TITLE
Create users in `withUser` when possible

### DIFF
--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -105,6 +105,35 @@ const goToMainLoginPage = (urlParamsObj = {}) => {
   }
 }
 
+/**
+ * Create an anonymous user in our authentication system and on our
+ * server side, if possible.
+ * @return {Object|null} The new user object (AuthUser), or null
+ *   if we could not create a user.
+ */
+export const createAnonymousUserIfPossible = async () => {
+  // To reduce noise in user creation stats, only create an anonymous
+  // user if the user recently installed the browser extension.
+  if (shouldCreateAnonymousUser()) {
+    // Authenticate the user anonymously.
+    try {
+      await signInAnonymously()
+    } catch (e) {
+      throw e
+    }
+
+    // Create a user in our database.
+    try {
+      await createNewUser()
+    } catch (e) {
+      throw e
+    }
+    return await getCurrentUser()
+  } else {
+    return null
+  }
+}
+
 // TODO: break into simpler pieces
 /**
  * Based on the user object state, determine if we need to redirect

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -105,6 +105,7 @@ const goToMainLoginPage = (urlParamsObj = {}) => {
   }
 }
 
+// TODO: break into simpler pieces
 /**
  * Based on the user object state, determine if we need to redirect
  * to an authentication page. If the user is not fully authenticated,

--- a/web/src/js/components/General/__tests__/withUser.test.js
+++ b/web/src/js/components/General/__tests__/withUser.test.js
@@ -332,4 +332,33 @@ describe('withUser', () => {
       mockCreatedUser
     )
   })
+
+  it('does not create an anonymous user when the createUserIfPossible option is false', async () => {
+    expect.assertions(2)
+
+    const mockCreatedUser = {
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false,
+    }
+    createAnonymousUserIfPossible.mockResolvedValue(mockCreatedUser)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({
+      createUserIfPossible: false,
+      renderIfNoUser: true,
+    })(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(createAnonymousUserIfPossible).not.toHaveBeenCalled()
+    expect(wrapper.find(MockComponent).prop('authUser')).toBeNull()
+  })
 })

--- a/web/src/js/components/General/__tests__/withUser.test.js
+++ b/web/src/js/components/General/__tests__/withUser.test.js
@@ -8,11 +8,14 @@ import {
   __triggerAuthStateChange,
 } from 'js/authentication/user'
 import { flushAllPromises } from 'js/utils/test-utils'
+import { createAnonymousUserIfPossible } from 'js/authentication/helpers'
 
 jest.mock('js/authentication/user')
+jest.mock('js/authentication/helpers')
 
 afterEach(() => {
   jest.clearAllMocks()
+  createAnonymousUserIfPossible.mockResolvedValue(null)
   __unregisterAuthStateChangeListeners()
 })
 
@@ -49,7 +52,7 @@ describe('withUser', () => {
       emailVerified: true,
     })
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(1)
+    expect(wrapper.find(MockComponent).exists()).toBe(true)
   })
 
   it('does not render children if the user does not have an ID, by default', async () => {
@@ -67,7 +70,7 @@ describe('withUser', () => {
       emailVerified: false,
     })
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(0)
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
   })
 
   it('does not render children if the user is null, by default', async () => {
@@ -79,7 +82,7 @@ describe('withUser', () => {
     const wrapper = shallow(<WrappedComponent />)
     __triggerAuthStateChange(null)
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(0)
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
   })
 
   it('renders children if the user does not have an ID when the "renderIfNoUser" option is true', async () => {
@@ -102,7 +105,7 @@ describe('withUser', () => {
       emailVerified: false,
     })
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(1)
+    expect(wrapper.find(MockComponent).exists()).toBe(true)
   })
 
   it('renders children if the user is null when the "renderIfNoUser" option is true', async () => {
@@ -119,7 +122,7 @@ describe('withUser', () => {
     const wrapper = shallow(<WrappedComponent />)
     __triggerAuthStateChange(null)
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(1)
+    expect(wrapper.find(MockComponent).exists()).toBe(true)
   })
 
   it('passes the user as a prop to the wrapped component', async () => {
@@ -143,7 +146,7 @@ describe('withUser', () => {
     expect(wrapper.find(MockComponent).prop('authUser')).toEqual(mockAuthUser)
   })
 
-  it('renders children only after determing the auth state', async () => {
+  it('renders children only after determining the auth state, when a user exists', async () => {
     expect.assertions(2)
 
     const withUser = require('js/components/General/withUser').default
@@ -158,7 +161,7 @@ describe('withUser', () => {
 
     // Should not yet have rendered children.
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(0)
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
 
     __triggerAuthStateChange({
       id: 'abc123',
@@ -169,6 +172,164 @@ describe('withUser', () => {
     })
 
     await flushAllPromises()
-    expect(wrapper.find(MockComponent).length).toBe(1)
+    expect(wrapper.find(MockComponent).exists()).toBe(true)
+  })
+
+  it('renders children only after determining the auth state, when we create a new anonymous user', async () => {
+    expect.assertions(3)
+
+    jest.useFakeTimers()
+
+    // Mock a delay in creating a new user.
+    createAnonymousUserIfPossible.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          setTimeout(() => {
+            resolve({
+              id: 'abc123',
+              email: 'foo@bar.com',
+              username: 'SomeUsername',
+              isAnonymous: false,
+              emailVerified: true,
+            })
+          }, 3e4)
+        })
+    )
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({
+      renderIfNoUser: true,
+    })(MockComponent)
+
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    // Should not yet have rendered children.
+    await flushAllPromises()
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
+
+    // Not enough time for the response from `createAnonymousUserIfPossible`.
+    jest.advanceTimersByTime(2e4)
+
+    // Still should not have rendered children.
+    await flushAllPromises()
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
+
+    // Mock that the created user returns.
+    jest.advanceTimersByTime(2e4)
+
+    await flushAllPromises()
+    expect(wrapper.find(MockComponent).exists()).toBe(true)
+  })
+
+  it('passes a null user to the child component when we could not create a new anonymous user and "renderIfNoUser" is true', async () => {
+    expect.assertions(1)
+
+    // We will not successfully create a new anonymous user.
+    createAnonymousUserIfPossible.mockResolvedValue(null)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({ renderIfNoUser: true })(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(wrapper.find(MockComponent).prop('authUser')).toBeNull()
+  })
+
+  it('does not render the child component when we could not create a new anonymous user and "renderIfNoUser" is false', async () => {
+    expect.assertions(1)
+
+    // We will not successfully create a new anonymous user.
+    createAnonymousUserIfPossible.mockResolvedValue(null)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser()(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
+  })
+
+  it('passes a null user to the child component when createAnonymousUserIfPossible throws and "renderIfNoUser" is true', async () => {
+    expect.assertions(1)
+
+    // Attempting to create a new anonymous user will error.
+    createAnonymousUserIfPossible.mockRejectedValue(
+      new Error('To new user creation – we say, "Not today."')
+    )
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({ renderIfNoUser: true })(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(wrapper.find(MockComponent).prop('authUser')).toBeNull()
+  })
+
+  it('does not render the child component when createAnonymousUserIfPossible throws and "renderIfNoUser" is false', async () => {
+    expect.assertions(1)
+
+    // Attempting to create a new anonymous user will error.
+    createAnonymousUserIfPossible.mockRejectedValue(
+      new Error('To new user creation – we say, "Not today."')
+    )
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser()(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(wrapper.find(MockComponent).exists()).toBe(false)
+  })
+
+  it('passes the anonymous user to the child component when a new user is created', async () => {
+    expect.assertions(1)
+
+    // We will create a new anonymous user.
+    const mockCreatedUser = {
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false,
+    }
+    createAnonymousUserIfPossible.mockResolvedValue(mockCreatedUser)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser()(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(wrapper.find(MockComponent).prop('authUser')).toEqual(
+      mockCreatedUser
+    )
   })
 })

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -11,6 +11,11 @@ function getDisplayName(WrappedComponent) {
  * @param {Object} options
  * @param {Boolean} options.renderIfNoUser - If true, we will render the
  *   children even if there is no user ID (the user is not signed in).
+ *   Defaults to false.
+ * @param {Boolean} options.createUserIfPossible - If true, when a user does
+ *   not exist, we will create a new anonymous user both in our auth service
+ *   and in our database. We might not always create a new user, depending on
+ *   our anonymous user restrictions. Defaults to true.
  * @return {Function} A higher-order component.
  */
 const withUser = (options = {}) => WrappedComponent => {
@@ -45,7 +50,7 @@ const withUser = (options = {}) => WrappedComponent => {
     }
 
     render() {
-      const { renderIfNoUser } = options
+      const { renderIfNoUser = false } = options
       // Return null if the user is not authenticated but the children require
       // an authenticated user.
       if (!this.state.authUser && !renderIfNoUser) {

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -36,6 +36,9 @@ const withUser = (options = {}) => WrappedComponent => {
           this.setState({
             authUser: user,
           })
+        } else {
+          // TODO:
+          // Create the user, if possible.
         }
         this.setState({
           authStateLoaded: true,

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { onAuthStateChanged } from 'js/authentication/user'
 import { createAnonymousUserIfPossible } from 'js/authentication/helpers'
+import logger from 'js/utils/logger'
 
 // https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
 function getDisplayName(WrappedComponent) {
@@ -51,8 +52,7 @@ const withUser = (options = {}) => WrappedComponent => {
               }
             })
             .catch(e => {
-              // TODO: logger
-              // console.error(e)
+              logger.error(e)
             })
             // Equivalent to .finally()
             .then(() => {

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -30,6 +30,8 @@ const withUser = (options = {}) => WrappedComponent => {
     }
 
     componentDidMount() {
+      const { createUserIfPossible = true } = options
+
       // Store unsubscribe function.
       // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged
       this.authListenerUnsubscribe = onAuthStateChanged(user => {
@@ -38,7 +40,7 @@ const withUser = (options = {}) => WrappedComponent => {
             authUser: user,
             authStateLoaded: true,
           })
-        } else {
+        } else if (createUserIfPossible) {
           // Create the user, if possible.
           createAnonymousUserIfPossible()
             .then(user => {
@@ -49,6 +51,7 @@ const withUser = (options = {}) => WrappedComponent => {
               }
             })
             .catch(e => {
+              // TODO: logger
               // console.error(e)
             })
             // Equivalent to .finally()
@@ -57,6 +60,10 @@ const withUser = (options = {}) => WrappedComponent => {
                 authStateLoaded: true,
               })
             })
+        } else {
+          this.setState({
+            authStateLoaded: true,
+          })
         }
       })
     }


### PR DESCRIPTION
Add anonymous user authentication server-side user creation in the `withUser` HOC to make it more likely that it provides a functional user. This also makes authentication and user creation logic a little more modular. We still restrict anonymous user creation to within 30 seconds of adding the extension to limit noisy/unnecessary anonymous user creation.

To confirm user creation works as expected:
1. delete the local Firebase user (clear IndexedDB)
2. set the local storage "install time" to now or in the future
3. load a component using `withUser`: it should auth the user, create the user server-side, then render the child component with the newly-created user