### PR TITLE
Enable search intro experiment v2

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -322,6 +322,9 @@ const ExperimentGroupsType = new GraphQLInputObjectType({
           INTRO_A: {
             value: experimentConfig.searchIntro.INTRO_A,
           },
+          INTRO_HOMEPAGE: {
+            value: experimentConfig.searchIntro.INTRO_HOMEPAGE,
+          },
         },
       }),
     },

--- a/graphql/utils/experiments.js
+++ b/graphql/utils/experiments.js
@@ -37,6 +37,7 @@ const experimentConfig = {
     NONE: 0,
     NO_INTRO: 1,
     INTRO_A: 2,
+    INTRO_HOMEPAGE: 3,
   },
   // @experiment-referral-notification
   referralNotification: {

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -247,6 +247,7 @@ enum ExperimentGroupSearchIntro {
   NONE
   NO_INTRO
   INTRO_A
+  INTRO_HOMEPAGE
 }
 
 """The test of enabling a third ad"""

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -323,15 +323,18 @@ class Dashboard extends React.Component {
                 />
               ) : null}
               {// @experiment-search-intro
-              searchIntroExperimentGroup ===
-                getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A &&
+              (searchIntroExperimentGroup ===
+                getExperimentGroups(EXPERIMENT_SEARCH_INTRO).INTRO_A ||
+                searchIntroExperimentGroup ===
+                  getExperimentGroups(EXPERIMENT_SEARCH_INTRO)
+                    .INTRO_HOMEPAGE) &&
               !(
                 user.experimentActions.searchIntro === 'CLICK' ||
                 user.experimentActions.searchIntro === 'DISMISS'
               ) &&
               user.tabs > 3 ? (
                 <Notification
-                  data-test-id={'search-intro-a'}
+                  data-test-id={'search-intro-notif'}
                   title={`We're working on Search for a Cause`}
                   message={
                     <span>
@@ -366,12 +369,20 @@ class Dashboard extends React.Component {
                       searchIntroExperimentGroup: false,
                     })
 
-                    if (browser === CHROME_BROWSER) {
-                      goTo(searchChromeExtensionPage)
-                    } else if (browser === FIREFOX_BROWSER) {
-                      goTo(searchFirefoxExtensionPage)
+                    if (
+                      searchIntroExperimentGroup ===
+                      getExperimentGroups(EXPERIMENT_SEARCH_INTRO)
+                        .INTRO_HOMEPAGE
+                    ) {
+                      goTo('https://search.gladly.io')
                     } else {
-                      goTo(searchChromeExtensionPage)
+                      if (browser === CHROME_BROWSER) {
+                        goTo(searchChromeExtensionPage)
+                      } else if (browser === FIREFOX_BROWSER) {
+                        goTo(searchFirefoxExtensionPage)
+                      } else {
+                        goTo(searchChromeExtensionPage)
+                      }
                     }
                   }}
                   onDismiss={async () => {

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -261,6 +261,7 @@ class Dashboard extends React.Component {
               {this.state.showNotification ? (
                 <Notification
                   data-test-id={'global-notification'}
+                  useGlobalDismissalTime
                   title={`Vote for the June Charity Spotlight`}
                   message={`
                         Each month this year, we're highlighting a charity chosen by our

--- a/web/src/js/components/Dashboard/NotificationComponent.js
+++ b/web/src/js/components/Dashboard/NotificationComponent.js
@@ -16,6 +16,7 @@ class Notification extends React.Component {
       buttonURL,
       onClick,
       onDismiss,
+      useGlobalDismissalTime,
     } = this.props
     return (
       <div style={Object.assign({ width: 340 }, style)}>
@@ -61,7 +62,11 @@ class Notification extends React.Component {
               <Button
                 color={'default'}
                 onClick={() => {
-                  setNotificationDismissTime()
+                  // If useGlobalDismissalTime is true, dismissing this notification
+                  // will hide future global notifications for ~10 days.
+                  if (useGlobalDismissalTime) {
+                    setNotificationDismissTime()
+                  }
                   if (onDismiss) {
                     onDismiss()
                   }
@@ -101,11 +106,13 @@ Notification.propTypes = {
   buttonURL: PropTypes.string,
   onDismiss: PropTypes.func,
   onClick: PropTypes.func,
+  useGlobalDismissalTime: PropTypes.bool.isRequired,
 }
 
 Notification.defaultProps = {
   style: {},
   onDismiss: () => {},
+  useGlobalDismissalTime: false,
 }
 
 export default Notification

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -131,160 +131,6 @@ describe('Dashboard component', () => {
     expect(wrapper.find(WidgetsContainer).length).toBe(1)
   })
 
-  // TODO: enable when Enzyme supports React.Suspense:
-  // https://github.com/airbnb/enzyme/issues/1917
-
-  // it('renders CampaignBase component when the campaign is live and the user has not dismissed it', () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.app.isGlobalCampaignLive = true
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-  //   expect(wrapper.find(CampaignBase).length).toBe(1)
-  // })
-
-  // it('does not render the CampaignBase component when the campaign is live but the user has dismissed it', () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.app.isGlobalCampaignLive = true
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(true)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-  //   expect(wrapper.find(CampaignBase).length).toBe(0)
-  // })
-
-  // it("does not render the CampaignBase component when the campaign is live but the it's the user's first tab", () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.user.tabs = 1
-  //   modifiedProps.app.isGlobalCampaignLive = true
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-  //   expect(wrapper.find(CampaignBase).length).toBe(0)
-  // })
-
-  // it("does render the CampaignBase component when the campaign is live and it's the user's second tab", () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.user.tabs = 2
-  //   modifiedProps.app.isGlobalCampaignLive = true
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-  //   expect(wrapper.find(CampaignBase).length).toBe(1)
-  // })
-
-  // it('does not render CampaignBase component when the campaign is not live', () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.app.isGlobalCampaignLive = false
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-  //   expect(wrapper.find(CampaignBase).length).toBe(0)
-  // })
-
-  // it('hides the campaign when the onDismiss callback is called', () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.app.isGlobalCampaignLive = true
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-
-  //   // Campaign should be visible.
-  //   expect(wrapper.find(CampaignBase).length).toBe(1)
-
-  //   // Mock that the user dismisses the notification.
-  //   wrapper.find(CampaignBase).prop('onDismiss')()
-
-  //   // Notification should be gone.
-  //   expect(wrapper.find(CampaignBase).length).toBe(0)
-  // })
-
-  // it('changes the value of the isCampaignLive passed to widgets when the campaign is dismissed', () => {
-  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-  //     .default
-  //   const modifiedProps = cloneDeep(mockProps)
-  //   modifiedProps.app.isGlobalCampaignLive = true
-  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
-  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-
-  //   expect(wrapper.find(WidgetsContainer).prop('isCampaignLive')).toBe(true)
-
-  //   // Mock that the user dismisses the notification.
-  //   wrapper.find(CampaignBase).prop('onDismiss')()
-
-  //   // Prop should change.
-  //   expect(wrapper.find(WidgetsContainer).prop('isCampaignLive')).toBe(false)
-  // })
-
-  it('does not render any ad components when 0 ads are enabled', () => {
-    getNumberOfAdsToShow.mockReturnValue(0)
-    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-      .default
-    const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Ad).length).toBe(0)
-  })
-
-  it('renders the expected 1 ad component when 1 ad is enabled', () => {
-    getNumberOfAdsToShow.mockReturnValue(1)
-    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-      .default
-    const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Ad).length).toBe(1)
-    const leaderboardAd = wrapper.find(Ad).at(0)
-    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
-  })
-
-  it('renders the expected 2 ad components when 2 ads are enabled', () => {
-    getNumberOfAdsToShow.mockReturnValue(2)
-    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-      .default
-    const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Ad).length).toBe(2)
-    const rectangleAd = wrapper.find(Ad).at(0)
-    const leaderboardAd = wrapper.find(Ad).at(1)
-    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
-    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
-  })
-
-  it('renders the expected 3 ad components when 3 ads are enabled', () => {
-    getNumberOfAdsToShow.mockReturnValue(3)
-    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-      .default
-    const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(Ad).length).toBe(3)
-    const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
-    const rectangleAd = wrapper.find(Ad).at(1)
-    const leaderboardAd = wrapper.find(Ad).at(2)
-    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
-    expect(rectangleAdNumberTwo.prop('adId')).toBe(
-      SECOND_VERTICAL_AD_SLOT_DOM_ID
-    )
-    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
-  })
-
-  it('the ads have expected IDs matched with their sizes', () => {
-    getNumberOfAdsToShow.mockReturnValue(3)
-    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
-      .default
-    const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
-    const rectangleAd = wrapper.find(Ad).at(1)
-    const leaderboardAd = wrapper.find(Ad).at(2)
-    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
-    expect(rectangleAd.prop('style').minWidth).toBe(300)
-    expect(rectangleAdNumberTwo.prop('adId')).toBe(
-      SECOND_VERTICAL_AD_SLOT_DOM_ID
-    )
-    expect(rectangleAdNumberTwo.prop('style').minWidth).toBe(300)
-    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
-    expect(leaderboardAd.prop('style').minWidth).toBe(728)
-  })
-
   it('renders LogTab component', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
@@ -583,7 +429,154 @@ describe('Dashboard component', () => {
       wrapper.find('[data-test-id="ad-explanation"]').find(Button).length
     ).toBe(0)
   })
+})
 
+describe('Dashboard component: campaign / charity spotlight', () => {
+  // TODO: enable when Enzyme supports React.Suspense:
+  // https://github.com/airbnb/enzyme/issues/1917
+  // it('renders CampaignBase component when the campaign is live and the user has not dismissed it', () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.app.isGlobalCampaignLive = true
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   expect(wrapper.find(CampaignBase).length).toBe(1)
+  // })
+  // it('does not render the CampaignBase component when the campaign is live but the user has dismissed it', () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.app.isGlobalCampaignLive = true
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(true)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   expect(wrapper.find(CampaignBase).length).toBe(0)
+  // })
+  // it("does not render the CampaignBase component when the campaign is live but the it's the user's first tab", () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.user.tabs = 1
+  //   modifiedProps.app.isGlobalCampaignLive = true
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   expect(wrapper.find(CampaignBase).length).toBe(0)
+  // })
+  // it("does render the CampaignBase component when the campaign is live and it's the user's second tab", () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.user.tabs = 2
+  //   modifiedProps.app.isGlobalCampaignLive = true
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   expect(wrapper.find(CampaignBase).length).toBe(1)
+  // })
+  // it('does not render CampaignBase component when the campaign is not live', () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.app.isGlobalCampaignLive = false
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   expect(wrapper.find(CampaignBase).length).toBe(0)
+  // })
+  // it('hides the campaign when the onDismiss callback is called', () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.app.isGlobalCampaignLive = true
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   // Campaign should be visible.
+  //   expect(wrapper.find(CampaignBase).length).toBe(1)
+  //   // Mock that the user dismisses the notification.
+  //   wrapper.find(CampaignBase).prop('onDismiss')()
+  //   // Notification should be gone.
+  //   expect(wrapper.find(CampaignBase).length).toBe(0)
+  // })
+  // it('changes the value of the isCampaignLive passed to widgets when the campaign is dismissed', () => {
+  //   const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+  //     .default
+  //   const modifiedProps = cloneDeep(mockProps)
+  //   modifiedProps.app.isGlobalCampaignLive = true
+  //   hasUserDismissedCampaignRecently.mockReturnValueOnce(false)
+  //   const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+  //   expect(wrapper.find(WidgetsContainer).prop('isCampaignLive')).toBe(true)
+  //   // Mock that the user dismisses the notification.
+  //   wrapper.find(CampaignBase).prop('onDismiss')()
+  //   // Prop should change.
+  //   expect(wrapper.find(WidgetsContainer).prop('isCampaignLive')).toBe(false)
+  // })
+})
+
+describe('Dashboard component: ads logic', () => {
+  it('does not render any ad components when 0 ads are enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(0)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    expect(wrapper.find(Ad).length).toBe(0)
+  })
+
+  it('renders the expected 1 ad component when 1 ad is enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(1)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    expect(wrapper.find(Ad).length).toBe(1)
+    const leaderboardAd = wrapper.find(Ad).at(0)
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+  })
+
+  it('renders the expected 2 ad components when 2 ads are enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(2)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    expect(wrapper.find(Ad).length).toBe(2)
+    const rectangleAd = wrapper.find(Ad).at(0)
+    const leaderboardAd = wrapper.find(Ad).at(1)
+    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+  })
+
+  it('renders the expected 3 ad components when 3 ads are enabled', () => {
+    getNumberOfAdsToShow.mockReturnValue(3)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    expect(wrapper.find(Ad).length).toBe(3)
+    const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
+    const rectangleAd = wrapper.find(Ad).at(1)
+    const leaderboardAd = wrapper.find(Ad).at(2)
+    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
+    expect(rectangleAdNumberTwo.prop('adId')).toBe(
+      SECOND_VERTICAL_AD_SLOT_DOM_ID
+    )
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+  })
+
+  it('the ads have expected IDs matched with their sizes', () => {
+    getNumberOfAdsToShow.mockReturnValue(3)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    const rectangleAdNumberTwo = wrapper.find(Ad).at(0)
+    const rectangleAd = wrapper.find(Ad).at(1)
+    const leaderboardAd = wrapper.find(Ad).at(2)
+    expect(rectangleAd.prop('adId')).toBe(VERTICAL_AD_SLOT_DOM_ID)
+    expect(rectangleAd.prop('style').minWidth).toBe(300)
+    expect(rectangleAdNumberTwo.prop('adId')).toBe(
+      SECOND_VERTICAL_AD_SLOT_DOM_ID
+    )
+    expect(rectangleAdNumberTwo.prop('style').minWidth).toBe(300)
+    expect(leaderboardAd.prop('adId')).toBe(HORIZONTAL_AD_SLOT_DOM_ID)
+    expect(leaderboardAd.prop('style').minWidth).toBe(728)
+  })
+})
+
+describe('Dashboard component: global notification', () => {
   it('renders a notification when one is live and the user has not dismissed it', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
@@ -650,7 +643,9 @@ describe('Dashboard component', () => {
     // Notification should be gone.
     expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(0)
   })
+})
 
+describe('Dashboard component: search intro experiment', () => {
   it('[search-intro-A] does not render the search intro notification when the user is not in the experiment', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
@@ -820,7 +815,9 @@ describe('Dashboard component', () => {
     const elem = wrapper.find('[data-test-id="search-intro-a"]')
     expect(elem.prop('useGlobalDismissalTime')).toBe(false)
   })
+})
 
+describe('Dashboard component: referral notification experiment', () => {
   it('[referral-notification-experiment] does not render the notification when the user is not in the experiment', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -617,6 +617,21 @@ describe('Dashboard component', () => {
     expect(wrapper.find('[data-test-id="global-notification"]').length).toBe(0)
   })
 
+  it('sets the "useGlobalDismissalTime" on the global notification', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    showGlobalNotification.mockReset()
+    hasUserDismissedNotificationRecently.mockReset()
+    showGlobalNotification.mockReturnValueOnce(true)
+    hasUserDismissedNotificationRecently.mockReturnValueOnce(false)
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    expect(
+      wrapper
+        .find('[data-test-id="global-notification"]')
+        .prop('useGlobalDismissalTime')
+    ).toBe(true)
+  })
+
   it('hides the notification when the onDismiss callback is called', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
@@ -795,6 +810,15 @@ describe('Dashboard component', () => {
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
     await wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
     expect(goTo).toHaveBeenCalledWith(searchChromeExtensionPage)
+  })
+
+  it('[search-intro-A] does not sets the "useGlobalDismissalTime" on the experiment notification', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('introA')
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    expect(elem.prop('useGlobalDismissalTime')).toBe(false)
   })
 
   it('[referral-notification-experiment] does not render the notification when the user is not in the experiment', () => {

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -646,111 +646,131 @@ describe('Dashboard component: global notification', () => {
 })
 
 describe('Dashboard component: search intro experiment', () => {
-  it('[search-intro-A] does not render the search intro notification when the user is not in the experiment', () => {
+  it('[none group] does not render the search intro notification when the user is not in the experiment', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('none')
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find('[data-test-id="search-intro-a"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
+      false
+    )
   })
 
-  it('[search-intro-A] does not render the search intro notification when the user is in the control group', () => {
+  it('[control group] does not render the search intro notification when the user is in the control group', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('noIntro')
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find('[data-test-id="search-intro-a"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
+      false
+    )
   })
 
-  it('[search-intro-A] renders the search intro notification when the user is in the experimental group', () => {
+  it('[search-intro-A] renders the search intro notification when the user is in the search-intro-A group', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('introA')
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
     expect(elem.exists()).toBe(true)
     expect(elem.prop('title')).toEqual(`We're working on Search for a Cause`)
   })
 
-  it('[search-intro-A] does not render the search intro notification when the user has opened fewer than 4 tabs', () => {
+  it('[search-intro-homepage] renders the search intro notification when the user is in the search-intro-homepage group', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    getUserExperimentGroup.mockReturnValue('introHomepage')
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
+    expect(elem.exists()).toBe(true)
+    expect(elem.prop('title')).toEqual(`We're working on Search for a Cause`)
+  })
+
+  it('[experimental group] does not render the search intro notification when the user has opened fewer than 4 tabs', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('introA')
     const modifiedProps = cloneDeep(mockProps)
     modifiedProps.user.tabs = 2
     const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-    expect(wrapper.find('[data-test-id="search-intro-a"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
+      false
+    )
     wrapper.setProps({
       user: {
         ...modifiedProps.user,
         tabs: 4,
       },
     })
-    expect(wrapper.find('[data-test-id="search-intro-a"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
+      true
+    )
   })
 
-  it('[search-intro-A] does not render the search intro notification when the user has previously clicked it', () => {
+  it('[experimental group] does not render the search intro notification when the user has previously clicked it', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('introA')
     const modifiedProps = cloneDeep(mockProps)
     modifiedProps.user.experimentActions.searchIntro = 'CLICK'
     const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
     expect(elem.exists()).toBe(false)
   })
 
-  it('[search-intro-A] does not render the search intro notification when the user has previously dismissed it', () => {
+  it('[experimental group] does not render the search intro notification when the user has previously dismissed it', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('introA')
     const modifiedProps = cloneDeep(mockProps)
     modifiedProps.user.experimentActions.searchIntro = 'DISMISS'
     const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
     expect(elem.exists()).toBe(false)
   })
 
-  it('[search-intro-A] does render the search intro notification if the user has not taken any action', () => {
+  it('[experimental group] does render the search intro notification if the user has not taken any action', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('introA')
     const modifiedProps = cloneDeep(mockProps)
     modifiedProps.user.experimentActions.searchIntro = 'NONE'
     const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
-    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
     expect(elem.exists()).toBe(true)
   })
 
-  it('[search-intro-A] hides the search intro when the onClick callback is called', async () => {
+  it('[experimental group] hides the search intro when the onClick callback is called', async () => {
     expect.assertions(2)
     getUserExperimentGroup.mockReturnValue('introA')
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find('[data-test-id="search-intro-a"]').length).toBe(1)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
-    expect(wrapper.find('[data-test-id="search-intro-a"]').length).toBe(0)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').length).toBe(1)
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').length).toBe(0)
   })
 
-  it('[search-intro-A] hides the search intro when the onDismiss callback is called', async () => {
+  it('[experimental group] hides the search intro when the onDismiss callback is called', async () => {
     expect.assertions(2)
     getUserExperimentGroup.mockReturnValue('introA')
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find('[data-test-id="search-intro-a"]').length).toBe(1)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onDismiss')()
-    expect(wrapper.find('[data-test-id="search-intro-a"]').length).toBe(0)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').length).toBe(1)
+    await wrapper
+      .find('[data-test-id="search-intro-notif"]')
+      .prop('onDismiss')()
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').length).toBe(0)
   })
 
-  it('[search-intro-A] logs the search intro experiment action when the onClick callback is called', async () => {
+  it('[experimental group] logs the search intro experiment action when the onClick callback is called', async () => {
     expect.assertions(1)
     getUserExperimentGroup.mockReturnValue('introA')
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
     expect(LogUserExperimentActionsMutation).toHaveBeenCalledWith({
       userId: 'abc-123',
       experimentActions: {
@@ -759,13 +779,15 @@ describe('Dashboard component: search intro experiment', () => {
     })
   })
 
-  it('[search-intro-A] logs the search intro experiment action when the onDismiss callback is called', async () => {
+  it('[experimental group] logs the search intro experiment action when the onDismiss callback is called', async () => {
     expect.assertions(1)
     getUserExperimentGroup.mockReturnValue('introA')
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onDismiss')()
+    await wrapper
+      .find('[data-test-id="search-intro-notif"]')
+      .prop('onDismiss')()
     expect(LogUserExperimentActionsMutation).toHaveBeenCalledWith({
       userId: 'abc-123',
       experimentActions: {
@@ -781,7 +803,7 @@ describe('Dashboard component: search intro experiment', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
     expect(goTo).toHaveBeenCalledWith(searchChromeExtensionPage)
   })
 
@@ -792,27 +814,60 @@ describe('Dashboard component: search intro experiment', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
     expect(goTo).toHaveBeenCalledWith(searchFirefoxExtensionPage)
   })
 
-  it('[search-intro-A] redirects to the Chrome web store when the user clicks the search intro action button on an unknown/unsupported browser', async () => {
+  it('[search-intro-homepage] redirects to the Search for a Cause homepage when the user clicks the search intro action button on an unknown/unsupported browser', async () => {
     expect.assertions(1)
     detectSupportedBrowser.mockReturnValue(UNSUPPORTED_BROWSER)
-    getUserExperimentGroup.mockReturnValue('introA')
+    getUserExperimentGroup.mockReturnValue('introHomepage')
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    await wrapper.find('[data-test-id="search-intro-a"]').prop('onClick')()
-    expect(goTo).toHaveBeenCalledWith(searchChromeExtensionPage)
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
+    expect(goTo).toHaveBeenCalledWith('https://search.gladly.io')
   })
 
-  it('[search-intro-A] does not sets the "useGlobalDismissalTime" on the experiment notification', () => {
+  it('[search-intro-homepage] redirects to the Search for a Cause homepage when the user clicks the search intro action button on a Chrome browser', async () => {
+    expect.assertions(1)
+    detectSupportedBrowser.mockReturnValue(CHROME_BROWSER)
+    getUserExperimentGroup.mockReturnValue('introHomepage')
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
+    expect(goTo).toHaveBeenCalledWith('https://search.gladly.io')
+  })
+
+  it('[search-intro-homepage] redirects to the Search for a Cause homepage when the user clicks the search intro action button on a Firefox browser', async () => {
+    expect.assertions(1)
+    detectSupportedBrowser.mockReturnValue(FIREFOX_BROWSER)
+    getUserExperimentGroup.mockReturnValue('introHomepage')
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
+    expect(goTo).toHaveBeenCalledWith('https://search.gladly.io')
+  })
+
+  it('[search-intro-homepage] redirects to the Search for a Cause homepage when the user clicks the search intro action button on an unknown/unsupported browser', async () => {
+    expect.assertions(1)
+    detectSupportedBrowser.mockReturnValue(UNSUPPORTED_BROWSER)
+    getUserExperimentGroup.mockReturnValue('introHomepage')
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    await wrapper.find('[data-test-id="search-intro-notif"]').prop('onClick')()
+    expect(goTo).toHaveBeenCalledWith('https://search.gladly.io')
+  })
+
+  it('[experimental group] does not sets the "useGlobalDismissalTime" on the experiment notification', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     getUserExperimentGroup.mockReturnValue('introA')
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    const elem = wrapper.find('[data-test-id="search-intro-a"]')
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
     expect(elem.prop('useGlobalDismissalTime')).toBe(false)
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/NotificationComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/NotificationComponent.test.js
@@ -16,6 +16,7 @@ const getMockProps = () => ({
   buttonURL: 'http://example.com/some-link/',
   onClick: undefined,
   onDismiss: undefined,
+  useGlobalDismissalTime: false,
 })
 
 afterEach(() => {
@@ -159,16 +160,30 @@ describe('Notification component', () => {
     ).toBe(false)
   })
 
-  it('sets the dismiss time in local storage when clicking the "dismiss" button', () => {
+  it('sets the dismiss time in local storage when clicking the "dismiss" button and the "useGlobalDismissalTime" prop is true', () => {
     const Notification = require('js/components/Dashboard/NotificationComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.useGlobalDismissalTime = true
     const wrapper = shallow(<Notification {...mockProps} />)
     wrapper
       .find(Button)
       .first()
       .simulate('click')
     expect(setNotificationDismissTime).toHaveBeenCalled()
+  })
+
+  it('does not set the dismiss time in local storage when clicking the "dismiss" button if the "useGlobalDismissalTime" is false', () => {
+    const Notification = require('js/components/Dashboard/NotificationComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.useGlobalDismissalTime = false
+    const wrapper = shallow(<Notification {...mockProps} />)
+    wrapper
+      .find(Button)
+      .first()
+      .simulate('click')
+    expect(setNotificationDismissTime).not.toHaveBeenCalled()
   })
 
   it('calls the onDismiss prop when clicking the "dismiss" button', () => {

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -1185,7 +1185,7 @@ describe('Actual experiments we are running or will run', () => {
       {
         name: 'searchIntro',
         active: false,
-        disabled: true,
+        disabled: false,
       },
     ])
   })

--- a/web/src/js/utils/__tests__/experiments.test.js
+++ b/web/src/js/utils/__tests__/experiments.test.js
@@ -1184,7 +1184,7 @@ describe('Actual experiments we are running or will run', () => {
       },
       {
         name: 'searchIntro',
-        active: false,
+        active: true,
         disabled: false,
       },
     ])

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -280,9 +280,9 @@ export const _experimentsConfig = [
   createExperiment({
     name: EXPERIMENT_SEARCH_INTRO,
     active: false,
-    disabled: true,
-    percentageOfExistingUsersInExperiment: 10.0,
-    percentageOfNewUsersInExperiment: 40.0,
+    disabled: false,
+    percentageOfExistingUsersInExperiment: 20.0,
+    percentageOfNewUsersInExperiment: 50.0,
     filters: [
       // In this test, include brand new users and users
       // who joined more than 2 months ago.
@@ -299,6 +299,10 @@ export const _experimentsConfig = [
       INTRO_A: createExperimentGroup({
         value: 'introA',
         schemaValue: 'INTRO_A',
+      }),
+      INTRO_HOMEPAGE: createExperimentGroup({
+        value: 'introHomepage',
+        schemaValue: 'INTRO_HOMEPAGE',
       }),
     },
   }),

--- a/web/src/js/utils/experiments.js
+++ b/web/src/js/utils/experiments.js
@@ -279,7 +279,7 @@ export const _experimentsConfig = [
   // @experiment-search-intro
   createExperiment({
     name: EXPERIMENT_SEARCH_INTRO,
-    active: false,
+    active: true,
     disabled: false,
     percentageOfExistingUsersInExperiment: 20.0,
     percentageOfNewUsersInExperiment: 50.0,


### PR DESCRIPTION
* Adds another experiment group to the "search intro" experiment, in which we send interested users directly to the Search for a Cause landing page
* Reenables the experiment, expanding from 10% to 20% of existing users 
* Fixes #579
