### PR TITLE
Set restrictive stack policies on all stacks

### DIFF
--- a/dynamodb/package.json
+++ b/dynamodb/package.json
@@ -41,7 +41,7 @@
     "format": "prettier \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "format:fix": "yarn run format --write",
     "lint": "eslint \"**/*.{js,jsx}\"",
-    "deploy": "serverless deploy -v"
+    "deploy": "serverless deploy -v --force"
   },
   "repository": {
     "type": "git",

--- a/dynamodb/package.json
+++ b/dynamodb/package.json
@@ -41,7 +41,7 @@
     "format": "prettier \"**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
     "format:fix": "yarn run format --write",
     "lint": "eslint \"**/*.{js,jsx}\"",
-    "deploy": "serverless deploy -v --force"
+    "deploy": "serverless deploy -v"
   },
   "repository": {
     "type": "git",

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -7,14 +7,14 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
-  # Let's be conservative and prevent any unexpected changes
-  # to the stack. See:
-  # https://github.com/gladly-team/tab/issues/582
-  stackPolicy:
-    - Effect: Deny
-      Principal: "*"
-      Action: "Update:*"
-      Resource: "*"
+  # # Let's be conservative and prevent any unexpected changes
+  # # to the stack. See:
+  # # https://github.com/gladly-team/tab/issues/582
+  # stackPolicy:
+  #   - Effect: Deny
+  #     Principal: "*"
+  #     Action: "Update:*"
+  #     Resource: "*"
 
 plugins:
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -8,6 +8,15 @@ provider:
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
 
+# Let's be conservative and prevent any unexpected changes
+# to the stack. See:
+# https://github.com/gladly-team/tab/issues/582
+stackPolicy:
+  - Effect: Deny
+    Principal: "*"
+    Action: "Update:*"
+    Resource: "*"
+
 plugins:
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-examples-application-autoscaling

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -145,15 +145,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      referralLinkClickLog:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # referralLinkClickLog:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
     # prod stage table capacities
     prod: 
       usersTable:
@@ -274,15 +274,15 @@ custom:
           minimum: 10
           maximum: 9001
           usage: 0.60
-      referralLinkClickLog:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # referralLinkClickLog:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
 
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   capacities:
@@ -409,15 +409,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.usage}
-    - table: referralLinkClickLog
-      read:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
-      write:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
+    # - table: referralLinkClickLog
+    #   read:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
+    #   write:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
 
 resources:
   Resources:
@@ -683,21 +683,21 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    referralLinkClickLog:  
-      Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
-      Properties:  
-        TableName: ReferralLinkClickLog-${self:provider.stage}
-        KeySchema:
-          - AttributeName: userId
-            KeyType: HASH
-          - AttributeName: timestamp
-            KeyType: RANGE
-        AttributeDefinitions:
-          - AttributeName: userId
-            AttributeType: S
-          - AttributeName: timestamp
-            AttributeType: S
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+    # referralLinkClickLog:  
+    #   Type: AWS::DynamoDB::Table
+    #   DeletionPolicy: Retain
+    #   Properties:  
+    #     TableName: ReferralLinkClickLog-${self:provider.stage}
+    #     KeySchema:
+    #       - AttributeName: userId
+    #         KeyType: HASH
+    #       - AttributeName: timestamp
+    #         KeyType: RANGE
+    #     AttributeDefinitions:
+    #       - AttributeName: userId
+    #         AttributeType: S
+    #       - AttributeName: timestamp
+    #         AttributeType: S
+    #     ProvisionedThroughput:
+    #       ReadCapacityUnits: 1
+    #       WriteCapacityUnits: 1

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -7,14 +7,14 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
-  # # Let's be conservative and prevent any unexpected changes
-  # # to the stack. See:
-  # # https://github.com/gladly-team/tab/issues/582
-  # stackPolicy:
-  #   - Effect: Deny
-  #     Principal: "*"
-  #     Action: "Update:*"
-  #     Resource: "*"
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
 
 plugins:
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -146,15 +146,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      # referralLinkClickLog:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      referralLinkClickLog:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
     # prod stage table capacities
     prod: 
       usersTable:
@@ -275,15 +275,15 @@ custom:
           minimum: 10
           maximum: 9001
           usage: 0.60
-      # referralLinkClickLog:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      referralLinkClickLog:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
 
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   capacities:
@@ -410,15 +410,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.usage}
-    # - table: referralLinkClickLog
-    #   read:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
-    #   write:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
+    - table: referralLinkClickLog
+      read:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
+      write:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
 
 resources:
   Resources:
@@ -684,21 +684,21 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    # referralLinkClickLog:  
-    #   Type: AWS::DynamoDB::Table
-    #   DeletionPolicy: Retain
-    #   Properties:  
-    #     TableName: ReferralLinkClickLog-${self:provider.stage}
-    #     KeySchema:
-    #       - AttributeName: userId
-    #         KeyType: HASH
-    #       - AttributeName: timestamp
-    #         KeyType: RANGE
-    #     AttributeDefinitions:
-    #       - AttributeName: userId
-    #         AttributeType: S
-    #       - AttributeName: timestamp
-    #         AttributeType: S
-    #     ProvisionedThroughput:
-    #       ReadCapacityUnits: 1
-    #       WriteCapacityUnits: 1
+    referralLinkClickLog:  
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
+      Properties:  
+        TableName: ReferralLinkClickLog-${self:provider.stage}
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+          - AttributeName: timestamp
+            KeyType: RANGE
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: timestamp
+            AttributeType: S
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -146,15 +146,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      referralLinkClickLog:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # referralLinkClickLog:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
     # prod stage table capacities
     prod: 
       usersTable:
@@ -275,15 +275,15 @@ custom:
           minimum: 10
           maximum: 9001
           usage: 0.60
-      referralLinkClickLog:
-        read:
-          minimum: 1
-          maximum: 1000
-          usage: 0.75
-        write:
-          minimum: 1
-          maximum: 1000
-          usage: 0.60
+      # referralLinkClickLog:
+      #   read:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.75
+      #   write:
+      #     minimum: 1
+      #     maximum: 1000
+      #     usage: 0.60
 
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   capacities:
@@ -410,15 +410,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.usage}
-    - table: referralLinkClickLog
-      read:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
-      write:
-        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
-        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
-        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
+    # - table: referralLinkClickLog
+    #   read:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
+    #   write:
+    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
+    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
+    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
 
 resources:
   Resources:
@@ -684,21 +684,21 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    referralLinkClickLog:  
-      Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
-      Properties:  
-        TableName: ReferralLinkClickLog-${self:provider.stage}
-        KeySchema:
-          - AttributeName: userId
-            KeyType: HASH
-          - AttributeName: timestamp
-            KeyType: RANGE
-        AttributeDefinitions:
-          - AttributeName: userId
-            AttributeType: S
-          - AttributeName: timestamp
-            AttributeType: S
-        ProvisionedThroughput:
-          ReadCapacityUnits: 1
-          WriteCapacityUnits: 1
+    # referralLinkClickLog:  
+    #   Type: AWS::DynamoDB::Table
+    #   DeletionPolicy: Retain
+    #   Properties:  
+    #     TableName: ReferralLinkClickLog-${self:provider.stage}
+    #     KeySchema:
+    #       - AttributeName: userId
+    #         KeyType: HASH
+    #       - AttributeName: timestamp
+    #         KeyType: RANGE
+    #     AttributeDefinitions:
+    #       - AttributeName: userId
+    #         AttributeType: S
+    #       - AttributeName: timestamp
+    #         AttributeType: S
+    #     ProvisionedThroughput:
+    #       ReadCapacityUnits: 1
+    #       WriteCapacityUnits: 1

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -11,7 +11,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Deny
+    - Effect: Allow # TODO: change to Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -145,15 +145,15 @@ custom:
           minimum: 1
           maximum: 1000
           usage: 0.60
-      # referralLinkClickLog:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      referralLinkClickLog:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
     # prod stage table capacities
     prod: 
       usersTable:
@@ -274,15 +274,15 @@ custom:
           minimum: 10
           maximum: 9001
           usage: 0.60
-      # referralLinkClickLog:
-      #   read:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.75
-      #   write:
-      #     minimum: 1
-      #     maximum: 1000
-      #     usage: 0.60
+      referralLinkClickLog:
+        read:
+          minimum: 1
+          maximum: 1000
+          usage: 0.75
+        write:
+          minimum: 1
+          maximum: 1000
+          usage: 0.60
 
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling
   capacities:
@@ -409,15 +409,15 @@ custom:
         minimum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.minimum}
         maximum: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.maximum}
         usage: ${self:custom.customCapacities.${self:provider.stage}.referralDataLogTable.write.usage}
-    # - table: referralLinkClickLog
-    #   read:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
-    #   write:
-    #     minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
-    #     maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
-    #     usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
+    - table: referralLinkClickLog
+      read:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.read.usage}
+      write:
+        minimum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.minimum}
+        maximum: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.maximum}
+        usage: ${self:custom.customCapacities.${self:provider.stage}.referralLinkClickLog.write.usage}
 
 resources:
   Resources:
@@ -683,21 +683,21 @@ resources:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
 
-    # referralLinkClickLog:  
-    #   Type: AWS::DynamoDB::Table
-    #   DeletionPolicy: Retain
-    #   Properties:  
-    #     TableName: ReferralLinkClickLog-${self:provider.stage}
-    #     KeySchema:
-    #       - AttributeName: userId
-    #         KeyType: HASH
-    #       - AttributeName: timestamp
-    #         KeyType: RANGE
-    #     AttributeDefinitions:
-    #       - AttributeName: userId
-    #         AttributeType: S
-    #       - AttributeName: timestamp
-    #         AttributeType: S
-    #     ProvisionedThroughput:
-    #       ReadCapacityUnits: 1
-    #       WriteCapacityUnits: 1
+    referralLinkClickLog:  
+      Type: AWS::DynamoDB::Table
+      DeletionPolicy: Retain
+      Properties:  
+        TableName: ReferralLinkClickLog-${self:provider.stage}
+        KeySchema:
+          - AttributeName: userId
+            KeyType: HASH
+          - AttributeName: timestamp
+            KeyType: RANGE
+        AttributeDefinitions:
+          - AttributeName: userId
+            AttributeType: S
+          - AttributeName: timestamp
+            AttributeType: S
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -7,15 +7,14 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
-
-# Let's be conservative and prevent any unexpected changes
-# to the stack. See:
-# https://github.com/gladly-team/tab/issues/582
-stackPolicy:
-  - Effect: Deny
-    Principal: "*"
-    Action: "Update:*"
-    Resource: "*"
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
 
 plugins:
   # https://github.com/sbstjn/serverless-dynamodb-autoscaling

--- a/dynamodb/serverless.yml
+++ b/dynamodb/serverless.yml
@@ -11,7 +11,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Allow # TODO: change to Deny
+    - Effect: Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -62,7 +62,7 @@
     "build": "rm -rf ./build && yarn run build:compile",
     "build:compile": "cross-env NODE_ENV=production babel --out-dir='build' --ignore='build,coverage,__mocks__,__tests__,integration-tests,node_modules,server.js' ./ && cp ./database/userRevenue/amazon-cpm-codes.json ./build/database/userRevenue/amazon-cpm-codes.json && yarn run build:config",
     "build:config": "NODE_ENV=production node -r dotenv-extended/config ./scripts/generateConfig.js",
-    "deploy": "yarn run build && serverless deploy -v",
+    "deploy": "yarn run build && serverless deploy -v --force",
     "update-schema": "babel-node ./scripts/updateSchema.js",
     "test": "npm-run-all -s lint test:run test:codecov",
     "test:run": "jest --testPathIgnorePatterns=integration-tests --maxWorkers=2 --coverage --watchAll=false",

--- a/graphql/package.json
+++ b/graphql/package.json
@@ -62,7 +62,7 @@
     "build": "rm -rf ./build && yarn run build:compile",
     "build:compile": "cross-env NODE_ENV=production babel --out-dir='build' --ignore='build,coverage,__mocks__,__tests__,integration-tests,node_modules,server.js' ./ && cp ./database/userRevenue/amazon-cpm-codes.json ./build/database/userRevenue/amazon-cpm-codes.json && yarn run build:config",
     "build:config": "NODE_ENV=production node -r dotenv-extended/config ./scripts/generateConfig.js",
-    "deploy": "yarn run build && serverless deploy -v --force",
+    "deploy": "yarn run build && serverless deploy -v",
     "update-schema": "babel-node ./scripts/updateSchema.js",
     "test": "npm-run-all -s lint test:run test:codecov",
     "test:run": "jest --testPathIgnorePatterns=integration-tests --maxWorkers=2 --coverage --watchAll=false",

--- a/graphql/serverless.yml
+++ b/graphql/serverless.yml
@@ -22,7 +22,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Allow # TODO: change to Deny
+    - Effect: Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/graphql/serverless.yml
+++ b/graphql/serverless.yml
@@ -22,7 +22,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Deny
+    - Effect: Allow # TODO: change to Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/graphql/serverless.yml
+++ b/graphql/serverless.yml
@@ -18,6 +18,14 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
   # Rules for fine-grained DynamoDB access:
   #   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/specifying-conditions.html
   #   https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/using-identity-based-policies.html

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "start": "nodemon -e js,json,yml --exec \"babel-node\" ./server.js",
-    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v --force && cp serverless-lambda-edge.yml serverless.yml && serverless deploy -v --force ",
+    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v && cp serverless-lambda-edge.yml serverless.yml && serverless deploy -v ",
     "build": "rm -rf ./build && npm run build:compile",
     "build:compile": "cross-env NODE_ENV=production babel --out-dir='build' --ignore='build,coverage,__mocks__,__tests__,node_modules' ./src/",
     "test": "npm-run-all -s lint test:run test:codecov",

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "start": "nodemon -e js,json,yml --exec \"babel-node\" ./server.js",
-    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v && cp serverless-lambda-edge.yml serverless.yml && serverless deploy -v ",
+    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v --force && cp serverless-lambda-edge.yml serverless.yml && serverless deploy -v --force ",
     "build": "rm -rf ./build && npm run build:compile",
     "build:compile": "cross-env NODE_ENV=production babel --out-dir='build' --ignore='build,coverage,__mocks__,__tests__,node_modules' ./src/",
     "test": "npm-run-all -s lint test:run test:codecov",

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -20,6 +20,15 @@ provider:
   # Let's be conservative and prevent any unexpected changes
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
+  # To update the stack policy when the deploy is failing due to
+  # stack policy restrictions, set the policy with the AWS CLI. Docs:
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html#protect-stack-resources-modifying
+  # https://docs.aws.amazon.com/cli/latest/reference/cloudformation/set-stack-policy.html
+  # Example:
+  #  aws cloudformation set-stack-policy --stack-name lambda-edge-dev --region us-east-1 --stack-policy-body '{"Statement":[{"Effect":"Allow","Principal":"*","Action":"Update:*","Resource":"*"}]}'
+  # We could also set a temporary policy, but it's unclear how we'd
+  # do this with the Serverless framework:
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html#protect-stack-resources-updating
   stackPolicy:
     - Effect: Allow # TODO: change to Deny
       Principal: "*"

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -21,7 +21,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Deny
+    - Effect: Allow # TODO: change to Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -17,6 +17,14 @@ provider:
   region: us-east-1
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
   role: gladlyLambdaEdgeRole
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
 
 custom:
   stageDefault: dev

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -21,7 +21,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Allow # TODO: change to Deny
+    - Effect: Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/lambda/serverless-lambda.yml
+++ b/lambda/serverless-lambda.yml
@@ -26,7 +26,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Allow # TODO: change to Deny
+    - Effect: Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/lambda/serverless-lambda.yml
+++ b/lambda/serverless-lambda.yml
@@ -26,7 +26,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Deny
+    - Effect: Allow # TODO: change to Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/lambda/serverless-lambda.yml
+++ b/lambda/serverless-lambda.yml
@@ -22,6 +22,14 @@ provider:
       Action:
         - KMS:Decrypt
       Resource: ${self:custom.awsKmsKeyArn} 
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
 
 custom:
   stageDefault: dev

--- a/s3/package.json
+++ b/s3/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "node ./server.js",
-    "deploy": "serverless deploy -v --force"
+    "deploy": "serverless deploy -v"
   },
   "repository": {
     "type": "git",

--- a/s3/package.json
+++ b/s3/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "start": "node ./server.js",
-    "deploy": "serverless deploy -v"
+    "deploy": "serverless deploy -v --force"
   },
   "repository": {
     "type": "git",

--- a/s3/serverless.yml
+++ b/s3/serverless.yml
@@ -7,6 +7,14 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
 
 custom:
   stageDefault: dev

--- a/s3/serverless.yml
+++ b/s3/serverless.yml
@@ -11,7 +11,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Deny
+    - Effect: Allow # TODO: change to Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/s3/serverless.yml
+++ b/s3/serverless.yml
@@ -11,7 +11,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Allow # TODO: change to Deny
+    - Effect: Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/web/package.json
+++ b/web/package.json
@@ -101,7 +101,7 @@
     "prebid:create-patches": "yarn patch-package prebid.js --include '^(src|modules)/'",
     "prebid:test-patches": "yarn run prebid:test-patches:explanation && cross-env NODE_PATH=node_modules/prebid.js/ react-scripts test --testMatch **/**/prebidPatches* --watchAll=false",
     "prebid:test-patches:explanation": "echo \"Testing Prebid patches. Be sure to run prebid:install first. Note this doesn't currently work because CRA doesn't support Jest's transformIgnorePatterns, which we need to transform Prebid source code.\"",
-    "sls:deploy": "serverless deploy -v"
+    "sls:deploy": "serverless deploy -v --force"
   },
   "proxy": "http://localhost:8080",
   "jest": {

--- a/web/package.json
+++ b/web/package.json
@@ -101,7 +101,7 @@
     "prebid:create-patches": "yarn patch-package prebid.js --include '^(src|modules)/'",
     "prebid:test-patches": "yarn run prebid:test-patches:explanation && cross-env NODE_PATH=node_modules/prebid.js/ react-scripts test --testMatch **/**/prebidPatches* --watchAll=false",
     "prebid:test-patches:explanation": "echo \"Testing Prebid patches. Be sure to run prebid:install first. Note this doesn't currently work because CRA doesn't support Jest's transformIgnorePatterns, which we need to transform Prebid source code.\"",
-    "sls:deploy": "serverless deploy -v --force"
+    "sls:deploy": "serverless deploy -v"
   },
   "proxy": "http://localhost:8080",
   "jest": {

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -7,6 +7,14 @@ provider:
   runtime: nodejs8.10
   region: us-west-2
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
+  # Let's be conservative and prevent any unexpected changes
+  # to the stack. See:
+  # https://github.com/gladly-team/tab/issues/582
+  stackPolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: "Update:*"
+      Resource: "*"
 
 custom:
   stageDefault: dev

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -11,7 +11,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Deny
+    - Effect: Allow # TODO: change to Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -11,7 +11,7 @@ provider:
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
   stackPolicy:
-    - Effect: Allow # TODO: change to Deny
+    - Effect: Deny
       Principal: "*"
       Action: "Update:*"
       Resource: "*"


### PR DESCRIPTION
Addresses part of #582 

In prior commits, I confirmed:
* Deleting a DynamoDB table fails with this stack policy
* Deleting the stack policy from serverless.yml does not remove the stack policy from Cloudformation

This is a multi-PR deployment.

**First deployment (this PR):**
- [x] set all stack policies to `Allow` and deploy to dev
- [x] set deployment to be forced with `serverless deploy --force`
- [x] confirm all stack policies are set in Cloudformation and services work as expected
- [ ] deploy to production and  confirm all stack policies are set in Cloudformation

**Second deployment:**
- [ ] make sure deployment is forced with `serverless deploy --force`
- [ ] set all stack policies to `Deny` (excepting `Update:Modify` on lambda functions) and deploy to dev
- [ ] deploy again to make sure future deploys will succeed
- [ ] deploy to production and check all stack policies are set as expected

**Third deployment:**
- [ ] disabled forced deployment by removing `--force` from `serverless deploy --force`