### PR TITLE
Make search intro more prominent with extension CTA

### DIFF
--- a/web/src/js/components/Search/SearchMenuComponent.js
+++ b/web/src/js/components/Search/SearchMenuComponent.js
@@ -7,6 +7,9 @@ import {
   withStyles,
 } from '@material-ui/core/styles'
 import CircleIcon from '@material-ui/icons/Lens'
+import Paper from '@material-ui/core/Paper'
+import Button from '@material-ui/core/Button'
+import Typography from '@material-ui/core/Typography'
 import theme from 'js/theme/searchTheme'
 import MoneyRaised from 'js/components/MoneyRaised/MoneyRaisedContainer'
 import Hearts from 'js/components/Search/SearchHeartsContainer'
@@ -28,7 +31,7 @@ const styles = {
 const menuFontSize = 22
 
 const SearchMenuComponent = props => {
-  const { app, classes, style, user } = props
+  const { app, classes, showIntroMessage, style, user } = props
   const userExists = !!user
   return (
     <MuiThemeProvider
@@ -72,7 +75,64 @@ const SearchMenuComponent = props => {
           style
         )}
       >
-        <MoneyRaised app={app} />
+        <div style={{ position: 'relative' }}>
+          <MoneyRaised app={app} />
+          {showIntroMessage ? (
+            <Paper
+              data-test-id={'search-intro-msg'}
+              elevation={1}
+              style={{
+                position: 'absolute',
+                top: 40,
+                right: 0,
+                width: 400,
+                boxSizing: 'border-box',
+                padding: '10px 18px',
+                marginBottom: 20,
+              }}
+            >
+              <span
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-start',
+                }}
+              >
+                <Typography
+                  variant={'h6'}
+                  style={{ marginTop: 8, marginBottom: 8 }}
+                >
+                  Your searches do good :)
+                </Typography>
+                <Typography variant={'body2'}>
+                  When you search, you raise money for charity! The money comes
+                  from the ads in search results, and you decide where the money
+                  goes by donating your Hearts to your favorite nonprofit.
+                </Typography>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignSelf: 'flex-end',
+                    marginTop: 10,
+                  }}
+                >
+                  <Button
+                    color={'primary'}
+                    variant={'contained'}
+                    // onClick={() => {
+                    //   setUserDismissedSearchIntro()
+                    //   this.setState({
+                    //     showIntroMessage: false,
+                    //   })
+                    // }}
+                  >
+                    Great!
+                  </Button>
+                </div>
+              </span>
+            </Paper>
+          ) : null}
+        </div>
         {userExists ? (
           <div
             style={{
@@ -105,9 +165,11 @@ SearchMenuComponent.propTypes = {
   style: PropTypes.object,
   // May not exist if the user is not signed in.
   user: PropTypes.shape({}),
+  showIntroMessage: PropTypes.bool.isRequired,
 }
 
 SearchMenuComponent.defaultProps = {
+  showIntroMessage: false,
   style: {},
 }
 

--- a/web/src/js/components/Search/SearchMenuComponent.js
+++ b/web/src/js/components/Search/SearchMenuComponent.js
@@ -7,9 +7,6 @@ import {
   withStyles,
 } from '@material-ui/core/styles'
 import CircleIcon from '@material-ui/icons/Lens'
-import Paper from '@material-ui/core/Paper'
-import Button from '@material-ui/core/Button'
-import Typography from '@material-ui/core/Typography'
 import theme from 'js/theme/searchTheme'
 import MoneyRaised from 'js/components/MoneyRaised/MoneyRaisedContainer'
 import Hearts from 'js/components/Search/SearchHeartsContainer'
@@ -31,7 +28,7 @@ const styles = {
 const menuFontSize = 22
 
 const SearchMenuComponent = props => {
-  const { app, classes, showIntroMessage, style, user } = props
+  const { app, classes, style, user } = props
   const userExists = !!user
   return (
     <MuiThemeProvider
@@ -75,64 +72,7 @@ const SearchMenuComponent = props => {
           style
         )}
       >
-        <div style={{ position: 'relative' }}>
-          <MoneyRaised app={app} />
-          {showIntroMessage ? (
-            <Paper
-              data-test-id={'search-intro-msg'}
-              elevation={1}
-              style={{
-                position: 'absolute',
-                top: 40,
-                right: 0,
-                width: 400,
-                boxSizing: 'border-box',
-                padding: '10px 18px',
-                marginBottom: 20,
-              }}
-            >
-              <span
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-start',
-                }}
-              >
-                <Typography
-                  variant={'h6'}
-                  style={{ marginTop: 8, marginBottom: 8 }}
-                >
-                  Your searches do good :)
-                </Typography>
-                <Typography variant={'body2'}>
-                  When you search, you raise money for charity! The money comes
-                  from the ads in search results, and you decide where the money
-                  goes by donating your Hearts to your favorite nonprofit.
-                </Typography>
-                <div
-                  style={{
-                    display: 'flex',
-                    alignSelf: 'flex-end',
-                    marginTop: 10,
-                  }}
-                >
-                  <Button
-                    color={'primary'}
-                    variant={'contained'}
-                    // onClick={() => {
-                    //   setUserDismissedSearchIntro()
-                    //   this.setState({
-                    //     showIntroMessage: false,
-                    //   })
-                    // }}
-                  >
-                    Great!
-                  </Button>
-                </div>
-              </span>
-            </Paper>
-          ) : null}
-        </div>
+        <MoneyRaised app={app} />
         {userExists ? (
           <div
             style={{
@@ -165,11 +105,9 @@ SearchMenuComponent.propTypes = {
   style: PropTypes.object,
   // May not exist if the user is not signed in.
   user: PropTypes.shape({}),
-  showIntroMessage: PropTypes.bool.isRequired,
 }
 
 SearchMenuComponent.defaultProps = {
-  showIntroMessage: false,
   style: {},
 }
 

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -565,6 +565,8 @@ class SearchPage extends React.Component {
                   width: '100%',
                   boxSizing: 'border-box',
                   padding: '10px 18px',
+                  marginTop: -50, // for more prominence
+                  backgroundColor: '#ebfffc',
                   marginBottom: 20,
                 }}
               >
@@ -579,13 +581,12 @@ class SearchPage extends React.Component {
                     variant={'h6'}
                     style={{ marginTop: 8, marginBottom: 8 }}
                   >
-                    Your searches do good :)
+                    Your searches do good!
                   </Typography>
                   <Typography variant={'body2'}>
-                    When you search, you raise money for charity! The money
-                    comes from the ads in search results, and you decide where
-                    the money goes by donating your Hearts to your favorite
-                    nonprofit.
+                    When you search, you raise money for charity! You pick what
+                    cause to support, from conserving the rainforest to giving
+                    cash to people who need it most.
                   </Typography>
                   <div
                     style={{

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -557,7 +557,7 @@ class SearchPage extends React.Component {
             }}
           >
             {' '}
-            {showIntroMessage ? (
+            {mounted && showIntroMessage ? (
               <Paper
                 data-test-id={'search-intro-msg'}
                 elevation={1}
@@ -583,11 +583,18 @@ class SearchPage extends React.Component {
                   >
                     Your searches do good!
                   </Typography>
-                  <Typography variant={'body2'}>
-                    When you search, you raise money for charity! You pick what
-                    cause to support, from conserving the rainforest to giving
-                    cash to people who need it most.
+                  <Typography variant={'body2'} gutterBottom>
+                    When you search, you're raising money for charity! Choose
+                    your cause, from protecting the rainforest to giving cash to
+                    people who need it most.
                   </Typography>
+                  {!isSearchExtensionInstalled ? (
+                    <Typography variant={'body2'} gutterBottom>
+                      Make Search for a Cause your default search engine to
+                      change lives with{' '}
+                      <span style={{ fontStyle: 'italic' }}>every</span> search.
+                    </Typography>
+                  ) : null}
                   <div
                     style={{
                       display: 'flex',
@@ -597,7 +604,9 @@ class SearchPage extends React.Component {
                   >
                     <Button
                       color={'primary'}
-                      variant={'contained'}
+                      variant={
+                        isSearchExtensionInstalled ? 'contained' : 'outlined'
+                      }
                       onClick={() => {
                         setUserDismissedSearchIntro()
                         this.setState({
@@ -607,6 +616,27 @@ class SearchPage extends React.Component {
                     >
                       Great!
                     </Button>
+                    {!isSearchExtensionInstalled &&
+                    [CHROME_BROWSER, FIREFOX_BROWSER].indexOf(browser) > -1 ? (
+                      <div
+                        data-test-id={'search-intro-add-extension-cta'}
+                        style={{ marginLeft: 10 }}
+                      >
+                        {browser === CHROME_BROWSER ? (
+                          <Link to={searchChromeExtensionPage}>
+                            <Button color={'primary'} variant={'contained'}>
+                              Add to Chrome
+                            </Button>
+                          </Link>
+                        ) : browser === FIREFOX_BROWSER ? (
+                          <Link to={searchFirefoxExtensionPage}>
+                            <Button color={'primary'} variant={'contained'}>
+                              Add to Firefox
+                            </Button>
+                          </Link>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
                 </span>
               </Paper>

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -235,6 +235,10 @@ class SearchPage extends React.Component {
       return null
     }
 
+    const showExtensionInstallCTA =
+      !isSearchExtensionInstalled &&
+      [CHROME_BROWSER, FIREFOX_BROWSER].indexOf(browser) > -1
+
     return (
       <div
         data-test-id={'search-page'}
@@ -327,9 +331,7 @@ class SearchPage extends React.Component {
                 }
               />
             </div>
-            {mounted &&
-            !isSearchExtensionInstalled &&
-            [CHROME_BROWSER, FIREFOX_BROWSER].indexOf(browser) > -1 ? (
+            {mounted && showExtensionInstallCTA ? (
               <div
                 data-test-id={'search-add-extension-cta'}
                 style={{ marginLeft: 30, marginRight: 10 }}
@@ -588,7 +590,7 @@ class SearchPage extends React.Component {
                     your cause, from protecting the rainforest to giving cash to
                     people who need it most.
                   </Typography>
-                  {!isSearchExtensionInstalled ? (
+                  {showExtensionInstallCTA ? (
                     <Typography variant={'body2'} gutterBottom>
                       Make Search for a Cause your default search engine to
                       change lives with{' '}
@@ -605,7 +607,7 @@ class SearchPage extends React.Component {
                     <Button
                       color={'primary'}
                       variant={
-                        isSearchExtensionInstalled ? 'contained' : 'outlined'
+                        showExtensionInstallCTA ? 'outlined' : 'contained'
                       }
                       onClick={() => {
                         setUserDismissedSearchIntro()
@@ -616,8 +618,7 @@ class SearchPage extends React.Component {
                     >
                       Great!
                     </Button>
-                    {!isSearchExtensionInstalled &&
-                    [CHROME_BROWSER, FIREFOX_BROWSER].indexOf(browser) > -1 ? (
+                    {showExtensionInstallCTA ? (
                       <div
                         data-test-id={'search-intro-add-extension-cta'}
                         style={{ marginLeft: 10 }}

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -38,7 +38,7 @@ import detectAdblocker from 'js/utils/detectAdblocker'
 import Link from 'js/components/General/Link'
 import {
   hasUserDismissedSearchIntro,
-  // setUserDismissedSearchIntro,
+  setUserDismissedSearchIntro,
 } from 'js/utils/local-user-data-mgr'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 import ErrorBoundarySearchResults from 'js/components/Search/ErrorBoundarySearchResults'
@@ -367,7 +367,7 @@ class SearchPage extends React.Component {
               >
                 <Button color={'primary'}>Feedback</Button>
               </Link>
-              <SearchMenuQuery showIntroMessage={showIntroMessage} />
+              <SearchMenuQuery />
             </div>
           </div>
           <Tabs
@@ -556,6 +556,60 @@ class SearchPage extends React.Component {
               minWidth: 300,
             }}
           >
+            {' '}
+            {showIntroMessage ? (
+              <Paper
+                data-test-id={'search-intro-msg'}
+                elevation={1}
+                style={{
+                  width: '100%',
+                  boxSizing: 'border-box',
+                  padding: '10px 18px',
+                  marginBottom: 20,
+                }}
+              >
+                <span
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'flex-start',
+                  }}
+                >
+                  <Typography
+                    variant={'h6'}
+                    style={{ marginTop: 8, marginBottom: 8 }}
+                  >
+                    Your searches do good :)
+                  </Typography>
+                  <Typography variant={'body2'}>
+                    When you search, you raise money for charity! The money
+                    comes from the ads in search results, and you decide where
+                    the money goes by donating your Hearts to your favorite
+                    nonprofit.
+                  </Typography>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignSelf: 'flex-end',
+                      marginTop: 10,
+                    }}
+                  >
+                    <Button
+                      color={'primary'}
+                      variant={'contained'}
+                      onClick={() => {
+                        setUserDismissedSearchIntro()
+                        this.setState({
+                          showIntroMessage: false,
+                        })
+                      }}
+                    >
+                      Great!
+                    </Button>
+                  </div>
+                </span>
+              </Paper>
+            ) : null}
             <ErrorBoundary brand={'search'} ignoreErrors>
               {query ? (
                 <WikipediaQuery

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -38,7 +38,7 @@ import detectAdblocker from 'js/utils/detectAdblocker'
 import Link from 'js/components/General/Link'
 import {
   hasUserDismissedSearchIntro,
-  setUserDismissedSearchIntro,
+  // setUserDismissedSearchIntro,
 } from 'js/utils/local-user-data-mgr'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 import ErrorBoundarySearchResults from 'js/components/Search/ErrorBoundarySearchResults'
@@ -367,7 +367,7 @@ class SearchPage extends React.Component {
               >
                 <Button color={'primary'}>Feedback</Button>
               </Link>
-              <SearchMenuQuery />
+              <SearchMenuQuery showIntroMessage={showIntroMessage} />
             </div>
           </div>
           <Tabs
@@ -556,60 +556,6 @@ class SearchPage extends React.Component {
               minWidth: 300,
             }}
           >
-            {' '}
-            {showIntroMessage ? (
-              <Paper
-                data-test-id={'search-intro-msg'}
-                elevation={1}
-                style={{
-                  width: '100%',
-                  boxSizing: 'border-box',
-                  padding: '10px 18px',
-                  marginBottom: 20,
-                }}
-              >
-                <span
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'flex-start',
-                  }}
-                >
-                  <Typography
-                    variant={'h6'}
-                    style={{ marginTop: 8, marginBottom: 8 }}
-                  >
-                    Your searches do good :)
-                  </Typography>
-                  <Typography variant={'body2'}>
-                    When you search, you raise money for charity! The money
-                    comes from the ads in search results, and you decide where
-                    the money goes by donating your Hearts to your favorite
-                    nonprofit.
-                  </Typography>
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignSelf: 'flex-end',
-                      marginTop: 10,
-                    }}
-                  >
-                    <Button
-                      color={'primary'}
-                      variant={'contained'}
-                      onClick={() => {
-                        setUserDismissedSearchIntro()
-                        this.setState({
-                          showIntroMessage: false,
-                        })
-                      }}
-                    >
-                      Great!
-                    </Button>
-                  </div>
-                </span>
-              </Paper>
-            ) : null}
             <ErrorBoundary brand={'search'} ignoreErrors>
               {query ? (
                 <WikipediaQuery

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -780,7 +780,7 @@ describe('Search page component', () => {
         .first()
         .render()
         .text()
-    ).toEqual('Your searches do good :)')
+    ).toEqual('Your searches do good!')
   })
 
   it('shows the expected intro message description', () => {
@@ -797,7 +797,7 @@ describe('Search page component', () => {
         .render()
         .text()
     ).toEqual(
-      'When you search, you raise money for charity! The money comes from the ads in search results, and you decide where the money goes by donating your Hearts to your favorite nonprofit.'
+      "When you search, you're raising money for charity! Choose your cause, from protecting the rainforest to giving cash to people who need it most."
     )
   })
 

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -687,7 +687,7 @@ describe('Search page: "add extension" button', () => {
     ).toBe(true)
   })
 
-  it('does not show the "Add extension" button when the extension is not installed', () => {
+  it('does not show the "Add extension" button when the extension IS installed', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
     const mockProps = getMockProps()
@@ -835,7 +835,20 @@ describe('Search page: intro message', () => {
     expect(setUserDismissedSearchIntro).toHaveBeenCalledTimes(1)
   })
 
-  it('shows the expected intro message title', () => {
+  it('does not show the intro message if prerendering with React Snap', () => {
+    hasUserDismissedSearchIntro.mockReturnValueOnce(false)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    isReactSnapClient.mockReturnValue(true)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="search-intro-msg"]').exists()).toBe(
+      false
+    )
+  })
+
+  it('[extension installed] shows the expected intro message title', () => {
+    isSearchExtensionInstalled.mockReturnValue(true) // extension already installed
     hasUserDismissedSearchIntro.mockReturnValueOnce(false)
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
@@ -851,7 +864,8 @@ describe('Search page: intro message', () => {
     ).toEqual('Your searches do good!')
   })
 
-  it('shows the expected intro message description', () => {
+  it('[extension installed] shows the expected intro message description', () => {
+    isSearchExtensionInstalled.mockReturnValue(true) // extension already installed
     hasUserDismissedSearchIntro.mockReturnValueOnce(false)
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
@@ -867,9 +881,13 @@ describe('Search page: intro message', () => {
     ).toEqual(
       "When you search, you're raising money for charity! Choose your cause, from protecting the rainforest to giving cash to people who need it most."
     )
+    expect(
+      wrapper.find('[data-test-id="search-intro-msg"]').find(Typography).length
+    ).toBe(2)
   })
 
-  it('shows the expected intro message button text', () => {
+  it('[extension installed] shows the expected intro message button text', () => {
+    isSearchExtensionInstalled.mockReturnValue(true) // extension already installed
     hasUserDismissedSearchIntro.mockReturnValueOnce(false)
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
@@ -885,15 +903,145 @@ describe('Search page: intro message', () => {
     ).toEqual('Great!')
   })
 
-  it('does not show the intro message if prerendering with React Snap', () => {
+  it('[extension installed] does not show the "Add extension" button', () => {
+    isSearchExtensionInstalled.mockReturnValue(true) // extension already installed
     hasUserDismissedSearchIntro.mockReturnValueOnce(false)
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
     const mockProps = getMockProps()
-    isReactSnapClient.mockReturnValue(true)
     const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
-    expect(wrapper.find('[data-test-id="search-intro-msg"]').exists()).toBe(
-      false
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    expect(
+      introElem.find('[data-test-id="search-intro-add-extension-cta"]').exists()
+    ).toBe(false)
+    expect(introElem.find(Button).length).toBe(1)
+  })
+
+  it('[not installed] shows the "Add extension" button when the extension is not installed', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    hasUserDismissedSearchIntro.mockReturnValueOnce(false)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    expect(
+      introElem.find('[data-test-id="search-intro-add-extension-cta"]').exists()
+    ).toBe(true)
+    expect(introElem.find(Button).length).toBe(2)
+  })
+
+  it('[not installed] the "Add extension" button says "Add to Chrome" when the browser is Chrome', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectSupportedBrowser.mockReturnValue('chrome')
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    const button = introElem.find(Button).at(1)
+    expect(button.render().text()).toEqual('Add to Chrome')
+  })
+
+  it('[not installed] the "Add extension" button says "Add to Firefox" when the browser is Firefox', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectSupportedBrowser.mockReturnValue('firefox')
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    const button = introElem.find(Button).at(1)
+    expect(button.render().text()).toEqual('Add to Firefox')
+  })
+
+  it('[not installed] the "Add extension" button links to the Chrome Web Store when the browser is Chrome', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectSupportedBrowser.mockReturnValue('chrome')
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    const elem = introElem.find(Link)
+    expect(elem.prop('to')).toEqual(
+      'https://chrome.google.com/webstore/detail/search-for-a-cause/eeiiknnphladbapfamiamfimnnnodife/'
+    )
+  })
+
+  it('[not installed] the "Add extension" button links to the Firefox Add-ons page when the browser is Firefox', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectSupportedBrowser.mockReturnValue('firefox')
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    const elem = introElem.find(Link)
+    expect(elem.prop('to')).toEqual(
+      'https://addons.mozilla.org/en-US/firefox/addon/search-for-a-cause/'
+    )
+  })
+
+  it('[not installed] the "Add extension" button does not appear if the browser is not Chrome or Firefox', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    detectSupportedBrowser.mockReturnValue('safari')
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const introElem = wrapper.find('[data-test-id="search-intro-msg"]')
+    expect(
+      introElem.find('[data-test-id="search-intro-add-extension-cta"]').exists()
+    ).toBe(false)
+  })
+
+  it('[not installed] shows the expected intro message title', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    hasUserDismissedSearchIntro.mockReturnValueOnce(false)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-msg"]')
+        .find(Typography)
+        .first()
+        .render()
+        .text()
+    ).toEqual('Your searches do good!')
+  })
+
+  it('[not installed] shows the expected intro message description', () => {
+    isSearchExtensionInstalled.mockReturnValue(false) // extension not installed
+    hasUserDismissedSearchIntro.mockReturnValueOnce(false)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(
+      wrapper.find('[data-test-id="search-intro-msg"]').find(Typography).length
+    ).toBe(3)
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-msg"]')
+        .find(Typography)
+        .at(1)
+        .render()
+        .text()
+    ).toEqual(
+      "When you search, you're raising money for charity! Choose your cause, from protecting the rainforest to giving cash to people who need it most."
+    )
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-msg"]')
+        .find(Typography)
+        .at(2)
+        .render()
+        .text()
+    ).toEqual(
+      'Make Search for a Cause your default search engine to change lives with every search.'
     )
   })
 })


### PR DESCRIPTION
* Move the intro message higher (overlapping the search results line break) so it's visually distinct from the search results
* Make the intro message background a teal color
* For users without the extension installed, add a second button that links to the extension store page, plus an extra sentence in the intro