### PR TITLE
Add additional username validation

### DIFF
--- a/web/src/js/components/Authentication/__tests__/__snapshots__/EnterUsernameForm.test.js.snap
+++ b/web/src/js/components/Authentication/__tests__/__snapshots__/EnterUsernameForm.test.js.snap
@@ -66,7 +66,7 @@ exports[`EnterUsernameForm tests it does not call SetUsernameMutation when the u
             floatingLabelFixed={false}
             floatingLabelText={
               <span>
-                Username
+                Username for Tab for a Cause
               </span>
             }
             fullWidth={false}
@@ -548,7 +548,7 @@ exports[`EnterUsernameForm tests it does not call SetUsernameMutation when the u
                   }
                 >
                   <span>
-                    Username
+                    Username for Tab for a Cause
                   </span>
                 </label>
               </TextFieldLabel>
@@ -1324,7 +1324,7 @@ exports[`EnterUsernameForm tests it shows an error message when the username is 
             floatingLabelFixed={false}
             floatingLabelText={
               <span>
-                Username
+                Username for Tab for a Cause
               </span>
             }
             fullWidth={false}
@@ -1806,7 +1806,7 @@ exports[`EnterUsernameForm tests it shows an error message when the username is 
                   }
                 >
                   <span>
-                    Username
+                    Username for Tab for a Cause
                   </span>
                 </label>
               </TextFieldLabel>

--- a/web/src/js/components/General/UsernameField.js
+++ b/web/src/js/components/General/UsernameField.js
@@ -48,12 +48,18 @@ class UsernameField extends React.Component {
   validate() {
     if (this.hasValue()) {
       const username = this.username.input.value.trim()
-      const isValid = validateUsername(username)
+
+      const { isValid, reason } = validateUsername(username)
       if (!isValid) {
-        if (username.length < 2) {
-          this.setErrorMessage('Must be at least two characters.')
-        } else {
-          this.setErrorMessage('Username is invalid.')
+        switch (reason) {
+          case 'TOO_SHORT': {
+            this.setErrorMessage('Must be at least two characters.')
+            break
+          }
+          default: {
+            this.setErrorMessage('Username is invalid.')
+            break
+          }
         }
       } else {
         this.setErrorMessage(null)
@@ -66,10 +72,7 @@ class UsernameField extends React.Component {
   }
 
   render() {
-    const props = Object.assign({}, this.props)
-    delete props['usernameDuplicate']
-    delete props['otherError']
-
+    const { usernameDuplicate, otherError, ...otherProps } = this.props
     return (
       <TextField
         id={'username-input'}
@@ -78,7 +81,7 @@ class UsernameField extends React.Component {
           this.username = input
         }}
         floatingLabelText={<span>Username</span>}
-        {...props}
+        {...otherProps}
         errorText={this.state.error}
       />
     )

--- a/web/src/js/components/General/UsernameField.js
+++ b/web/src/js/components/General/UsernameField.js
@@ -88,7 +88,7 @@ class UsernameField extends React.Component {
         ref={input => {
           this.username = input
         }}
-        floatingLabelText={<span>Username</span>}
+        floatingLabelText={<span>Username for Tab for a Cause</span>}
         {...otherProps}
         errorText={this.state.error}
       />

--- a/web/src/js/components/General/UsernameField.js
+++ b/web/src/js/components/General/UsernameField.js
@@ -56,6 +56,14 @@ class UsernameField extends React.Component {
             this.setErrorMessage('Must be at least two characters.')
             break
           }
+          case 'NO_SPACES': {
+            this.setErrorMessage('Cannot contain spaces.')
+            break
+          }
+          case 'NO_AT_SIGN': {
+            this.setErrorMessage('Should not contain "@".')
+            break
+          }
           default: {
             this.setErrorMessage('Username is invalid.')
             break

--- a/web/src/js/components/General/__tests__/__snapshots__/UsernameField.test.js.snap
+++ b/web/src/js/components/General/__tests__/__snapshots__/UsernameField.test.js.snap
@@ -8,7 +8,7 @@ exports[`UsernameField tests matches expected snapshot 1`] = `
   floatingLabelFixed={false}
   floatingLabelText={
     <span>
-      Username
+      Username for Tab for a Cause
     </span>
   }
   fullWidth={false}

--- a/web/src/js/utils/__tests__/utils.test.js
+++ b/web/src/js/utils/__tests__/utils.test.js
@@ -12,41 +12,86 @@ afterEach(() => {
 describe('validating username', () => {
   it('accepts alphanumeric usernames', () => {
     const validateUsername = require('js/utils/utils').validateUsername
-    expect(validateUsername('blah')).toEqual(true)
-    expect(validateUsername('somebody123')).toEqual(true)
+    expect(validateUsername('blah')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('somebody123')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
   })
 
   it('rejects usernames that are too short', () => {
     const validateUsername = require('js/utils/utils').validateUsername
-    expect(validateUsername('')).toEqual(false)
-    expect(validateUsername('a')).toEqual(false)
-    expect(validateUsername('aa')).toEqual(true)
+    expect(validateUsername('')).toEqual({
+      isValid: false,
+      reason: 'TOO_SHORT',
+    })
+    expect(validateUsername('a')).toEqual({
+      isValid: false,
+      reason: 'TOO_SHORT',
+    })
+    expect(validateUsername('aa')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
   })
 
   it('accepts common special characters', () => {
     const validateUsername = require('js/utils/utils').validateUsername
-    expect(validateUsername('somebody_123')).toEqual(true)
-    expect(validateUsername('somebody-123')).toEqual(true)
-    expect(validateUsername('somebody$123')).toEqual(true)
-    expect(validateUsername('somebody*123')).toEqual(true)
-    expect(validateUsername('somebody!123')).toEqual(true)
+    expect(validateUsername('somebody_123')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('somebody-123')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('somebody$123')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('somebody*123')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('somebody!123')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
   })
 
   it('accepts modified Roman letters', () => {
     const validateUsername = require('js/utils/utils').validateUsername
-    expect(validateUsername('óóóó')).toEqual(true)
-    expect(validateUsername('åååå')).toEqual(true)
+    expect(validateUsername('óóóó')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('åååå')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
   })
 
   it('accepts Mandarin', () => {
     const validateUsername = require('js/utils/utils').validateUsername
-    expect(validateUsername('我我我我')).toEqual(true)
+    expect(validateUsername('我我我我')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
   })
 
   it('accpets other special characters', () => {
     const validateUsername = require('js/utils/utils').validateUsername
-    expect(validateUsername('©©©©')).toEqual(true)
-    expect(validateUsername('💩💩💩💩')).toEqual(true)
+    expect(validateUsername('©©©©')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
+    expect(validateUsername('💩💩💩💩')).toEqual({
+      isValid: true,
+      reason: 'NONE',
+    })
   })
 })
 

--- a/web/src/js/utils/__tests__/utils.test.js
+++ b/web/src/js/utils/__tests__/utils.test.js
@@ -38,6 +38,42 @@ describe('validating username', () => {
     })
   })
 
+  it('rejects usernames with "@"', () => {
+    const validateUsername = require('js/utils/utils').validateUsername
+    expect(validateUsername('@@')).toEqual({
+      isValid: false,
+      reason: 'NO_AT_SIGN',
+    })
+    expect(validateUsername('hi@blah')).toEqual({
+      isValid: false,
+      reason: 'NO_AT_SIGN',
+    })
+    expect(validateUsername('x@@@@@@x')).toEqual({
+      isValid: false,
+      reason: 'NO_AT_SIGN',
+    })
+    expect(validateUsername('hello@')).toEqual({
+      isValid: false,
+      reason: 'NO_AT_SIGN',
+    })
+  })
+
+  it('rejects usernames with spaces', () => {
+    const validateUsername = require('js/utils/utils').validateUsername
+    expect(validateUsername('My Name')).toEqual({
+      isValid: false,
+      reason: 'NO_SPACES',
+    })
+    expect(validateUsername('   ')).toEqual({
+      isValid: false,
+      reason: 'NO_SPACES',
+    })
+    expect(validateUsername('SpaceAtEndOops ')).toEqual({
+      isValid: false,
+      reason: 'NO_SPACES',
+    })
+  })
+
   it('accepts common special characters', () => {
     const validateUsername = require('js/utils/utils').validateUsername
     expect(validateUsername('somebody_123')).toEqual({

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -14,9 +14,15 @@ import qs from 'qs'
  */
 export const validateUsername = username => {
   if (username.length < 2) {
-    return false
+    return {
+      isValid: false,
+      reason: 'TOO_SHORT',
+    }
   }
-  return true
+  return {
+    isValid: true,
+    reason: 'NONE',
+  }
 }
 
 // Note: in general, we should probably use react-router's

--- a/web/src/js/utils/utils.js
+++ b/web/src/js/utils/utils.js
@@ -19,6 +19,20 @@ export const validateUsername = username => {
       reason: 'TOO_SHORT',
     }
   }
+  // This validation rule added 2019 June 7.
+  if (username.indexOf('@') > -1) {
+    return {
+      isValid: false,
+      reason: 'NO_AT_SIGN',
+    }
+  }
+  // This validation rule added 2019 June 7.
+  if (username.indexOf(' ') > -1) {
+    return {
+      isValid: false,
+      reason: 'NO_SPACES',
+    }
+  }
   return {
     isValid: true,
     reason: 'NONE',


### PR DESCRIPTION
Fixes #591 

* Disallow `@` and space characters in username
* Clarify that the username is for Tab for a Cause. Some users think it's their email address or Google account username.