### PR TITLE
Search results page "Sign in" button

### DIFF
--- a/web/src/js/components/Search/SearchApp.js
+++ b/web/src/js/components/Search/SearchApp.js
@@ -5,6 +5,7 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 import defaultSearchTheme from 'js/theme/searchTheme'
+import SearchAuthRedirect from 'js/components/Search/SearchAuthRedirect'
 import SearchPageComponent from 'js/components/Search/SearchPageComponent'
 import SearchPostUninstallView from 'js/components/Search/SearchPostUninstallView'
 import SearchRandomQueryView from 'js/components/Search/SearchRandomQueryView'
@@ -52,6 +53,11 @@ class SearchApp extends React.Component {
                 exact
                 path="/search/uninstalled/"
                 component={SearchPostUninstallView}
+              />
+              <Route
+                exact
+                path="/search/auth/"
+                component={SearchAuthRedirect}
               />
               <Route
                 exact

--- a/web/src/js/components/Search/SearchAuthRedirect.js
+++ b/web/src/js/components/Search/SearchAuthRedirect.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { replaceUrl, loginURL } from 'js/navigation/navigation'
+import { SEARCH_APP } from 'js/constants'
+
+// A convenience route to redirect /search/auth/ to
+// /newtab/auth/?app=search.
+class SearchAuthRedirect extends React.Component {
+  componentDidMount() {
+    replaceUrl(loginURL, { app: SEARCH_APP })
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default SearchAuthRedirect

--- a/web/src/js/components/Search/SearchMenuComponent.js
+++ b/web/src/js/components/Search/SearchMenuComponent.js
@@ -6,11 +6,14 @@ import {
   MuiThemeProvider,
   withStyles,
 } from '@material-ui/core/styles'
+import Button from '@material-ui/core/Button'
 import CircleIcon from '@material-ui/icons/Lens'
 import theme from 'js/theme/searchTheme'
+import Link from 'js/components/General/Link'
 import MoneyRaised from 'js/components/MoneyRaised/MoneyRaisedContainer'
 import Hearts from 'js/components/Search/SearchHeartsContainer'
 import SettingsButton from 'js/components/Dashboard/SettingsButtonComponent'
+import { searchAuthURL } from 'js/navigation/navigation'
 
 const defaultTheme = createMuiTheme(theme)
 
@@ -28,9 +31,13 @@ const styles = {
 const menuFontSize = 22
 
 const SearchMenuComponent = props => {
-  // TODO: use isSearchExtensionInstalled
-  const { app, classes, style, user } = props
+  const { app, classes, isSearchExtensionInstalled, style, user } = props
   const userExists = !!user
+
+  // We only want to show the sign in button if the user is
+  // not signed in and has already installed the extension.
+  // Adding the extension is a higher priority.
+  const showSignInButton = !userExists && isSearchExtensionInstalled
   return (
     <MuiThemeProvider
       theme={{
@@ -74,7 +81,7 @@ const SearchMenuComponent = props => {
         )}
       >
         <MoneyRaised app={app} />
-        {userExists ? (
+        {userExists || showSignInButton ? (
           <div
             style={{
               display: 'flex',
@@ -89,8 +96,22 @@ const SearchMenuComponent = props => {
                 root: classes.circleIcon,
               }}
             />
-            <Hearts app={app} user={user} showMaxHeartsFromSearchesMessage />
-            <SettingsButton isUserAnonymous={false} />
+            {userExists ? (
+              <>
+                <Hearts
+                  app={app}
+                  user={user}
+                  showMaxHeartsFromSearchesMessage
+                />
+                <SettingsButton isUserAnonymous={false} />
+              </>
+            ) : showSignInButton ? (
+              <Link to={searchAuthURL} data-test-id={'search-sign-in-link'}>
+                <Button color={'primary'} variant={'contained'}>
+                  Sign in
+                </Button>
+              </Link>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/web/src/js/components/Search/SearchMenuComponent.js
+++ b/web/src/js/components/Search/SearchMenuComponent.js
@@ -28,6 +28,7 @@ const styles = {
 const menuFontSize = 22
 
 const SearchMenuComponent = props => {
+  // TODO: use isSearchExtensionInstalled
   const { app, classes, style, user } = props
   const userExists = !!user
   return (
@@ -102,12 +103,14 @@ SearchMenuComponent.displayName = 'SearchMenuComponent'
 SearchMenuComponent.propTypes = {
   app: PropTypes.shape({}).isRequired,
   classes: PropTypes.object.isRequired,
+  isSearchExtensionInstalled: PropTypes.bool.isRequired,
   style: PropTypes.object,
   // May not exist if the user is not signed in.
   user: PropTypes.shape({}),
 }
 
 SearchMenuComponent.defaultProps = {
+  isSearchExtensionInstalled: true,
   style: {},
 }
 

--- a/web/src/js/components/Search/SearchMenuQuery.js
+++ b/web/src/js/components/Search/SearchMenuQuery.js
@@ -83,12 +83,15 @@ SearchMenuQuery.propTypes = {
     isAnonymous: PropTypes.bool,
     emailVerified: PropTypes.bool,
   }),
+  isSearchExtensionInstalled: PropTypes.bool.isRequired,
   location: PropTypes.shape({
     search: PropTypes.string.isRequired,
   }),
 }
 
-SearchMenuQuery.defaultProps = {}
+SearchMenuQuery.defaultProps = {
+  isSearchExtensionInstalled: true,
+}
 
 export default withUser({
   redirectToAuthIfIncomplete: false,

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -366,7 +366,9 @@ class SearchPage extends React.Component {
               >
                 <Button color={'primary'}>Feedback</Button>
               </Link>
-              <SearchMenuQuery />
+              <SearchMenuQuery
+                isSearchExtensionInstalled={isSearchExtensionInstalled}
+              />
             </div>
           </div>
           <Tabs

--- a/web/src/js/components/Search/__tests__/SearchApp.test.js
+++ b/web/src/js/components/Search/__tests__/SearchApp.test.js
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme'
 import { Route } from 'react-router-dom'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import V0MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import SearchAuthRedirect from 'js/components/Search/SearchAuthRedirect'
 import SearchPageComponent from 'js/components/Search/SearchPageComponent'
 import SearchPostUninstallView from 'js/components/Search/SearchPostUninstallView'
 import SearchRandomQueryView from 'js/components/Search/SearchRandomQueryView'
@@ -107,13 +108,21 @@ describe('SearchApp', () => {
     expect(route.prop('component')).toBe(SearchPostUninstallView)
   })
 
-  it('contains the search browser extension post-uninstall route', async () => {
+  it('contains the search auth redirect route', async () => {
     const SearchApp = require('js/components/Search/SearchApp').default
     const wrapper = shallow(<SearchApp />)
     const route = wrapper
       .find(Route)
-      // Do not change this URL, because the browser extensions
-      // use it.
+      .filterWhere(n => n.prop('path') === '/search/auth/')
+    expect(route.exists()).toBe(true)
+    expect(route.prop('component')).toBe(SearchAuthRedirect)
+  })
+
+  it('contains the "random search" route', async () => {
+    const SearchApp = require('js/components/Search/SearchApp').default
+    const wrapper = shallow(<SearchApp />)
+    const route = wrapper
+      .find(Route)
       .filterWhere(n => n.prop('path') === '/search/random/')
     expect(route.exists()).toBe(true)
     expect(route.prop('component')).toBe(SearchRandomQueryView)

--- a/web/src/js/components/Search/__tests__/SearchAuthRedirect.test.js
+++ b/web/src/js/components/Search/__tests__/SearchAuthRedirect.test.js
@@ -1,0 +1,28 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import { replaceUrl } from 'js/navigation/navigation'
+
+jest.mock('js/navigation/navigation')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const mockProps = {}
+
+describe('SearchAuthRedirect', function() {
+  it('renders without error', () => {
+    const SearchAuthRedirect = require('js/components/Search/SearchAuthRedirect')
+      .default
+    shallow(<SearchAuthRedirect {...mockProps} />)
+  })
+
+  it('redirects to the auth page on mount', () => {
+    const SearchAuthRedirect = require('js/components/Search/SearchAuthRedirect')
+      .default
+    shallow(<SearchAuthRedirect {...mockProps} />)
+    expect(replaceUrl).toHaveBeenCalledWith('/newtab/auth/', { app: 'search' })
+  })
+})

--- a/web/src/js/components/Search/__tests__/SearchMenuComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchMenuComponent.test.js
@@ -4,20 +4,24 @@ import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { MuiThemeProvider } from '@material-ui/core/styles'
 import Hearts from 'js/components/Search/SearchHeartsContainer'
+import Button from '@material-ui/core/Button'
 import CircleIcon from '@material-ui/icons/Lens'
 import SettingsButton from 'js/components/Dashboard/SettingsButtonComponent'
 import MoneyRaised from 'js/components/MoneyRaised/MoneyRaisedContainer'
+import Link from 'js/components/General/Link'
 
 jest.mock('react-relay')
 jest.mock('js/components/Search/SearchHeartsContainer')
 jest.mock('js/components/Dashboard/SettingsButtonComponent')
 jest.mock('js/components/MoneyRaised/MoneyRaisedContainer')
+jest.mock('js/components/General/Link')
 
 const getMockProps = () => ({
   app: {
     moneyRaised: 610234.56,
     dollarsPerDayRate: 500.0,
   },
+  isSearchExtensionInstalled: true,
   user: null,
 })
 
@@ -88,13 +92,24 @@ describe('SearchMenuComponent', () => {
     )
   })
 
-  it('does not show the CircleIcon component if there is no user', () => {
+  it('does not show the CircleIcon component if there is no user and the user has not installed the extension', () => {
     const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
       .default
     const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = false
     mockProps.user = null
     const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
     expect(wrapper.find(CircleIcon).exists()).toBe(false)
+  })
+
+  it('shows the CircleIcon component if there is no user but the user has installed the extension (so we should show the sign-in button)', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = true
+    mockProps.user = null
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find(CircleIcon).exists()).toBe(true)
   })
 
   it('shows the CircleIcon component if there is a user', () => {
@@ -128,6 +143,73 @@ describe('SearchMenuComponent', () => {
     }
     const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
     expect(wrapper.find(SettingsButton).exists()).toBe(true)
+  })
+
+  it('shows the "sign in" button component if the user is not signed in and already installed the extension', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = true
+    mockProps.user = null
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="search-sign-in-link"]').exists()).toBe(
+      true
+    )
+  })
+
+  it('does not show the "sign in" button component if the user is already signed in', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = true
+    mockProps.user = {
+      tabsToday: 123,
+      vcCurrent: 864,
+    }
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="search-sign-in-link"]').exists()).toBe(
+      false
+    )
+  })
+
+  it('does not show the "sign in" button component if the user has not yet installed the extension (even if the user is not signed in)', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = false
+    mockProps.user = undefined
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="search-sign-in-link"]').exists()).toBe(
+      false
+    )
+  })
+
+  it('links the "sign in" button to the expected auth URL', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = true
+    mockProps.user = null
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    const elem = wrapper.find('[data-test-id="search-sign-in-link"]')
+    expect(elem.type()).toEqual(Link)
+    expect(elem.prop('to')).toEqual('/search/auth/')
+  })
+
+  it('shows the expected text in the "sign in" button', () => {
+    const SearchMenuComponent = require('js/components/Search/SearchMenuComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.isSearchExtensionInstalled = true
+    mockProps.user = null
+    const wrapper = shallow(<SearchMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="search-sign-in-link"]')
+        .find(Button)
+        .render()
+        .text()
+    ).toEqual('Sign in')
   })
 
   it('sets the expected theme typography h2 values', () => {

--- a/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
+++ b/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
@@ -124,4 +124,48 @@ describe('SearchMenuQuery', () => {
       .default
     expect(wrapper.find(SearchMenuContainer).length).toBe(0)
   })
+
+  it('passes the "isSearchExtensionInstalled" prop to the SearchMenuContainer', () => {
+    const fakeProps = {
+      app: {
+        some: 'value',
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    const { QueryRenderer } = require('react-relay')
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeProps,
+      retry: jest.fn(),
+    })
+
+    const SearchMenuQuery = require('js/components/Search/SearchMenuQuery')
+      .default
+    const wrapper = mount(
+      <SearchMenuQuery
+        isSearchExtensionInstalled={false}
+        location={{
+          search: '?q=tacos',
+        }}
+      />
+    )
+    const SearchMenuContainer = require('js/components/Search/SearchMenuContainer')
+      .default
+    expect(
+      wrapper.find(SearchMenuContainer).prop('isSearchExtensionInstalled')
+    ).toEqual(false)
+    wrapper.setProps({ isSearchExtensionInstalled: true })
+    expect(
+      wrapper.find(SearchMenuContainer).prop('isSearchExtensionInstalled')
+    ).toEqual(true)
+
+    // By default, pass that the search extension is installed.
+    wrapper.setProps({ isSearchExtensionInstalled: undefined })
+    expect(
+      wrapper.find(SearchMenuContainer).prop('isSearchExtensionInstalled')
+    ).toEqual(true)
+  })
 })

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -19,6 +19,7 @@ import {
   searchBetaFeedback,
 } from 'js/navigation/navigation'
 import { externalRedirect } from 'js/navigation/utils'
+import SearchMenuQuery from 'js/components/Search/SearchMenuQuery'
 import SearchResults from 'js/components/Search/SearchResults'
 import SearchResultsQueryBing from 'js/components/Search/SearchResultsQueryBing'
 import Tabs from '@material-ui/core/Tabs'
@@ -384,6 +385,35 @@ describe('Search page component', () => {
         .render()
         .text()
     ).toEqual('Feedback')
+  })
+
+  it('includes the SearchMenuQuery component', () => {
+    isSearchPageEnabled.mockReturnValue(true)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    const elem = wrapper.find(SearchMenuQuery)
+    expect(elem.exists()).toEqual(true)
+  })
+
+  it('passes the extension install state to the SearchMenuQuery component', () => {
+    isSearchPageEnabled.mockReturnValue(true)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+
+    isSearchExtensionInstalled.mockReturnValue(false)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(
+      wrapper.find(SearchMenuQuery).prop('isSearchExtensionInstalled')
+    ).toEqual(false)
+
+    isSearchExtensionInstalled.mockReturnValue(true)
+    const newWrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(
+      newWrapper.find(SearchMenuQuery).prop('isSearchExtensionInstalled')
+    ).toEqual(true)
   })
 })
 

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -138,9 +138,7 @@ export const accountURL = '/newtab/account/'
 
 // Search
 export const searchBaseURL = '/search'
-
-// TODO: for convenience, make '/search/auth/' redirect to
-//   /newtab/auth/?app=search
+export const searchAuthURL = '/search/auth/'
 
 // Homepage
 

--- a/web/src/js/utils/__tests__/search-utils.test.js
+++ b/web/src/js/utils/__tests__/search-utils.test.js
@@ -202,20 +202,54 @@ describe('getSearchResultCountPerPage', () => {
 })
 
 describe('isSearchExtensionInstalled', () => {
-  it('returns false if window.searchforacause is not defined', () => {
+  beforeEach(() => {
+    window.searchforacause.extension.isInstalled = false
+  })
+
+  it('returns false if window.searchforacause is not defined and the "q" URL param has a value', () => {
     delete window.searchforacause
+    getUrlParameters.mockReturnValue({
+      q: 'coffee',
+    })
     const { isSearchExtensionInstalled } = require('js/utils/search-utils')
     expect(isSearchExtensionInstalled()).toBe(false)
   })
 
   it('returns false if window.searchforacause.extension.isInstalled is false', () => {
     window.searchforacause.extension.isInstalled = false
+    getUrlParameters.mockReturnValue({
+      q: 'coffee',
+    })
     const { isSearchExtensionInstalled } = require('js/utils/search-utils')
     expect(isSearchExtensionInstalled()).toBe(false)
   })
 
   it('returns true if window.searchforacause.extension.isInstalled is true', () => {
     window.searchforacause.extension.isInstalled = true
+    getUrlParameters.mockReturnValue({
+      q: 'coffee',
+    })
+    const { isSearchExtensionInstalled } = require('js/utils/search-utils')
+    expect(isSearchExtensionInstalled()).toBe(true)
+  })
+
+  it('returns false if the search "src" URL param is null and a "q" URL param has a value', () => {
+    getUrlParameters.mockReturnValue({
+      q: 'coffee',
+      src: null,
+    })
+    detectSupportedBrowser.mockReturnValue('chrome')
+    const { isSearchExtensionInstalled } = require('js/utils/search-utils')
+    expect(isSearchExtensionInstalled()).toBe(false)
+  })
+
+  it('returns true when the "q" URL param does not have value, even if the "src" URL param is not defined', () => {
+    window.searchforacause.extension.isInstalled = false
+    getUrlParameters.mockReturnValue({
+      q: null,
+      src: null,
+    })
+    detectSupportedBrowser.mockReturnValue('chrome')
     const { isSearchExtensionInstalled } = require('js/utils/search-utils')
     expect(isSearchExtensionInstalled()).toBe(true)
   })
@@ -243,7 +277,6 @@ describe('isSearchExtensionInstalled', () => {
   })
 
   it('returns false if the search "src" URL param is Firefox but the browser is Chrome', () => {
-    window.searchforacause.extension.isInstalled = false
     getUrlParameters.mockReturnValue({
       q: 'coffee',
       src: 'ff',
@@ -254,7 +287,6 @@ describe('isSearchExtensionInstalled', () => {
   })
 
   it('returns false if the search "src" URL param is "self" but the browser is Chrome', () => {
-    window.searchforacause.extension.isInstalled = false
     getUrlParameters.mockReturnValue({
       q: 'coffee',
       src: 'self',
@@ -265,10 +297,20 @@ describe('isSearchExtensionInstalled', () => {
   })
 
   it('sets window.searchforacause.extension.isInstalled to true when the search source browser extension matches the browser', () => {
-    window.searchforacause.extension.isInstalled = false
     getUrlParameters.mockReturnValue({
       q: 'coffee',
       src: 'ff',
+    })
+    detectSupportedBrowser.mockReturnValue('firefox')
+    const { isSearchExtensionInstalled } = require('js/utils/search-utils')
+    isSearchExtensionInstalled()
+    expect(window.searchforacause.extension.isInstalled).toBe(true)
+  })
+
+  it('sets window.searchforacause.extension.isInstalled to true when the "q" URL parameter is null', () => {
+    getUrlParameters.mockReturnValue({
+      q: null,
+      src: null,
     })
     detectSupportedBrowser.mockReturnValue('firefox')
     const { isSearchExtensionInstalled } = require('js/utils/search-utils')

--- a/web/src/js/utils/search-utils.js
+++ b/web/src/js/utils/search-utils.js
@@ -128,20 +128,29 @@ export const isSearchExtensionInstalled = () => {
     window,
     'searchforacause.extension.isInstalled'
   )
-  let isSearchFromExt = false
+  let isInstalled = false
   if (!detectedExtPreviously) {
-    const searchSrc = getUrlParameters()['src']
+    const urlParams = getUrlParameters()
+    const searchSrc = urlParams.src
     const browser = detectSupportedBrowser()
-    isSearchFromExt =
+    const isSearchFromExt =
       (browser === CHROME_BROWSER &&
         searchSrc === SEARCH_SRC_CHROME_EXTENSION) ||
       (browser === FIREFOX_BROWSER &&
         searchSrc === SEARCH_SRC_FIREFOX_EXTENSION)
-    if (isSearchFromExt) {
+
+    // If there is no search query, let's say the extension is
+    // installed even if we're not sure. This avoids showing the
+    // "Add extension" button at inopportune times, like right after
+    // we send the user to the search page after sign-in without any
+    // URL parameter values set.
+    const hasSearchQuery = !!urlParams.q
+    isInstalled = !hasSearchQuery || isSearchFromExt
+    if (isInstalled) {
       set(window, 'searchforacause.extension.isInstalled', true)
     }
   }
-  return detectedExtPreviously || isSearchFromExt
+  return detectedExtPreviously || isInstalled
 }
 
 /**


### PR DESCRIPTION
Show a "Sign in" button on the search results page.

To limit the clutter, we do not always show the "Sign in" button when the user is not signed in. The logic to display the "Sign in" and "Add extension" buttons is:
* If the user has *not* installed the extension:
  * Show the "Add extension" button
  * Do not show the "Sign in" button, even if the user is not signed in
* If the user *has* installed the extension and is *not* signed in:
  * Do not show the "Add extension" button
  * Show the "Sign in" button
* If the user *has* installed the extension and *is* signed in:
  * Do not show the "Add extension" button
  * Do not show the "Sign in" button -- instead, show the Hearts and settings components in the user menu

**One exception**: we will not show the "Add extension" button when there is no `q` URL parameter value. Our current code to determine if the user has added the extension is somewhat imprecise: it uses the `src` URL parameter rather than any extension messaging (see https://github.com/gladly-team/tab/issues/616). After sign-in, we send the users to the `/search` page without a query, and it would be weird to ask people to add the extension if they have already done so. 