### PR TITLE
Set resource DeletionPolicy in Cloudformation stack

### DIFF
--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -553,6 +553,7 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
+      DeletionPolicy: Retain
 
     backgroundImagesTable:  
       Type: AWS::DynamoDB::Table
@@ -662,20 +663,21 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    referralLinkClickLog:  
-      Type: AWS::DynamoDB::Table
-      Properties:  
-        TableName: ReferralLinkClickLog-${self:provider.stage}
-        KeySchema:
-          - AttributeName: userId
-            KeyType: HASH
-          - AttributeName: timestamp
-            KeyType: RANGE
-        AttributeDefinitions:
-          - AttributeName: userId
-            AttributeType: S
-          - AttributeName: timestamp
-            AttributeType: S
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+    ### Deleting to confirm the resource will be destroyed by default.
+    # referralLinkClickLog:  
+    #   Type: AWS::DynamoDB::Table
+    #   Properties:  
+    #     TableName: ReferralLinkClickLog-${self:provider.stage}
+    #     KeySchema:
+    #       - AttributeName: userId
+    #         KeyType: HASH
+    #       - AttributeName: timestamp
+    #         KeyType: RANGE
+    #     AttributeDefinitions:
+    #       - AttributeName: userId
+    #         AttributeType: S
+    #       - AttributeName: timestamp
+    #         AttributeType: S
+    #     ProvisionedThroughput:
+    #       ReadCapacityUnits: 1
+    #       WriteCapacityUnits: 1

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -83,15 +83,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      userDataConsentLogTable:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # userDataConsentLogTable:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
       backgroundImagesTable:
         read:
           minimum: 1
@@ -212,15 +212,15 @@ custom:
           minimum: 20
           maximum: 9001
           usage: 0.60
-      userDataConsentLogTable:
-        read:
-          minimum: 1
-          maximum: 9001
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 9001
-          usage: 0.60
+      # userDataConsentLogTable:
+      #   read:
+      #     minimum: 1
+      #     maximum: 9001
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 9001
+      #     usage: 0.60
       backgroundImagesTable:
         read:
           minimum: 5
@@ -343,15 +343,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.usage}
-    - table: userDataConsentLogTable
-      read:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.usage}
-      write:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.usage}
+    # - table: userDataConsentLogTable
+    #   read:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.usage}
+    #   write:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.usage}
     - table: backgroundImagesTable
       read:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.backgroundImagesTable.read.minimum}
@@ -536,24 +536,24 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    userDataConsentLogTable:  
-      Type: AWS::DynamoDB::Table
-      Properties:  
-        TableName: UserDataConsentLog-${self:provider.stage}
-        KeySchema:
-          - AttributeName: userId
-            KeyType: HASH
-          - AttributeName: timestamp
-            KeyType: RANGE
-        AttributeDefinitions:
-          - AttributeName: userId
-            AttributeType: S
-          - AttributeName: timestamp
-            AttributeType: S
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
-      DeletionPolicy: Retain
+    # userDataConsentLogTable:  
+    #   Type: AWS::DynamoDB::Table
+    #   Properties:  
+    #     TableName: UserDataConsentLog-${self:provider.stage}
+    #     KeySchema:
+    #       - AttributeName: userId
+    #         KeyType: HASH
+    #       - AttributeName: timestamp
+    #         KeyType: RANGE
+    #     AttributeDefinitions:
+    #       - AttributeName: userId
+    #         AttributeType: S
+    #       - AttributeName: timestamp
+    #         AttributeType: S
+    #     ProvisionedThroughput:
+    #       ReadCapacityUnits: 1
+    #       WriteCapacityUnits: 1
+    #   DeletionPolicy: Retain
 
     backgroundImagesTable:  
       Type: AWS::DynamoDB::Table

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -83,15 +83,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      # userDataConsentLogTable:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      userDataConsentLogTable:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
       backgroundImagesTable:
         read:
           minimum: 1
@@ -137,15 +137,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      # referralLinkClickLog:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      referralLinkClickLog:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
     # prod stage table capacities
     prod: 
       usersTable:
@@ -212,15 +212,15 @@ custom:
           minimum: 20
           maximum: 9001
           usage: 0.60
-      # userDataConsentLogTable:
-      #   read:
-      #     minimum: 1
-      #     maximum: 9001
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 9001
-      #     usage: 0.60
+      userDataConsentLogTable:
+        read:
+          minimum: 1
+          maximum: 9001
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 9001
+          usage: 0.60
       backgroundImagesTable:
         read:
           minimum: 5
@@ -266,15 +266,15 @@ custom:
           minimum: 10
           maximum: 9001
           usage: 0.60
-      # referralLinkClickLog:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      referralLinkClickLog:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
 
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   capacities:
@@ -343,15 +343,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.userRevenueLogTable.write.usage}
-    # - table: userDataConsentLogTable
-    #   read:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.usage}
-    #   write:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.usage}
+    - table: userDataConsentLogTable
+      read:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.read.usage}
+      write:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.userDataConsentLogTable.write.usage}
     - table: backgroundImagesTable
       read:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.backgroundImagesTable.read.minimum}
@@ -401,15 +401,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.usage}
-    # - table: referralLinkClickLog
-    #   read:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
-    #   write:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
+    - table: referralLinkClickLog
+      read:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
+      write:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
 
 resources:
   Resources:
@@ -536,24 +536,24 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    # userDataConsentLogTable:  
-    #   Type: AWS::DynamoDB::Table
-    #   Properties:  
-    #     TableName: UserDataConsentLog-${self:provider.stage}
-    #     KeySchema:
-    #       - AttributeName: userId
-    #         KeyType: HASH
-    #       - AttributeName: timestamp
-    #         KeyType: RANGE
-    #     AttributeDefinitions:
-    #       - AttributeName: userId
-    #         AttributeType: S
-    #       - AttributeName: timestamp
-    #         AttributeType: S
-    #     ProvisionedThroughput:
-    #       ReadCapacityUnits: 1
-    #       WriteCapacityUnits: 1
-    #   DeletionPolicy: Retain
+    userDataConsentLogTable:  
+      Type: AWS::DynamoDB::Table
+      Properties:  
+        TableName: UserDataConsentLog-${self:provider.stage}
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+          - AttributeName: timestamp
+            KeyType: RANGE
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: timestamp
+            AttributeType: S
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+      DeletionPolicy: Retain
 
     backgroundImagesTable:  
       Type: AWS::DynamoDB::Table
@@ -663,21 +663,20 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    ### Deleting to confirm the resource will be destroyed by default.
-    # referralLinkClickLog:  
-    #   Type: AWS::DynamoDB::Table
-    #   Properties:  
-    #     TableName: ReferralLinkClickLog-${self:provider.stage}
-    #     KeySchema:
-    #       - AttributeName: userId
-    #         KeyType: HASH
-    #       - AttributeName: timestamp
-    #         KeyType: RANGE
-    #     AttributeDefinitions:
-    #       - AttributeName: userId
-    #         AttributeType: S
-    #       - AttributeName: timestamp
-    #         AttributeType: S
-    #     ProvisionedThroughput:
-    #       ReadCapacityUnits: 1
-    #       WriteCapacityUnits: 1
+    referralLinkClickLog:  
+      Type: AWS::DynamoDB::Table
+      Properties:  
+        TableName: ReferralLinkClickLog-${self:provider.stage}
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+          - AttributeName: timestamp
+            KeyType: RANGE
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: timestamp
+            AttributeType: S
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -137,15 +137,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      referralLinkClickLog:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # referralLinkClickLog:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
     # prod stage table capacities
     prod: 
       usersTable:
@@ -266,15 +266,15 @@ custom:
           minimum: 10
           maximum: 9001
           usage: 0.60
-      referralLinkClickLog:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # referralLinkClickLog:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
 
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   capacities:
@@ -401,15 +401,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.usage}
-    - table: referralLinkClickLog
-      read:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
-      write:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
+    # - table: referralLinkClickLog
+    #   read:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
+    #   write:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
 
 resources:
   Resources:

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -416,6 +416,7 @@ resources:
 
     usersTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: Users-${self:provider.stage}
         KeySchema:
@@ -442,6 +443,7 @@ resources:
 
     charitiesTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: Charities-${self:provider.stage}
         KeySchema:
@@ -456,6 +458,7 @@ resources:
 
     widgetsTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: Widgets-${self:provider.stage}
         KeySchema:
@@ -470,6 +473,7 @@ resources:
 
     userLevelsTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: UserLevels-${self:provider.stage}
         KeySchema:
@@ -484,6 +488,7 @@ resources:
 
     vcDonationLogTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: VcDonationLog-${self:provider.stage}
         KeySchema:
@@ -502,6 +507,7 @@ resources:
 
     vcDonationByCharityTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: VcDonationByCharity-${self:provider.stage}
         KeySchema:
@@ -520,6 +526,7 @@ resources:
 
     userRevenueLogTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: UserRevenueLog-${self:provider.stage}
         KeySchema:
@@ -538,6 +545,7 @@ resources:
 
     userDataConsentLogTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: UserDataConsentLog-${self:provider.stage}
         KeySchema:
@@ -553,10 +561,10 @@ resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
-      DeletionPolicy: Retain
 
     backgroundImagesTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: BackgroundImages-${self:provider.stage}
         KeySchema:
@@ -571,6 +579,7 @@ resources:
 
     userWidgetsTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: UserWidgets-${self:provider.stage}
         KeySchema:
@@ -599,6 +608,7 @@ resources:
 
     userTabsLogTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: UserTabsLog-${self:provider.stage}
         KeySchema:
@@ -617,6 +627,7 @@ resources:
 
     userSearchLogTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: UserSearchLog-${self:provider.stage}
         KeySchema:
@@ -635,6 +646,7 @@ resources:
 
     referralDataLogTable:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: ReferralDataLog-${self:provider.stage}
         KeySchema:
@@ -665,6 +677,7 @@ resources:
 
     referralLinkClickLog:  
       Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
       Properties:  
         TableName: ReferralLinkClickLog-${self:provider.stage}
         KeySchema:

--- a/s3/serverless.yml
+++ b/s3/serverless.yml
@@ -21,6 +21,7 @@ resources:
     # S3 Bucket
     TabMediaBucket:
       Type: AWS::S3::Bucket
+      DeletionPolicy: Retain
       Properties:
         BucketName: ${self:custom.s3Bucket}
         AccessControl: PublicRead
@@ -31,6 +32,7 @@ resources:
     # Bucket policy (public read)
     TabS3BucketPolicy:
       Type: AWS::S3::BucketPolicy
+      DeletionPolicy: Retain
       Properties:
         Bucket:
           Ref: TabMediaBucket
@@ -46,6 +48,7 @@ resources:
     # Serve media through Cloudfront.
     WebAppCloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
+      DeletionPolicy: Retain
       Properties:
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html
         DistributionConfig:

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -35,6 +35,7 @@ resources:
     # New tab app S3 bucket
     TabS3Bucket:
       Type: AWS::S3::Bucket
+      DeletionPolicy: Retain
       Properties:
         BucketName: ${self:custom.newTabAppS3Bucket}
         AccessControl: PublicRead
@@ -48,6 +49,7 @@ resources:
           ErrorDocument: newtab/index.html
     TabS3BucketPolicy:
       Type: AWS::S3::BucketPolicy
+      DeletionPolicy: Retain
       Properties:
         Bucket:
           Ref: TabS3Bucket
@@ -63,6 +65,7 @@ resources:
     # Search app S3 bucket
     SearchAppS3Bucket:
       Type: AWS::S3::Bucket
+      DeletionPolicy: Retain
       Properties:
         BucketName: ${self:custom.searchAppS3Bucket}
         AccessControl: PublicRead
@@ -71,6 +74,7 @@ resources:
           ErrorDocument: search/index.html
     SearchAppS3BucketPolicy:
       Type: AWS::S3::BucketPolicy
+      DeletionPolicy: Retain
       Properties:
         Bucket:
           Ref: SearchAppS3Bucket
@@ -86,6 +90,7 @@ resources:
     # Serve the app through Cloudfront.
     WebAppCloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
+      DeletionPolicy: Retain
       Properties:
         # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html
         DistributionConfig:


### PR DESCRIPTION
Addresses part of #582 

By default, we will retain these resources even when the stack deletes them:
* DynamoDB tables
* S3 buckets
* Cloudfront distributions

In previous commits, I confirmed DynamoDB tables are retained after deletion.
