### PR TITLE
Replace `AuthUser` component with `withUser` HOC in settings

### DIFF
--- a/web/src/js/components/Background/BackgroundCustomImagePickerComponent.js
+++ b/web/src/js/components/Background/BackgroundCustomImagePickerComponent.js
@@ -7,7 +7,7 @@ import RaisedButton from 'material-ui/RaisedButton'
 import { cardHeaderSubtitleStyle } from 'js/theme/default'
 import brokenImage from 'js/assets/nopicture.jpg'
 
-class BackgroundCustomeImagePicker extends React.Component {
+class BackgroundCustomImagePicker extends React.Component {
   constructor(props) {
     super(props)
 
@@ -135,7 +135,7 @@ class BackgroundCustomeImagePicker extends React.Component {
   }
 }
 
-BackgroundCustomeImagePicker.propTypes = {
+BackgroundCustomImagePicker.propTypes = {
   user: PropTypes.shape({
     customImage: PropTypes.string.isRequired,
   }),
@@ -143,4 +143,4 @@ BackgroundCustomeImagePicker.propTypes = {
   onCustomImageSelection: PropTypes.func.isRequired,
 }
 
-export default BackgroundCustomeImagePicker
+export default BackgroundCustomImagePicker

--- a/web/src/js/components/General/__mocks__/withUser.js
+++ b/web/src/js/components/General/__mocks__/withUser.js
@@ -1,15 +1,19 @@
 /* eslint-env jest */
 import React from 'react'
 
-export default jest.fn(options => ChildComponent => props => (
-  <ChildComponent
-    authUser={{
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    }}
-    {...props}
-  />
-))
+export const __mockWithUserWrappedFunction = jest.fn(
+  ChildComponent => props => (
+    <ChildComponent
+      authUser={{
+        id: 'abc123xyz456',
+        email: 'foo@example.com',
+        username: 'example',
+        isAnonymous: false,
+        emailVerified: true,
+      }}
+      {...props}
+    />
+  )
+)
+
+export default jest.fn(options => __mockWithUserWrappedFunction)

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -117,7 +117,6 @@ const withUser = (options = {}) => WrappedComponent => {
       const { renderIfNoUser = false } = options
       const { authUser, authStateLoaded, userCreationInProgress } = this.state
       // Don't render the children until we've determined the auth state.
-      // if (!authStateLoaded) {
       if (!authStateLoaded || userCreationInProgress) {
         return null
       }
@@ -129,7 +128,7 @@ const withUser = (options = {}) => WrappedComponent => {
       return <WrappedComponent authUser={authUser} {...this.props} />
     }
   }
-  CompWithUser.displayName = `CompWithUser(${getDisplayName(WrappedComponent)})`
+  CompWithUser.displayName = `withUser(${getDisplayName(WrappedComponent)})`
   return CompWithUser
 }
 

--- a/web/src/js/components/Settings/Account/AccountView.js
+++ b/web/src/js/components/Settings/Account/AccountView.js
@@ -1,17 +1,23 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import environment from 'js/relay-env'
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import Account from 'js/components/Settings/Account/AccountContainer'
-import AuthUserComponent from 'js/components/General/AuthUserComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
 class AccountView extends React.Component {
   render() {
+    const { authUser } = this.props
     return (
-      <AuthUserComponent>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <QueryRenderer
           environment={environment}
           query={graphql`
@@ -21,6 +27,9 @@ class AccountView extends React.Component {
               }
             }
           `}
+          variables={{
+            userId: authUser.id,
+          }}
           render={({ error, props }) => {
             if (error) {
               logger.error(error)
@@ -38,9 +47,18 @@ class AccountView extends React.Component {
             )
           }}
         />
-      </AuthUserComponent>
+      </div>
     )
   }
 }
+
+AccountView.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  showError: PropTypes.func.isRequired,
+}
+
+AccountView.defaultProps = {}
 
 export default AccountView

--- a/web/src/js/components/Settings/Account/__tests__/AccountView.test.js
+++ b/web/src/js/components/Settings/Account/__tests__/AccountView.test.js
@@ -1,0 +1,138 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import AccountView from 'js/components/Settings/Account/AccountView'
+import Account from 'js/components/Settings/Account/AccountContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Account/AccountContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
+  showError: jest.fn(),
+})
+
+describe('AccountView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<AccountView {...mockProps} />)
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<AccountView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<AccountView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<AccountView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'example-user-id', // from the authUser prop
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<AccountView {...mockProps} />)
+    expect(wrapper.find(Account).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<AccountView {...mockProps} />)
+    expect(wrapper.find(Account).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<AccountView {...mockProps} />)
+    expect(wrapper.find(Account).props()).toEqual({
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<AccountView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(Account).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading your account :('
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/Background/BackgroundSettingsView.js
+++ b/web/src/js/components/Settings/Background/BackgroundSettingsView.js
@@ -1,18 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import BackgroundSettings from 'js/components/Settings/Background/BackgroundSettingsContainer'
-import AuthUserComponent from 'js/components/General/AuthUserComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
 class BackgroundSettingsView extends React.Component {
   render() {
+    const { authUser } = this.props
     return (
-      <AuthUserComponent>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <QueryRenderer
           environment={environment}
           query={graphql`
@@ -25,6 +31,9 @@ class BackgroundSettingsView extends React.Component {
               }
             }
           `}
+          variables={{
+            userId: authUser.id,
+          }}
           render={({ error, props }) => {
             if (error) {
               logger.error(error)
@@ -47,9 +56,18 @@ class BackgroundSettingsView extends React.Component {
             )
           }}
         />
-      </AuthUserComponent>
+      </div>
     )
   }
 }
+
+BackgroundSettingsView.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  showError: PropTypes.func.isRequired,
+}
+
+BackgroundSettingsView.defaultProps = {}
 
 export default BackgroundSettingsView

--- a/web/src/js/components/Settings/Background/__tests__/BackgroundSettingsView.test.js
+++ b/web/src/js/components/Settings/Background/__tests__/BackgroundSettingsView.test.js
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+import BackgroundSettings from 'js/components/Settings/Background/BackgroundSettingsContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Background/BackgroundSettingsContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
+  showError: jest.fn(),
+})
+
+describe('BackgroundSettingsView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<BackgroundSettingsView {...mockProps} />)
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<BackgroundSettingsView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<BackgroundSettingsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<BackgroundSettingsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'example-user-id', // from the authUser prop
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<BackgroundSettingsView {...mockProps} />)
+    expect(wrapper.find(BackgroundSettings).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<BackgroundSettingsView {...mockProps} />)
+    expect(wrapper.find(BackgroundSettings).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      app: {
+        some: 'value',
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<BackgroundSettingsView {...mockProps} />)
+    expect(wrapper.find(BackgroundSettings).props()).toEqual({
+      app: fakeQueryRendererProps.app,
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<BackgroundSettingsView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(BackgroundSettings).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading the background settings :('
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
@@ -1,18 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsContainer'
-import AuthUserComponent from 'js/components/General/AuthUserComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
 class ProfileDonateHeartsView extends React.Component {
   render() {
+    const { authUser } = this.props
     return (
-      <AuthUserComponent>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <QueryRenderer
           environment={environment}
           query={graphql`
@@ -25,6 +31,9 @@ class ProfileDonateHeartsView extends React.Component {
               }
             }
           `}
+          variables={{
+            userId: authUser.id,
+          }}
           render={({ error, props }) => {
             if (error) {
               logger.error(error)
@@ -46,9 +55,18 @@ class ProfileDonateHeartsView extends React.Component {
             )
           }}
         />
-      </AuthUserComponent>
+      </div>
     )
   }
 }
+
+ProfileDonateHeartsView.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  showError: PropTypes.func.isRequired,
+}
+
+ProfileDonateHeartsView.defaultProps = {}
 
 export default ProfileDonateHeartsView

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
@@ -1,18 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendContainer'
-import AuthUserComponent from 'js/components/General/AuthUserComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
 class ProfileInviteFriendView extends React.Component {
   render() {
+    const { authUser } = this.props
     return (
-      <AuthUserComponent>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <QueryRenderer
           environment={environment}
           query={graphql`
@@ -25,6 +31,9 @@ class ProfileInviteFriendView extends React.Component {
               }
             }
           `}
+          variables={{
+            userId: authUser.id,
+          }}
           render={({ error, props }) => {
             if (error) {
               logger.error(error)
@@ -46,9 +55,18 @@ class ProfileInviteFriendView extends React.Component {
             )
           }}
         />
-      </AuthUserComponent>
+      </div>
     )
   }
 }
+
+ProfileInviteFriendView.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  showError: PropTypes.func.isRequired,
+}
+
+ProfileInviteFriendView.defaultProps = {}
 
 export default ProfileInviteFriendView

--- a/web/src/js/components/Settings/Profile/ProfileStatsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsView.js
@@ -1,18 +1,24 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import ProfileStats from 'js/components/Settings/Profile/ProfileStatsContainer'
-import AuthUserComponent from 'js/components/General/AuthUserComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
 class ProfileStatsView extends React.Component {
   render() {
+    const { authUser } = this.props
     return (
-      <AuthUserComponent>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <QueryRenderer
           environment={environment}
           query={graphql`
@@ -22,6 +28,9 @@ class ProfileStatsView extends React.Component {
               }
             }
           `}
+          variables={{
+            userId: authUser.id,
+          }}
           render={({ error, props }) => {
             if (error) {
               logger.error(error)
@@ -39,9 +48,18 @@ class ProfileStatsView extends React.Component {
             )
           }}
         />
-      </AuthUserComponent>
+      </div>
     )
   }
 }
+
+ProfileStatsView.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  showError: PropTypes.func.isRequired,
+}
+
+ProfileStatsView.defaultProps = {}
 
 export default ProfileStatsView

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsView.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsView.test.js
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import ProfileDonateHeartsView from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Profile/ProfileDonateHeartsContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
+  showError: jest.fn(),
+})
+
+describe('ProfileDonateHeartsView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<ProfileDonateHeartsView {...mockProps} />)
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileDonateHeartsView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileDonateHeartsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileDonateHeartsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'example-user-id', // from the authUser prop
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileDonateHeartsView {...mockProps} />)
+    expect(wrapper.find(ProfileDonateHearts).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileDonateHeartsView {...mockProps} />)
+    expect(wrapper.find(ProfileDonateHearts).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      app: {
+        some: 'value',
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileDonateHeartsView {...mockProps} />)
+    expect(wrapper.find(ProfileDonateHearts).props()).toEqual({
+      app: fakeQueryRendererProps.app,
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileDonateHeartsView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(ProfileDonateHearts).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading the Donate Hearts page.'
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendView.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendView.test.js
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import ProfileInviteFriendView from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Profile/ProfileInviteFriendContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
+  showError: jest.fn(),
+})
+
+describe('ProfileInviteFriendView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<ProfileInviteFriendView {...mockProps} />)
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'example-user-id', // from the authUser prop
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(ProfileInviteFriend).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(ProfileInviteFriend).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      app: {
+        some: 'value',
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(ProfileInviteFriend).props()).toEqual({
+      app: fakeQueryRendererProps.app,
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(ProfileInviteFriend).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading this page :('
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsView.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsView.test.js
@@ -1,0 +1,138 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileStats from 'js/components/Settings/Profile/ProfileStatsContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Profile/ProfileStatsContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
+  showError: jest.fn(),
+})
+
+describe('ProfileStatsView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<ProfileStatsView {...mockProps} />)
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileStatsView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileStatsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileStatsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'example-user-id', // from the authUser prop
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileStatsView {...mockProps} />)
+    expect(wrapper.find(ProfileStats).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileStatsView {...mockProps} />)
+    expect(wrapper.find(ProfileStats).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileStatsView {...mockProps} />)
+    expect(wrapper.find(ProfileStats).props()).toEqual({
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileStatsView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(ProfileStats).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading your stats :('
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -59,7 +59,7 @@ class SettingsPage extends React.Component {
   }
 
   render() {
-    const { classes } = this.props
+    const { authUser, classes } = this.props
     const showError = this.showError
     const errorMessage = this.state.errorMessage
     const sidebarWidth = 240
@@ -136,6 +136,7 @@ class SettingsPage extends React.Component {
               render={props => (
                 <WidgetsSettingsView
                   {...props}
+                  authUser={authUser}
                   showError={showError.bind(this)}
                 />
               )}

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -153,7 +153,7 @@ class SettingsPage extends React.Component {
             />
             <Route
               exact
-              path="/newtab/profile/stats"
+              path="/newtab/profile/stats/"
               render={props => (
                 <ProfileStatsView {...props} showError={showError.bind(this)} />
               )}

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -157,7 +157,11 @@ class SettingsPage extends React.Component {
               exact
               path="/newtab/profile/stats/"
               render={props => (
-                <ProfileStatsView {...props} showError={showError.bind(this)} />
+                <ProfileStatsView
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
               )}
             />
             <Route

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -1,7 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Redirect, Route, Switch } from 'react-router-dom'
+import { withStyles } from '@material-ui/core/styles'
+import AppBar from '@material-ui/core/AppBar'
+import Divider from '@material-ui/core/Divider'
+import IconButton from '@material-ui/core/IconButton'
+import List from '@material-ui/core/List'
+import ListSubheader from '@material-ui/core/ListSubheader'
+import Toolbar from '@material-ui/core/Toolbar'
+import CloseIcon from 'material-ui/svg-icons/navigation/close'
+
+import AccountView from 'js/components/Settings/Account/AccountView'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
 import ErrorMessage from 'js/components/General/ErrorMessage'
+import Logo from 'js/components/Logo/Logo'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import withUser from 'js/components/General/withUser'
 import {
   goToDashboard,
   accountURL,
@@ -11,22 +29,6 @@ import {
   statsURL,
   widgetSettingsURL,
 } from 'js/navigation/navigation'
-import { withStyles } from '@material-ui/core/styles'
-import AppBar from '@material-ui/core/AppBar'
-import Divider from '@material-ui/core/Divider'
-import IconButton from '@material-ui/core/IconButton'
-import List from '@material-ui/core/List'
-import ListSubheader from '@material-ui/core/ListSubheader'
-import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
-import Toolbar from '@material-ui/core/Toolbar'
-import Logo from 'js/components/Logo/Logo'
-import CloseIcon from 'material-ui/svg-icons/navigation/close'
-import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
-import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
-import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
-import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
-import AccountView from 'js/components/Settings/Account/AccountView'
 
 const styles = theme => ({
   listSubheader: {
@@ -204,7 +206,10 @@ class SettingsPage extends React.Component {
 }
 
 SettingsPage.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
   classes: PropTypes.object.isRequired,
 }
 
-export default withStyles(styles)(SettingsPage)
+export default withStyles(styles)(withUser()(SettingsPage))

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -148,6 +148,7 @@ class SettingsPage extends React.Component {
               render={props => (
                 <BackgroundSettingsView
                   {...props}
+                  authUser={authUser}
                   showError={showError.bind(this)}
                 />
               )}

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -170,6 +170,7 @@ class SettingsPage extends React.Component {
               render={props => (
                 <ProfileDonateHearts
                   {...props}
+                  authUser={authUser}
                   showError={showError.bind(this)}
                 />
               )}
@@ -180,6 +181,7 @@ class SettingsPage extends React.Component {
               render={props => (
                 <ProfileInviteFriend
                   {...props}
+                  authUser={authUser}
                   showError={showError.bind(this)}
                 />
               )}
@@ -188,7 +190,11 @@ class SettingsPage extends React.Component {
               exact
               path="/newtab/account/"
               render={props => (
-                <AccountView {...props} showError={showError.bind(this)} />
+                <AccountView
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
               )}
             />
             {/* Redirect any incorrect paths */}

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -1,18 +1,25 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import WidgetsSettings from 'js/components/Settings/Widgets/WidgetsSettingsContainer'
-import AuthUserComponent from 'js/components/General/AuthUserComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
+import withUser from 'js/components/General/withUser'
 
 class WidgetsSettingsView extends React.Component {
   render() {
+    const { authUser } = this.props
     return (
-      <AuthUserComponent>
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
         <QueryRenderer
           environment={environment}
           query={graphql`
@@ -25,6 +32,9 @@ class WidgetsSettingsView extends React.Component {
               }
             }
           `}
+          variables={{
+            userId: authUser.id,
+          }}
           render={({ error, props }) => {
             if (error) {
               logger.error(error)
@@ -46,9 +56,18 @@ class WidgetsSettingsView extends React.Component {
             )
           }}
         />
-      </AuthUserComponent>
+      </div>
     )
   }
 }
 
-export default WidgetsSettingsView
+WidgetsSettingsView.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  showError: PropTypes.func.isRequired,
+}
+
+WidgetsSettingsView.defaultProps = {}
+
+export default withUser()(WidgetsSettingsView)

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -8,7 +8,6 @@ import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperCom
 import WidgetsSettings from 'js/components/Settings/Widgets/WidgetsSettingsContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
-import withUser from 'js/components/General/withUser'
 
 class WidgetsSettingsView extends React.Component {
   render() {
@@ -70,5 +69,4 @@ WidgetsSettingsView.propTypes = {
 
 WidgetsSettingsView.defaultProps = {}
 
-// TODO: receive authUser from parent
-export default withUser()(WidgetsSettingsView)
+export default WidgetsSettingsView

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -70,4 +70,5 @@ WidgetsSettingsView.propTypes = {
 
 WidgetsSettingsView.defaultProps = {}
 
+// TODO: receive authUser from parent
 export default withUser()(WidgetsSettingsView)

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
@@ -37,7 +37,11 @@ describe('WidgetsSettingsView', () => {
 
   it('sets a root style of 100% width and height', () => {
     const mockProps = getMockProps()
-    shallow(<WidgetsSettingsView {...mockProps} />)
+    const wrapper = shallow(<WidgetsSettingsView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
   })
 
   it('includes a QueryRenderer', () => {

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
@@ -19,48 +19,30 @@ afterEach(() => {
 })
 
 const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
   showError: jest.fn(),
-})
-
-describe('withUser HOC in WidgetsSettingsView', () => {
-  beforeEach(() => {
-    jest.resetModules()
-  })
-
-  it('is called with the expected options', () => {
-    const withUser = require('js/components/General/withUser').default
-
-    /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/Widgets/WidgetsSettingsView').default
-    expect(withUser).toHaveBeenCalledWith()
-  })
-
-  it('wraps the WidgetsSettingsView component', () => {
-    const {
-      __mockWithUserWrappedFunction,
-    } = require('js/components/General/withUser')
-
-    /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/Widgets/WidgetsSettingsView').default
-    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
-    expect(wrappedComponent.name).toEqual('WidgetsSettingsView')
-  })
 })
 
 describe('WidgetsSettingsView', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()
-    shallow(<WidgetsSettingsView {...mockProps} />).dive()
+    shallow(<WidgetsSettingsView {...mockProps} />)
   })
 
   it('sets a root style of 100% width and height', () => {
     const mockProps = getMockProps()
-    shallow(<WidgetsSettingsView {...mockProps} />).dive()
+    shallow(<WidgetsSettingsView {...mockProps} />)
   })
 
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<WidgetsSettingsView {...mockProps} />).dive()
+    const wrapper = shallow(<WidgetsSettingsView {...mockProps} />)
     expect(wrapper.find(QueryRenderer).exists()).toBe(true)
   })
 
@@ -68,7 +50,7 @@ describe('WidgetsSettingsView', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
     expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
-      userId: 'abc123xyz456', // default value in `withUser` mock
+      userId: 'example-user-id', // from the authUser prop
     })
   })
 

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
@@ -22,6 +22,22 @@ const getMockProps = () => ({
   showError: jest.fn(),
 })
 
+describe('withUser HOC in WidgetsSettingsView', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('is called with the expected options', () => {
+    const withUser = require('js/components/General/withUser').default
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/Widgets/WidgetsSettingsView').default
+    expect(withUser).toHaveBeenCalledWith()
+  })
+
+  // TODO: test it actually wraps the WidgetsSettingsView component
+})
+
 describe('WidgetsSettingsView', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
@@ -1,0 +1,131 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import WidgetsSettings from 'js/components/Settings/Widgets/WidgetsSettingsContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Widgets/WidgetsSettingsContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  showError: jest.fn(),
+})
+
+describe('WidgetsSettingsView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<WidgetsSettingsView {...mockProps} />).dive()
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    shallow(<WidgetsSettingsView {...mockProps} />).dive()
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<WidgetsSettingsView {...mockProps} />).dive()
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'abc123xyz456', // default value in `withUser` mock
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
+    expect(wrapper.find(WidgetsSettings).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
+    expect(wrapper.find(WidgetsSettings).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      app: {
+        some: 'value',
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
+    expect(wrapper.find(WidgetsSettings).props()).toEqual({
+      app: fakeQueryRendererProps.app,
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(WidgetsSettings).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading the widget settings :('
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
@@ -35,7 +35,16 @@ describe('withUser HOC in WidgetsSettingsView', () => {
     expect(withUser).toHaveBeenCalledWith()
   })
 
-  // TODO: test it actually wraps the WidgetsSettingsView component
+  it('wraps the WidgetsSettingsView component', () => {
+    const {
+      __mockWithUserWrappedFunction,
+    } = require('js/components/General/withUser')
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/Widgets/WidgetsSettingsView').default
+    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
+    expect(wrappedComponent.name).toEqual('WidgetsSettingsView')
+  })
 })
 
 describe('WidgetsSettingsView', () => {

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -231,6 +231,14 @@ describe('SettingsPage', () => {
     )
     expect(ThisRouteComponentElem.type()).toEqual(ProfileDonateHearts)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
       expect.any(Function)
     )
@@ -263,6 +271,14 @@ describe('SettingsPage', () => {
     )
     expect(ThisRouteComponentElem.type()).toEqual(ProfileInviteFriend)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
       expect.any(Function)
     )
@@ -295,6 +311,14 @@ describe('SettingsPage', () => {
     )
     expect(ThisRouteComponentElem.type()).toEqual(AccountView)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
       expect.any(Function)
     )

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -6,7 +6,7 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-// import ErrorMessage from 'js/components/General/ErrorMessage'
+import ErrorMessage from 'js/components/General/ErrorMessage'
 // import Logo from 'js/components/Logo/Logo'
 import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
@@ -324,8 +324,32 @@ describe('SettingsPage', () => {
     expect(redirectElem.prop('to')).toEqual('/newtab/account/')
   })
 
+  it('displays an error message when a child route calls the showError prop', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+
+    // We should not show an error message yet.
+    expect(wrapper.find(ErrorMessage).exists()).toBe(false)
+
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    const showErrorFunc = ThisRouteComponentElem.prop('showError')
+    showErrorFunc('We made a mistake :(')
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
+      'We made a mistake :('
+    )
+  })
+
   // TODO:
-  //  - add tests for the showError prop functionality
   //  - pass authUser to WidgetsSettingsView and test for that prop; remove
   //    the withUser HOC from WidgetsSettingsView
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -191,6 +191,14 @@ describe('SettingsPage', () => {
     )
     expect(ThisRouteComponentElem.type()).toEqual(ProfileStatsView)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
       expect.any(Function)
     )

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -30,6 +30,31 @@ afterEach(() => {
 
 const getMockProps = () => ({})
 
+describe('withUser HOC in SettingsPage', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('is called with the expected options', () => {
+    const withUser = require('js/components/General/withUser').default
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/SettingsPageComponent').default
+    expect(withUser).toHaveBeenCalledWith()
+  })
+
+  it('wraps the SettingsPage component', () => {
+    const {
+      __mockWithUserWrappedFunction,
+    } = require('js/components/General/withUser')
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/SettingsPageComponent').default
+    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
+    expect(wrappedComponent.name).toEqual('SettingsPage')
+  })
+})
+
 describe('SettingsPage', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -10,7 +10,7 @@ import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 // import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 // import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 // import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
-// import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 // import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 
 jest.mock('js/components/Settings/Account/AccountView')
@@ -58,6 +58,27 @@ describe('withUser HOC in SettingsPage', () => {
 describe('SettingsPage', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()
-    shallow(<SettingsPage {...mockProps} />).dive()
+    shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+  })
+
+  it('renders the expected side menu items', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const menuItems = wrapper.find(SettingsMenuItem)
+    const expectedMenuItems = [
+      'Widgets',
+      'Background',
+      'Your Stats',
+      'Donate Hearts',
+      'Invite Friends',
+      'Account',
+    ]
+    menuItems.forEach((menuItem, index) => {
+      expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
+    })
   })
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -116,4 +116,11 @@ describe('SettingsPage', () => {
       expect.any(Function)
     )
   })
+
+  // TODO:
+  //  - add tests for remaining route components
+  //  - add tests for existence of the Redirect components
+  //  - add tests for the showError prop functionality
+  //  - pass authUser to WidgetsSettingsView and test for that prop; remove
+  //    the withUser HOC from WidgetsSettingsView
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -111,6 +111,14 @@ describe('SettingsPage', () => {
     )
     expect(ThisRouteComponentElem.type()).toEqual(WidgetsSettingsView)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
       expect.any(Function)
     )
@@ -350,6 +358,5 @@ describe('SettingsPage', () => {
   })
 
   // TODO:
-  //  - pass authUser to WidgetsSettingsView and test for that prop; remove
-  //    the withUser HOC from WidgetsSettingsView
+  //  - pass authUser to other child components
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Route, Switch } from 'react-router-dom'
+import { Redirect, Route, Switch } from 'react-router-dom'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
@@ -276,8 +276,55 @@ describe('SettingsPage', () => {
     )
   })
 
+  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
+  })
+
+  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
+  })
+
+  it('redirects from any nonexistent profile page to the profile stats page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/profile/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/profile/stats/')
+  })
+
+  it('redirects from any nonexistent account page to the main account page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/account/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/account/')
+  })
+
   // TODO:
-  //  - add tests for existence of the Redirect components
   //  - add tests for the showError prop functionality
   //  - pass authUser to WidgetsSettingsView and test for that prop; remove
   //    the withUser HOC from WidgetsSettingsView

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -396,7 +396,4 @@ describe('SettingsPage', () => {
       'We made a mistake :('
     )
   })
-
-  // TODO:
-  //  - pass authUser to other child components
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
+import { Route, Switch } from 'react-router-dom'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 // import AccountView from 'js/components/Settings/Account/AccountView'
 // import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
@@ -11,8 +12,9 @@ import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 // import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 // import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
-// import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 
+jest.mock('react-router-dom')
 jest.mock('js/components/Settings/Account/AccountView')
 jest.mock('js/components/Settings/Background/BackgroundSettingsView')
 jest.mock('js/components/General/ErrorMessage')
@@ -80,5 +82,38 @@ describe('SettingsPage', () => {
     menuItems.forEach((menuItem, index) => {
       expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
     })
+  })
+
+  it('includes a WidgetsSettingsView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected WidgetsSettingsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    expect(routeElem.exists()).toBe(true)
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(WidgetsSettingsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
   })
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -151,6 +151,14 @@ describe('SettingsPage', () => {
     )
     expect(ThisRouteComponentElem.type()).toEqual(BackgroundSettingsView)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
       expect.any(Function)
     )

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -4,13 +4,13 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { Route, Switch } from 'react-router-dom'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
-// import AccountView from 'js/components/Settings/Account/AccountView'
-// import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+import AccountView from 'js/components/Settings/Account/AccountView'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
 // import ErrorMessage from 'js/components/General/ErrorMessage'
 // import Logo from 'js/components/Logo/Logo'
-// import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
-// import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
-// import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 
@@ -105,7 +105,6 @@ describe('SettingsPage', () => {
       .find(Switch)
       .find(Route)
       .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    expect(routeElem.exists()).toBe(true)
     const ThisRouteComponent = routeElem.prop('render')
     const ThisRouteComponentElem = shallow(
       <ThisRouteComponent fakeProp={'abc'} />
@@ -117,8 +116,167 @@ describe('SettingsPage', () => {
     )
   })
 
+  it('includes a BackgroundSettingsView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected BackgroundSettingsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(BackgroundSettingsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a ProfileStatsView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileStatsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileStatsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a ProfileDonateHearts route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileDonateHearts component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileDonateHearts)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a ProfileInviteFriend route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileInviteFriend component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileInviteFriend)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a AccountView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected AccountView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(AccountView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
   // TODO:
-  //  - add tests for remaining route components
   //  - add tests for existence of the Redirect components
   //  - add tests for the showError prop functionality
   //  - pass authUser to WidgetsSettingsView and test for that prop; remove

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import SettingsPage from 'js/components/Settings/SettingsPageComponent'
+// import AccountView from 'js/components/Settings/Account/AccountView'
+// import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+// import ErrorMessage from 'js/components/General/ErrorMessage'
+// import Logo from 'js/components/Logo/Logo'
+// import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+// import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+// import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+// import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+// import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+
+jest.mock('js/components/Settings/Account/AccountView')
+jest.mock('js/components/Settings/Background/BackgroundSettingsView')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/Logo/Logo')
+jest.mock('js/components/Settings/Profile/ProfileStatsView')
+jest.mock('js/components/Settings/Profile/ProfileDonateHeartsView')
+jest.mock('js/components/Settings/Profile/ProfileInviteFriendView')
+jest.mock('js/components/Settings/SettingsMenuItem')
+jest.mock('js/components/Settings/Widgets/WidgetsSettingsView')
+jest.mock('js/components/General/withUser')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({})
+
+describe('SettingsPage', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<SettingsPage {...mockProps} />).dive()
+  })
+})


### PR DESCRIPTION
The `withUser` higher-order component is a cleaner and more flexible way to get the user ID than the AuthUser component. It also removes the invisible "magic" of setting the userId in QueryRenderer variables.

This PR replaces `AuthUser` in the settings page views. Another PR should replace it in the Dashboard component, at which point we can deprecate `AuthUser`.