### PR TITLE
Update components in settings/profile pages

### DIFF
--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -75,6 +75,7 @@ class Dashboard extends React.Component {
 
     this.state = {
       errorMessage: null,
+      errorOpen: false,
       tabId: uuid(),
       isUserAnonymous: false, // Set after mount if true
       // This may be false if the user cleared their storage,
@@ -132,12 +133,15 @@ class Dashboard extends React.Component {
 
   showError(msg) {
     this.setState({
+      errorOpen: true,
       errorMessage: msg,
     })
   }
 
   clearError() {
-    this.showError(null)
+    this.setState({
+      errorOpen: false,
+    })
   }
 
   render() {
@@ -151,7 +155,7 @@ class Dashboard extends React.Component {
       searchIntroExperimentGroup,
       tabId,
     } = this.state
-    const errorMessage = this.state.errorMessage
+    const { errorMessage, errorOpen } = this.state
 
     // Whether or not a campaign should show on the dashboard
     const showCampaign = !!(
@@ -587,12 +591,11 @@ class Dashboard extends React.Component {
         {user ? <LogConsentData user={user} /> : null}
         {user ? <LogAccountCreation user={user} /> : null}
         {user ? <AssignExperimentGroups user={user} isNewUser={false} /> : null}
-        {errorMessage ? (
-          <ErrorMessage
-            message={errorMessage}
-            onRequestClose={this.clearError.bind(this)}
-          />
-        ) : null}
+        <ErrorMessage
+          message={errorMessage}
+          open={errorOpen}
+          onClose={this.clearError.bind(this)}
+        />
       </div>
     )
   }

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -280,20 +280,20 @@ describe('Dashboard component', () => {
     expect(wrapper.find(NewUserTour).length).toBe(0)
   })
 
-  it('does not render the ErrorMessage component when no error message is set', () => {
+  it('does not display the ErrorMessage component when no error message is set', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
-    expect(wrapper.find(ErrorMessage).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
   })
 
-  it('renders the ErrorMessage component when WidgetsContainer calls its "showError" prop', () => {
+  it('displays the ErrorMessage component when WidgetsContainer calls its "showError" prop', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
     wrapper.find(WidgetsContainer).prop('showError')('Big widget problem!')
     wrapper.update()
-    expect(wrapper.find(ErrorMessage).length).toBe(1)
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
     expect(wrapper.find(ErrorMessage).prop('message')).toBe(
       'Big widget problem!'
     )

--- a/web/src/js/components/Donate/CharityComponent.js
+++ b/web/src/js/components/Donate/CharityComponent.js
@@ -47,6 +47,10 @@ class Charity extends React.Component {
                 cursor: 'pointer',
                 maxWidth: '100%',
                 minWidth: '100%',
+                // The minHeight specification may break flexibility in sizing
+                // but it also prevents shifting content before the image has
+                // loaded.
+                minHeight: 180,
               }}
               src={charity.logo}
               onClick={this.openCharityWebsite.bind(this)}

--- a/web/src/js/components/General/ErrorMessage.js
+++ b/web/src/js/components/General/ErrorMessage.js
@@ -1,31 +1,37 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Snackbar from 'material-ui/Snackbar'
+import Snackbar from '@material-ui/core/Snackbar'
 
-class ErrorMessage extends React.Component {
-  render() {
-    const { message } = this.props
-    // TODO: set theme color.
-    return (
-      <Snackbar
-        contentStyle={{ textAlign: 'center' }}
-        {...this.props}
-        data-test-id={'error-message'}
-        message={message}
-        open
-        autoHideDuration={4000}
-      />
-    )
+const ErrorMessage = props => {
+  const { message, open, style, ...otherProps } = props
+  if (!message) {
+    return null
   }
+  return (
+    <Snackbar
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'center',
+      }}
+      style={style}
+      data-test-id={'error-message'}
+      autoHideDuration={4000}
+      {...otherProps}
+      message={message}
+      open={open}
+    />
+  )
 }
 
 ErrorMessage.propTypes = {
   message: PropTypes.string,
+  open: PropTypes.bool.isRequired,
   style: PropTypes.object,
 }
 
 ErrorMessage.defaultProps = {
   message: null,
+  open: true,
   style: {},
 }
 

--- a/web/src/js/components/General/__tests__/ErrorMessage.test.js
+++ b/web/src/js/components/General/__tests__/ErrorMessage.test.js
@@ -1,0 +1,106 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import Snackbar from '@material-ui/core/Snackbar'
+
+const getMockProps = () => ({
+  message: 'We kinda messed up.',
+  open: true,
+})
+
+describe('ErrorMessage', () => {
+  it('renders without error', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    shallow(<ErrorMessage {...mockProps} />)
+  })
+
+  it('returns a Snackbar', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.type()).toEqual(Snackbar)
+  })
+
+  it('returns null if no message is set', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    mockProps.open = true
+    mockProps.message = undefined
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.type()).toBeNull()
+  })
+
+  it('passes the message to the Snackbar', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    mockProps.message = 'Ohhhhh boy.'
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('message')).toEqual('Ohhhhh boy.')
+  })
+
+  it('passes the "open" prop to the Snackbar', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    mockProps.open = true
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('open')).toBe(true)
+    wrapper.setProps({ open: false })
+    expect(wrapper.find(Snackbar).prop('open')).toBe(false)
+  })
+
+  it('sets the Snackbar to be open by default when no "open" prop is provided', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    mockProps.open = undefined
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('open')).toBe(true)
+  })
+
+  it('sets a data-test-id="error-message"', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('data-test-id')).toEqual('error-message')
+  })
+
+  it('shows the Snackbar at bottom-center by default', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('anchorOrigin')).toEqual({
+      vertical: 'bottom',
+      horizontal: 'center',
+    })
+  })
+
+  it('sets the Snackbar autoHideDuration to 4000ms by default', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('autoHideDuration')).toEqual(4000)
+  })
+
+  it('allows overriding most props and allows extending the style prop', () => {
+    const ErrorMessage = require('js/components/General/ErrorMessage').default
+    const mockProps = getMockProps()
+    mockProps.anchorOrigin = {
+      vertical: 'top',
+      horizontal: 'left',
+    }
+    mockProps.style = { fontSize: 200 }
+    mockProps['data-test-id'] = 'my-thing'
+    mockProps.autoHideDuration = 1400
+    const wrapper = shallow(<ErrorMessage {...mockProps} />)
+    expect(wrapper.find(Snackbar).prop('anchorOrigin')).toEqual({
+      vertical: 'top',
+      horizontal: 'left',
+    })
+    expect(wrapper.find(Snackbar).prop('style')).toEqual({
+      fontSize: 200,
+    })
+    expect(wrapper.find(Snackbar).prop('data-test-id')).toEqual('my-thing')
+    expect(wrapper.find(Snackbar).prop('autoHideDuration')).toEqual(1400)
+  })
+})

--- a/web/src/js/components/Settings/Account/AccountView.js
+++ b/web/src/js/components/Settings/Account/AccountView.js
@@ -41,7 +41,7 @@ class AccountView extends React.Component {
             const showError = this.props.showError
             const dataLoaded = !!props
             return (
-              <SettingsChildWrapper loaded={dataLoaded}>
+              <SettingsChildWrapper>
                 {dataLoaded ? (
                   <Account user={props.user} showError={showError} />
                 ) : null}

--- a/web/src/js/components/Settings/Account/AccountView.js
+++ b/web/src/js/components/Settings/Account/AccountView.js
@@ -34,7 +34,8 @@ class AccountView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading your account :('
-              // FIXME
+
+              // Error will not autohide.
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Account/AccountView.js
+++ b/web/src/js/components/Settings/Account/AccountView.js
@@ -34,6 +34,7 @@ class AccountView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading your account :('
+              // FIXME
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Background/BackgroundSettingsView.js
+++ b/web/src/js/components/Settings/Background/BackgroundSettingsView.js
@@ -39,6 +39,7 @@ class BackgroundSettingsView extends React.Component {
               logger.error(error)
               const errMsg =
                 'We had a problem loading the background settings :('
+              // FIXME
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Background/BackgroundSettingsView.js
+++ b/web/src/js/components/Settings/Background/BackgroundSettingsView.js
@@ -46,7 +46,7 @@ class BackgroundSettingsView extends React.Component {
             const showError = this.props.showError
             const dataLoaded = !!props
             return (
-              <SettingsChildWrapper loaded={dataLoaded}>
+              <SettingsChildWrapper>
                 {dataLoaded ? (
                   <BackgroundSettings
                     app={props.app}

--- a/web/src/js/components/Settings/Background/BackgroundSettingsView.js
+++ b/web/src/js/components/Settings/Background/BackgroundSettingsView.js
@@ -39,7 +39,8 @@ class BackgroundSettingsView extends React.Component {
               logger.error(error)
               const errMsg =
                 'We had a problem loading the background settings :('
-              // FIXME
+
+              // Error will not autohide.
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Profile/InviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/InviteFriendComponent.js
@@ -2,22 +2,18 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import TextField from '@material-ui/core/TextField'
 import { withStyles } from '@material-ui/core/styles'
-import { alternateAccentColor } from 'js/theme/default'
 import LogReferralLinkClick from 'js/mutations/LogReferralLinkClickMutation'
 import logger from 'js/utils/logger'
 
-// Can replace this with a proper theme after fully migrating to
-// material-ui 1.0.
-// https://github.com/callemall/material-ui/blob/v1-beta/src/Input/Input.js#L78
 const styles = theme => ({
   inputUnderline: {
     '&:after': {
-      borderColor: alternateAccentColor,
+      borderColor: theme.palette.secondary.main,
     },
   },
   formLabelRoot: {
     '&$formLabelFocused': {
-      color: alternateAccentColor,
+      color: theme.palette.secondary.main,
     },
   },
   formLabelFocused: {},
@@ -72,12 +68,6 @@ class InviteFriend extends React.Component {
         InputProps={{
           classes: {
             underline: classes.inputUnderline,
-          },
-        }}
-        /* eslint-disable-next-line react/jsx-no-duplicate-props */
-        inputProps={{
-          style: {
-            textAlign: 'left',
           },
         }}
         InputLabelProps={{

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles'
 import Charity from 'js/components/Donate/CharityContainer'
 import Paper from '@material-ui/core/Paper'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
+import Typography from '@material-ui/core/Typography'
 
 const spacingPx = 6
 
@@ -12,9 +13,10 @@ const styles = theme => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    paddingLeft: 20,
-    paddingRight: 20,
+    padding: 14,
     marginBottom: 2 * spacingPx,
+  },
+  messageText: {
     color: theme.palette.action.active,
   },
   infoIcon: {
@@ -38,10 +40,10 @@ class ProfileDonateHearts extends React.Component {
       <div key={'charities-container-key'}>
         <Paper className={classes.messageContainer}>
           <InfoIcon className={classes.infoIcon} />
-          <p>
+          <Typography variant={'body2'} className={classes.messageText}>
             When you donate Hearts, you're telling us to give more of the money
             we raise to that charity.
-          </p>
+          </Typography>
         </Paper>
         <span className={classes.charitiesContainer}>
           {app.charities.edges.map(edge => {

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -66,9 +66,25 @@ class ProfileDonateHearts extends React.Component {
 }
 
 ProfileDonateHearts.propTypes = {
-  app: PropTypes.object.isRequired,
-  user: PropTypes.object.isRequired,
+  app: PropTypes.shape({
+    charities: PropTypes.shape({
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            image: PropTypes.string.isRequired,
+            impact: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+            website: PropTypes.string.isRequired,
+          }),
+        })
+      ),
+    }).isRequired,
+  }).isRequired,
+  user: PropTypes.shape({}).isRequired,
   showError: PropTypes.func.isRequired,
 }
+
+ProfileDonateHearts.defaultProps = {}
 
 export default ProfileDonateHearts

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -1,51 +1,49 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
 import Charity from 'js/components/Donate/CharityContainer'
 import Paper from '@material-ui/core/Paper'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
 
-// TODO: new MUI components
-import { lighterTextColor } from 'js/theme/default'
+const spacingPx = 6
+
+const styles = theme => ({
+  messageContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingLeft: 20,
+    paddingRight: 20,
+    marginBottom: 2 * spacingPx,
+    color: theme.palette.action.active,
+  },
+  infoIcon: {
+    marginRight: 8,
+    color: theme.palette.action.active,
+    minHeight: 24,
+    minWidth: 24,
+  },
+  charitiesContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginBottom: 34,
+  },
+})
 
 class ProfileDonateHearts extends React.Component {
   render() {
-    const { app, user } = this.props
-    const containerStyle = {}
-    const spacingPx = 6
+    const { app, classes, user } = this.props
     return (
-      <div key={'charities-container-key'} style={containerStyle}>
-        <Paper
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            paddingLeft: 20,
-            paddingRight: 20,
-            marginBottom: 2 * spacingPx,
-            color: lighterTextColor,
-          }}
-        >
-          <InfoIcon
-            style={{
-              marginRight: 8,
-              color: lighterTextColor,
-              minHeight: 24,
-              minWidth: 24,
-            }}
-          />
+      <div key={'charities-container-key'}>
+        <Paper className={classes.messageContainer}>
+          <InfoIcon className={classes.infoIcon} />
           <p>
             When you donate Hearts, you're telling us to give more of the money
             we raise to that charity.
           </p>
         </Paper>
-        <span
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            justifyContent: 'center',
-            marginBottom: 34,
-          }}
-        >
+        <span className={classes.charitiesContainer}>
           {app.charities.edges.map(edge => {
             return (
               <Charity
@@ -77,6 +75,7 @@ ProfileDonateHearts.propTypes = {
       ),
     }).isRequired,
   }).isRequired,
+  classes: PropTypes.object.isRequired,
   user: PropTypes.shape({
     // Passes field defined in CharityContainer
   }).isRequired,
@@ -85,4 +84,4 @@ ProfileDonateHearts.propTypes = {
 
 ProfileDonateHearts.defaultProps = {}
 
-export default ProfileDonateHearts
+export default withStyles(styles)(ProfileDonateHearts)

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Charity from 'js/components/Donate/CharityContainer'
+import Paper from '@material-ui/core/Paper'
+import InfoIcon from '@material-ui/icons/InfoOutlined'
 
 // TODO: new MUI components
-import Paper from 'material-ui/Paper'
-import InfoOutlineIcon from 'material-ui/svg-icons/action/info-outline'
 import { lighterTextColor } from 'js/theme/default'
 
 class ProfileDonateHearts extends React.Component {
@@ -25,7 +25,7 @@ class ProfileDonateHearts extends React.Component {
             color: lighterTextColor,
           }}
         >
-          <InfoOutlineIcon
+          <InfoIcon
             style={{
               marginRight: 8,
               color: lighterTextColor,

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -71,17 +71,15 @@ ProfileDonateHearts.propTypes = {
       edges: PropTypes.arrayOf(
         PropTypes.shape({
           node: PropTypes.shape({
-            id: PropTypes.string.isRequired,
-            image: PropTypes.string.isRequired,
-            impact: PropTypes.string.isRequired,
-            name: PropTypes.string.isRequired,
-            website: PropTypes.string.isRequired,
+            // Passes field defined in CharityContainer
           }),
         })
       ),
     }).isRequired,
   }).isRequired,
-  user: PropTypes.shape({}).isRequired,
+  user: PropTypes.shape({
+    // Passes field defined in CharityContainer
+  }).isRequired,
   showError: PropTypes.func.isRequired,
 }
 

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Charity from 'js/components/Donate/CharityContainer'
+
+// TODO: new MUI components
 import Paper from 'material-ui/Paper'
 import InfoOutlineIcon from 'material-ui/svg-icons/action/info-outline'
 import { lighterTextColor } from 'js/theme/default'

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
@@ -38,7 +38,8 @@ class ProfileDonateHeartsView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading the Donate Hearts page.'
-              // FIXME
+
+              // Error will not autohide.
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
@@ -45,7 +45,7 @@ class ProfileDonateHeartsView extends React.Component {
             const showError = this.props.showError
             const dataLoaded = !!props
             return (
-              <SettingsChildWrapper loaded={dataLoaded}>
+              <SettingsChildWrapper>
                 {dataLoaded ? (
                   <ProfileDonateHearts
                     app={props.app}

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
@@ -38,6 +38,7 @@ class ProfileDonateHeartsView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading the Donate Hearts page.'
+              // FIXME
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
@@ -25,7 +25,6 @@ const styles = theme => ({
     flexBasis: '40%',
     minWidth: 200,
   },
-  // stat: {}, // TODO: need to override inline styles in StatComponent
   thankYouPaper: {
     display: 'flex',
     justifyContent: 'center',
@@ -44,47 +43,45 @@ const styles = theme => ({
   },
 })
 
-class ProfileInviteFriend extends React.Component {
-  render() {
-    const { app, classes, user } = this.props
-    const friendWord = user.numUsersRecruited === 1 ? 'friend' : 'friends'
-    const statStyle = {
-      margin: spacingPx,
-      flex: 1,
-      paddingTop: 40,
-      paddingBottom: 40,
-    }
-    return (
-      <span className={classes.container}>
-        <Paper elevation={1} className={classes.inviteFriendPaper}>
-          <InviteFriend
-            user={user}
-            style={{
-              width: '100%',
-              maxWidth: 300,
-            }}
-          />
-        </Paper>
-        <Stat
-          stat={user.numUsersRecruited}
-          statText={`${friendWord} recruited`}
-          style={statStyle}
-        />
-        <Stat
-          stat={app.referralVcReward}
-          statText={'extra Hearts when you recruit a new friend'}
-          style={statStyle}
-        />
-        <Paper className={classes.thankYouPaper}>
-          <HappyIcon className={classes.happyIcon} />
-          <Typography variant={'body2'}>
-            Thank you! Every new person raises more money for charity, and we
-            depend on people like you to get the word out.
-          </Typography>
-        </Paper>
-      </span>
-    )
+const ProfileInviteFriend = props => {
+  const { app, classes, user } = props
+  const friendWord = user.numUsersRecruited === 1 ? 'friend' : 'friends'
+  const statStyle = {
+    margin: spacingPx,
+    flex: 1,
+    paddingTop: 40,
+    paddingBottom: 40,
   }
+  return (
+    <span className={classes.container}>
+      <Paper elevation={1} className={classes.inviteFriendPaper}>
+        <InviteFriend
+          user={user}
+          style={{
+            width: '100%',
+            maxWidth: 300,
+          }}
+        />
+      </Paper>
+      <Stat
+        stat={user.numUsersRecruited}
+        statText={`${friendWord} recruited`}
+        style={statStyle}
+      />
+      <Stat
+        stat={app.referralVcReward}
+        statText={'extra Hearts when you recruit a new friend'}
+        style={statStyle}
+      />
+      <Paper className={classes.thankYouPaper}>
+        <HappyIcon className={classes.happyIcon} />
+        <Typography variant={'body2'}>
+          Thank you! Every new person raises more money for charity, and we
+          depend on people like you to get the word out.
+        </Typography>
+      </Paper>
+    </span>
+  )
 }
 
 ProfileInviteFriend.propTypes = {

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
@@ -2,9 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
 import Stat from 'js/components/Settings/Profile/StatComponent'
-import { lighterTextColor } from 'js/theme/default'
-import HappyIcon from 'material-ui/svg-icons/social/mood'
-import Paper from 'material-ui/Paper'
+import HappyIcon from '@material-ui/icons/Mood'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
 
 class ProfileInviteFriend extends React.Component {
   render() {
@@ -26,6 +26,7 @@ class ProfileInviteFriend extends React.Component {
         }}
       >
         <Paper
+          elevation={1}
           style={{
             display: 'flex',
             justifyContent: 'center',
@@ -74,7 +75,6 @@ class ProfileInviteFriend extends React.Component {
             flexBasis: '50%',
             minWidth: 200,
             padding: 20,
-            color: lighterTextColor,
             margin: spacingPx,
           }}
         >
@@ -83,13 +83,13 @@ class ProfileInviteFriend extends React.Component {
               minHeight: 24,
               minWidth: 24,
               marginRight: 8,
-              color: lighterTextColor,
+              color: 'black', // TODO: fix colors
             }}
           />
-          <p>
+          <Typography variant={'body2'}>
             Thank you! Every new person raises more money for charity, and we
             depend on people like you to get the word out.
-          </p>
+          </Typography>
         </Paper>
       </span>
     )

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
@@ -1,16 +1,53 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
 import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
 import Stat from 'js/components/Settings/Profile/StatComponent'
 import HappyIcon from '@material-ui/icons/Mood'
 import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
 
+const spacingPx = 6
+
+const styles = theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    margin: -spacingPx,
+  },
+  inviteFriendPaper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 18,
+    margin: spacingPx,
+    flex: 2,
+    flexBasis: '40%',
+    minWidth: 200,
+  },
+  // stat: {}, // TODO: need to override inline styles in StatComponent
+  thankYouPaper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flex: 1,
+    flexBasis: '50%',
+    minWidth: 200,
+    padding: 20,
+    margin: spacingPx,
+  },
+  happyIcon: {
+    minHeight: 24,
+    minWidth: 24,
+    marginRight: 8,
+    color: 'black', // TODO: fix colors
+  },
+})
+
 class ProfileInviteFriend extends React.Component {
   render() {
-    const { app, user } = this.props
+    const { app, classes, user } = this.props
     const friendWord = user.numUsersRecruited === 1 ? 'friend' : 'friends'
-    const spacingPx = 6
     const statStyle = {
       margin: spacingPx,
       flex: 1,
@@ -18,43 +55,15 @@ class ProfileInviteFriend extends React.Component {
       paddingBottom: 40,
     }
     return (
-      <span
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          margin: -spacingPx,
-        }}
-      >
-        <Paper
-          elevation={1}
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignContent: 'middle',
-            padding: 10,
-            margin: spacingPx,
-            flex: 2,
-            flexBasis: '40%',
-            minWidth: 200,
-          }}
-        >
-          <span
+      <span className={classes.container}>
+        <Paper elevation={1} className={classes.inviteFriendPaper}>
+          <InviteFriend
+            user={user}
             style={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignContent: 'middle',
               width: '100%',
               maxWidth: 300,
-              marginTop: 30,
-              marginBottom: 30,
-              marginLeft: 8,
-              marginRight: 8,
-              boxSizing: 'border-box',
             }}
-          >
-            <InviteFriend user={user} />
-          </span>
+          />
         </Paper>
         <Stat
           stat={user.numUsersRecruited}
@@ -66,26 +75,8 @@ class ProfileInviteFriend extends React.Component {
           statText={'extra Hearts when you recruit a new friend'}
           style={statStyle}
         />
-        <Paper
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            flex: 1,
-            flexBasis: '50%',
-            minWidth: 200,
-            padding: 20,
-            margin: spacingPx,
-          }}
-        >
-          <HappyIcon
-            style={{
-              minHeight: 24,
-              minWidth: 24,
-              marginRight: 8,
-              color: 'black', // TODO: fix colors
-            }}
-          />
+        <Paper className={classes.thankYouPaper}>
+          <HappyIcon className={classes.happyIcon} />
           <Typography variant={'body2'}>
             Thank you! Every new person raises more money for charity, and we
             depend on people like you to get the word out.
@@ -100,9 +91,10 @@ ProfileInviteFriend.propTypes = {
   app: PropTypes.shape({
     referralVcReward: PropTypes.number.isRequired,
   }),
+  classes: PropTypes.object.isRequired,
   user: PropTypes.shape({
     numUsersRecruited: PropTypes.number.isRequired,
   }),
 }
 
-export default ProfileInviteFriend
+export default withStyles(styles)(ProfileInviteFriend)

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
@@ -36,10 +36,13 @@ const styles = theme => ({
     margin: spacingPx,
   },
   happyIcon: {
-    minHeight: 24,
-    minWidth: 24,
+    height: 20,
+    width: 20,
     marginRight: 8,
-    color: 'black', // TODO: fix colors
+    color: theme.palette.action.active,
+  },
+  thankYouText: {
+    color: theme.palette.action.active,
   },
 })
 
@@ -75,7 +78,7 @@ const ProfileInviteFriend = props => {
       />
       <Paper className={classes.thankYouPaper}>
         <HappyIcon className={classes.happyIcon} />
-        <Typography variant={'body2'}>
+        <Typography variant={'body2'} className={classes.thankYouText}>
           Thank you! Every new person raises more money for charity, and we
           depend on people like you to get the word out.
         </Typography>

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
@@ -38,6 +38,7 @@ class ProfileInviteFriendView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading this page :('
+              // FIXME
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
@@ -45,7 +45,7 @@ class ProfileInviteFriendView extends React.Component {
             const showError = this.props.showError
             const dataLoaded = !!props
             return (
-              <SettingsChildWrapper loaded={dataLoaded}>
+              <SettingsChildWrapper>
                 {dataLoaded ? (
                   <ProfileInviteFriend
                     app={props.app}

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
@@ -38,8 +38,9 @@ class ProfileInviteFriendView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading this page :('
-              // FIXME
-              return <ErrorMessage message={errMsg} />
+
+              // Error will not autohide.
+              return <ErrorMessage message={errMsg} open />
             }
             const showError = this.props.showError
             const dataLoaded = !!props

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -9,7 +9,7 @@ import HeartBorderIcon from '@material-ui/icons/FavoriteBorder'
 import Typography from '@material-ui/core/Typography'
 
 import Stat from 'js/components/Settings/Profile/StatComponent'
-import { goToInviteFriends, goToDonate } from 'js/navigation/navigation'
+import { goTo, donateURL, inviteFriendsURL } from 'js/navigation/navigation'
 import { abbreviateNumber, commaFormatted } from 'js/utils/utils'
 
 const spacingPx = 6
@@ -123,7 +123,9 @@ const ProfileStats = props => {
             <Button
               color={'primary'}
               variant={'contained'}
-              onClick={goToInviteFriends}
+              onClick={() => {
+                goTo(inviteFriendsURL)
+              }}
               style={{ marginTop: 14 }}
             >
               Invite Friends
@@ -138,7 +140,9 @@ const ProfileStats = props => {
             <Button
               color={'primary'}
               variant={'contained'}
-              onClick={goToDonate}
+              onClick={() => {
+                goTo(donateURL)
+              }}
               style={{ marginTop: 14 }}
             >
               Donate Hearts

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
+
+// TODO: update MUI components
 import RaisedButton from 'material-ui/RaisedButton'
 import HeartBorderIcon from 'material-ui/svg-icons/action/favorite-border'
 import Stat from 'js/components/Settings/Profile/StatComponent'

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -6,6 +6,7 @@ import Paper from '@material-ui/core/Paper'
 import Button from '@material-ui/core/Button'
 import ChartIcon from '@material-ui/icons/InsertChart'
 import HeartBorderIcon from '@material-ui/icons/FavoriteBorder'
+import Typography from '@material-ui/core/Typography'
 
 // TODO: update MUI components
 import appTheme, { lighterTextColor } from 'js/theme/default'
@@ -42,8 +43,7 @@ class ProfileStats extends React.Component {
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
-            paddingLeft: 20,
-            paddingRight: 20,
+            padding: 14,
             marginBottom: 2 * spacingPx,
             color: lighterTextColor,
           }}
@@ -56,10 +56,10 @@ class ProfileStats extends React.Component {
               minWidth: 24,
             }}
           />
-          <p>
+          <Typography variant={'body2'}>
             <span style={{ fontWeight: 500 }}>{greeting}</span>
             <span> Here's all your great work Tabbing, by the numbers.</span>
-          </p>
+          </Typography>
         </Paper>
         <span
           style={{
@@ -82,9 +82,9 @@ class ProfileStats extends React.Component {
             stat={commaFormatted(user.maxTabsDay.numTabs)}
             statText={'max tabs in one day'}
             extraContent={
-              <span style={extraContentTextStyle}>
+              <Typography variant={'body2'} style={extraContentTextStyle}>
                 on {moment(user.maxTabsDay.date).format('LL')}
-              </span>
+              </Typography>
             }
             style={statStyle}
           />
@@ -92,7 +92,7 @@ class ProfileStats extends React.Component {
             stat={user.level}
             statText={'your level'}
             extraContent={
-              <span style={extraContentTextStyle}>
+              <Typography variant={'body2'} style={extraContentTextStyle}>
                 <span>{user.heartsUntilNextLevel}</span>
                 <HeartBorderIcon
                   style={{
@@ -105,7 +105,7 @@ class ProfileStats extends React.Component {
                   }}
                 />
                 <span>until next level</span>
-              </span>
+              </Typography>
             }
             style={statStyle}
           />

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -1,35 +1,67 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
-
+import { withStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Button from '@material-ui/core/Button'
 import ChartIcon from '@material-ui/icons/InsertChart'
 import HeartBorderIcon from '@material-ui/icons/FavoriteBorder'
 import Typography from '@material-ui/core/Typography'
 
-// TODO: update MUI components
-import appTheme, { lighterTextColor } from 'js/theme/default'
-
 import Stat from 'js/components/Settings/Profile/StatComponent'
 import { goToInviteFriends, goToDonate } from 'js/navigation/navigation'
 import { abbreviateNumber, commaFormatted } from 'js/utils/utils'
 
+const spacingPx = 6
+
+const styles = theme => ({
+  messageContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 14,
+    marginBottom: 2 * spacingPx,
+  },
+  chartIcon: {
+    marginRight: 8,
+    color: theme.palette.action.active,
+    minHeight: 24,
+    minWidth: 24,
+  },
+  messageText: {
+    color: theme.palette.action.active,
+  },
+  greetingText: {
+    fontWeight: 500,
+  },
+  statsWrapper: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    margin: -spacingPx,
+  },
+  statExtraContentText: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    color: theme.palette.action.active,
+  },
+  heartIcon: {
+    marginLeft: 0,
+    marginRight: 2,
+    height: 16,
+    width: 16,
+    paddingBottom: 0,
+  },
+})
+
 class ProfileStats extends React.Component {
   render() {
-    const { user } = this.props
+    const { classes, user } = this.props
     const now = moment().utc()
     const daysSinceJoined = now.diff(moment(user.joined), 'days')
     const dayWord = daysSinceJoined === 1 ? 'day' : 'days'
     const tabberWord = user.numUsersRecruited === 1 ? 'Tabber' : 'Tabbers'
     const heartsWord = user.vcDonatedAllTime === 1 ? 'Heart' : 'Hearts'
-    const extraContentTextStyle = {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      color: appTheme.palette.disabledColor,
-    }
-    const spacingPx = 6
     const statStyle = {
       flex: 1,
       flexBasis: '20%',
@@ -38,36 +70,14 @@ class ProfileStats extends React.Component {
     const greeting = user.username ? `Hi, ${user.username}!` : 'Hi!'
     return (
       <div>
-        <Paper
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            padding: 14,
-            marginBottom: 2 * spacingPx,
-            color: lighterTextColor,
-          }}
-        >
-          <ChartIcon
-            style={{
-              marginRight: 8,
-              color: lighterTextColor,
-              minHeight: 24,
-              minWidth: 24,
-            }}
-          />
-          <Typography variant={'body2'}>
-            <span style={{ fontWeight: 500 }}>{greeting}</span>
+        <Paper className={classes.messageContainer}>
+          <ChartIcon className={classes.chartIcon} />
+          <Typography variant={'body2'} className={classes.messageText}>
+            <span className={classes.greetingText}>{greeting}</span>
             <span> Here's all your great work Tabbing, by the numbers.</span>
           </Typography>
         </Paper>
-        <span
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            margin: -spacingPx,
-          }}
-        >
+        <span className={classes.statsWrapper}>
           <Stat
             stat={commaFormatted(daysSinceJoined)}
             statText={`${dayWord} as a Tabber`}
@@ -82,7 +92,10 @@ class ProfileStats extends React.Component {
             stat={commaFormatted(user.maxTabsDay.numTabs)}
             statText={'max tabs in one day'}
             extraContent={
-              <Typography variant={'body2'} style={extraContentTextStyle}>
+              <Typography
+                variant={'body2'}
+                className={classes.statExtraContentText}
+              >
                 on {moment(user.maxTabsDay.date).format('LL')}
               </Typography>
             }
@@ -92,18 +105,12 @@ class ProfileStats extends React.Component {
             stat={user.level}
             statText={'your level'}
             extraContent={
-              <Typography variant={'body2'} style={extraContentTextStyle}>
+              <Typography
+                variant={'body2'}
+                className={classes.statExtraContentText}
+              >
                 <span>{user.heartsUntilNextLevel}</span>
-                <HeartBorderIcon
-                  style={{
-                    color: appTheme.palette.disabledColor,
-                    marginLeft: 0,
-                    marginRight: 2,
-                    height: 16,
-                    width: 16,
-                    paddingBottom: 0,
-                  }}
-                />
+                <HeartBorderIcon className={classes.heartIcon} />
                 <span>until next level</span>
               </Typography>
             }
@@ -146,6 +153,7 @@ class ProfileStats extends React.Component {
 }
 
 ProfileStats.propTypes = {
+  classes: PropTypes.object.isRequired,
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
     username: PropTypes.string,
@@ -162,4 +170,4 @@ ProfileStats.propTypes = {
   }).isRequired,
 }
 
-export default ProfileStats
+export default withStyles(styles)(ProfileStats)

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -54,102 +54,100 @@ const styles = theme => ({
   },
 })
 
-class ProfileStats extends React.Component {
-  render() {
-    const { classes, user } = this.props
-    const now = moment().utc()
-    const daysSinceJoined = now.diff(moment(user.joined), 'days')
-    const dayWord = daysSinceJoined === 1 ? 'day' : 'days'
-    const tabberWord = user.numUsersRecruited === 1 ? 'Tabber' : 'Tabbers'
-    const heartsWord = user.vcDonatedAllTime === 1 ? 'Heart' : 'Hearts'
-    const statStyle = {
-      flex: 1,
-      flexBasis: '20%',
-      margin: spacingPx,
-    }
-    const greeting = user.username ? `Hi, ${user.username}!` : 'Hi!'
-    return (
-      <div>
-        <Paper className={classes.messageContainer}>
-          <ChartIcon className={classes.chartIcon} />
-          <Typography variant={'body2'} className={classes.messageText}>
-            <span className={classes.greetingText}>{greeting}</span>
-            <span> Here's all your great work Tabbing, by the numbers.</span>
-          </Typography>
-        </Paper>
-        <span className={classes.statsWrapper}>
-          <Stat
-            stat={commaFormatted(daysSinceJoined)}
-            statText={`${dayWord} as a Tabber`}
-            style={statStyle}
-          />
-          <Stat
-            stat={abbreviateNumber(user.tabs, 1)}
-            statText={'tabs all time'}
-            style={statStyle}
-          />
-          <Stat
-            stat={commaFormatted(user.maxTabsDay.numTabs)}
-            statText={'max tabs in one day'}
-            extraContent={
-              <Typography
-                variant={'body2'}
-                className={classes.statExtraContentText}
-              >
-                on {moment(user.maxTabsDay.date).format('LL')}
-              </Typography>
-            }
-            style={statStyle}
-          />
-          <Stat
-            stat={user.level}
-            statText={'your level'}
-            extraContent={
-              <Typography
-                variant={'body2'}
-                className={classes.statExtraContentText}
-              >
-                <span>{user.heartsUntilNextLevel}</span>
-                <HeartBorderIcon className={classes.heartIcon} />
-                <span>until next level</span>
-              </Typography>
-            }
-            style={statStyle}
-          />
-          <Stat
-            stat={commaFormatted(user.numUsersRecruited)}
-            statText={`${tabberWord} recruited`}
-            style={statStyle}
-            extraContent={
-              <Button
-                color={'primary'}
-                variant={'contained'}
-                onClick={goToInviteFriends}
-                style={{ marginTop: 14 }}
-              >
-                Invite Friends
-              </Button>
-            }
-          />
-          <Stat
-            stat={abbreviateNumber(user.vcDonatedAllTime, 1)}
-            statText={`${heartsWord} donated`}
-            style={statStyle}
-            extraContent={
-              <Button
-                color={'primary'}
-                variant={'contained'}
-                onClick={goToDonate}
-                style={{ marginTop: 14 }}
-              >
-                Donate Hearts
-              </Button>
-            }
-          />
-        </span>
-      </div>
-    )
+const ProfileStats = props => {
+  const { classes, user } = props
+  const now = moment().utc()
+  const daysSinceJoined = now.diff(moment(user.joined), 'days')
+  const dayWord = daysSinceJoined === 1 ? 'day' : 'days'
+  const tabberWord = user.numUsersRecruited === 1 ? 'Tabber' : 'Tabbers'
+  const heartsWord = user.vcDonatedAllTime === 1 ? 'Heart' : 'Hearts'
+  const statStyle = {
+    flex: 1,
+    flexBasis: '20%',
+    margin: spacingPx,
   }
+  const greeting = user.username ? `Hi, ${user.username}!` : 'Hi!'
+  return (
+    <div>
+      <Paper className={classes.messageContainer}>
+        <ChartIcon className={classes.chartIcon} />
+        <Typography variant={'body2'} className={classes.messageText}>
+          <span className={classes.greetingText}>{greeting}</span>
+          <span> Here's all your great work Tabbing, by the numbers.</span>
+        </Typography>
+      </Paper>
+      <span className={classes.statsWrapper}>
+        <Stat
+          stat={commaFormatted(daysSinceJoined)}
+          statText={`${dayWord} as a Tabber`}
+          style={statStyle}
+        />
+        <Stat
+          stat={abbreviateNumber(user.tabs, 1)}
+          statText={'tabs all time'}
+          style={statStyle}
+        />
+        <Stat
+          stat={commaFormatted(user.maxTabsDay.numTabs)}
+          statText={'max tabs in one day'}
+          extraContent={
+            <Typography
+              variant={'body2'}
+              className={classes.statExtraContentText}
+            >
+              on {moment(user.maxTabsDay.date).format('LL')}
+            </Typography>
+          }
+          style={statStyle}
+        />
+        <Stat
+          stat={user.level}
+          statText={'your level'}
+          extraContent={
+            <Typography
+              variant={'body2'}
+              className={classes.statExtraContentText}
+            >
+              <span>{user.heartsUntilNextLevel}</span>
+              <HeartBorderIcon className={classes.heartIcon} />
+              <span>until next level</span>
+            </Typography>
+          }
+          style={statStyle}
+        />
+        <Stat
+          stat={commaFormatted(user.numUsersRecruited)}
+          statText={`${tabberWord} recruited`}
+          style={statStyle}
+          extraContent={
+            <Button
+              color={'primary'}
+              variant={'contained'}
+              onClick={goToInviteFriends}
+              style={{ marginTop: 14 }}
+            >
+              Invite Friends
+            </Button>
+          }
+        />
+        <Stat
+          stat={abbreviateNumber(user.vcDonatedAllTime, 1)}
+          statText={`${heartsWord} donated`}
+          style={statStyle}
+          extraContent={
+            <Button
+              color={'primary'}
+              variant={'contained'}
+              onClick={goToDonate}
+              style={{ marginTop: 14 }}
+            >
+              Donate Hearts
+            </Button>
+          }
+        />
+      </span>
+    </div>
+  )
 }
 
 ProfileStats.propTypes = {

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -2,13 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 
+import Paper from '@material-ui/core/Paper'
+import Button from '@material-ui/core/Button'
+import ChartIcon from '@material-ui/icons/InsertChart'
+import HeartBorderIcon from '@material-ui/icons/FavoriteBorder'
+
 // TODO: update MUI components
-import RaisedButton from 'material-ui/RaisedButton'
-import HeartBorderIcon from 'material-ui/svg-icons/action/favorite-border'
-import Stat from 'js/components/Settings/Profile/StatComponent'
-import Paper from 'material-ui/Paper'
 import appTheme, { lighterTextColor } from 'js/theme/default'
-import ChartIcon from 'material-ui/svg-icons/editor/insert-chart'
+
+import Stat from 'js/components/Settings/Profile/StatComponent'
 import { goToInviteFriends, goToDonate } from 'js/navigation/navigation'
 import { abbreviateNumber, commaFormatted } from 'js/utils/utils'
 
@@ -94,13 +96,13 @@ class ProfileStats extends React.Component {
                 <span>{user.heartsUntilNextLevel}</span>
                 <HeartBorderIcon
                   style={{
+                    color: appTheme.palette.disabledColor,
                     marginLeft: 0,
                     marginRight: 2,
                     height: 16,
                     width: 16,
                     paddingBottom: 0,
                   }}
-                  color={appTheme.palette.disabledColor}
                 />
                 <span>until next level</span>
               </span>
@@ -112,12 +114,14 @@ class ProfileStats extends React.Component {
             statText={`${tabberWord} recruited`}
             style={statStyle}
             extraContent={
-              <RaisedButton
-                label="Invite Friends"
-                style={{ marginTop: 14 }}
-                primary
+              <Button
+                color={'primary'}
+                variant={'contained'}
                 onClick={goToInviteFriends}
-              />
+                style={{ marginTop: 14 }}
+              >
+                Invite Friends
+              </Button>
             }
           />
           <Stat
@@ -125,12 +129,14 @@ class ProfileStats extends React.Component {
             statText={`${heartsWord} donated`}
             style={statStyle}
             extraContent={
-              <RaisedButton
-                label="Donate Hearts"
-                style={{ marginTop: 14 }}
-                primary
+              <Button
+                color={'primary'}
+                variant={'contained'}
                 onClick={goToDonate}
-              />
+                style={{ marginTop: 14 }}
+              >
+                Donate Hearts
+              </Button>
             }
           />
         </span>

--- a/web/src/js/components/Settings/Profile/ProfileStatsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsView.js
@@ -42,7 +42,7 @@ class ProfileStatsView extends React.Component {
             const showError = this.props.showError
             const dataLoaded = !!props
             return (
-              <SettingsChildWrapper loaded={dataLoaded}>
+              <SettingsChildWrapper>
                 {dataLoaded ? (
                   <ProfileStats user={props.user} showError={showError} />
                 ) : null}

--- a/web/src/js/components/Settings/Profile/ProfileStatsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsView.js
@@ -35,6 +35,7 @@ class ProfileStatsView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading your stats :('
+              // FIXME
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Profile/ProfileStatsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsView.js
@@ -35,7 +35,8 @@ class ProfileStatsView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading your stats :('
-              // FIXME
+
+              // Error will not autohide.
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Profile/StatComponent.js
+++ b/web/src/js/components/Settings/Profile/StatComponent.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Paper from 'material-ui/Paper'
-import { alternateAccentColor } from 'js/theme/default'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
 
-class Stat extends React.Component {
-  render() {
-    const containerStyle = Object.assign(
-      {},
-      {
+const Stat = props => {
+  const { extraContent, stat, statText, style } = props
+  return (
+    <Paper
+      style={{
         paddingTop: 50,
         paddingBottom: 50,
         minWidth: 200,
@@ -15,43 +15,43 @@ class Stat extends React.Component {
         flexDirection: 'column',
         justifyContent: 'center',
         alignContent: 'middle',
-      },
-      this.props.style
-    )
-    const statStyle = {
-      color: alternateAccentColor,
-      display: 'block',
-      fontSize: 50,
-      textAlign: 'center',
-    }
-    const statTextStyle = {
-      display: 'block',
-      textAlign: 'center',
-      maxWidth: '70%',
-    }
-    const extraContentStyle = {
-      display: 'block',
-      marginTop: 4,
-      minHeight: 16,
-      alignSelf: 'center',
-      textAlign: 'center',
-    }
-    return (
-      <Paper style={containerStyle}>
-        <span
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-          }}
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
+        <Typography
+          variant={'h2'}
+          color={'secondary'}
+          style={{ textAlign: 'center' }}
         >
-          <span style={statStyle}>{this.props.stat}</span>
-          <span style={statTextStyle}>{this.props.statText}</span>
-        </span>
-        <span style={extraContentStyle}>{this.props.extraContent}</span>
-      </Paper>
-    )
-  }
+          {stat}
+        </Typography>
+        <Typography
+          variant={'body2'}
+          style={{ textAlign: 'center', maxWidth: '70%' }}
+        >
+          {statText}
+        </Typography>
+      </span>
+      <span
+        style={{
+          display: 'block',
+          marginTop: 4,
+          minHeight: 16,
+          alignSelf: 'center',
+          textAlign: 'center',
+        }}
+      >
+        {extraContent}
+      </span>
+    </Paper>
+  )
 }
 
 Stat.propTypes = {

--- a/web/src/js/components/Settings/Profile/StatComponent.js
+++ b/web/src/js/components/Settings/Profile/StatComponent.js
@@ -21,6 +21,7 @@ const styles = theme => ({
   },
   stat: {
     textAlign: 'center',
+    marginBottom: 6,
   },
   statText: {
     textAlign: 'center',

--- a/web/src/js/components/Settings/Profile/StatComponent.js
+++ b/web/src/js/components/Settings/Profile/StatComponent.js
@@ -1,60 +1,64 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
 
+const styles = theme => ({
+  root: {
+    paddingTop: 50,
+    paddingBottom: 50,
+    minWidth: 200,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignContent: 'middle',
+  },
+  mainContentContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  stat: {
+    textAlign: 'center',
+  },
+  statText: {
+    textAlign: 'center',
+    maxWidth: '70%',
+  },
+  extraContent: {
+    display: 'block',
+    marginTop: 4,
+    minHeight: 16,
+    alignSelf: 'center',
+    textAlign: 'center',
+  },
+})
+
 const Stat = props => {
-  const { extraContent, stat, statText, style } = props
+  const { classes, extraContent, stat, statText, style } = props
   return (
     <Paper
+      className={classes.root}
       style={{
-        paddingTop: 50,
-        paddingBottom: 50,
-        minWidth: 200,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignContent: 'middle',
         ...style,
       }}
     >
-      <span
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
-        <Typography
-          variant={'h2'}
-          color={'secondary'}
-          style={{ textAlign: 'center' }}
-        >
+      <span className={classes.mainContentContainer}>
+        <Typography variant={'h2'} color={'secondary'} className={classes.stat}>
           {stat}
         </Typography>
-        <Typography
-          variant={'body2'}
-          style={{ textAlign: 'center', maxWidth: '70%' }}
-        >
+        <Typography variant={'body2'} className={classes.statText}>
           {statText}
         </Typography>
       </span>
-      <span
-        style={{
-          display: 'block',
-          marginTop: 4,
-          minHeight: 16,
-          alignSelf: 'center',
-          textAlign: 'center',
-        }}
-      >
-        {extraContent}
-      </span>
+      <span className={classes.extraContent}>{extraContent}</span>
     </Paper>
   )
 }
 
 Stat.propTypes = {
+  classes: PropTypes.object.isRequired,
   stat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   statText: PropTypes.string.isRequired,
   extraContent: PropTypes.element,
@@ -65,4 +69,4 @@ Stat.default = {
   style: {},
 }
 
-export default Stat
+export default withStyles(styles)(Stat)

--- a/web/src/js/components/Settings/Profile/StatComponent.js
+++ b/web/src/js/components/Settings/Profile/StatComponent.js
@@ -12,7 +12,6 @@ const styles = theme => ({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
-    alignContent: 'middle',
   },
   mainContentContainer: {
     display: 'flex',

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsComponent.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import Charity from 'js/components/Donate/CharityContainer'
+
+const getMockProps = () => ({
+  app: {
+    charities: {
+      edges: [
+        {
+          node: {
+            id: 'some-charity-id',
+            image:
+              'http://static.example.com/img/charities/charity-post-donation-images/some-charity.jpg',
+            impact: 'Your donation helps do something in particular.',
+            name: 'Some Charity',
+            website: 'https://www.example.com/something/',
+          },
+        },
+        {
+          node: {
+            id: 'another-charity-id',
+            image:
+              'http://static.example.com/img/charities/charity-post-donation-images/another-charity.jpg',
+            impact: 'Your donation helps do another thing.',
+            name: 'Some Charity',
+            website: 'https://www.example.com/another-thing/',
+          },
+        },
+      ],
+    },
+  },
+  user: {
+    // No attributes available to the the top component. They're passed
+    // to child components.
+  },
+  showError: jest.fn(),
+})
+
+describe('ProfileDonateHearts component', () => {
+  it('renders without error', () => {
+    const ProfileDonateHearts = require('js/components/Settings/Profile/ProfileDonateHeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    shallow(<ProfileDonateHearts {...mockProps} />)
+  })
+
+  it('renders the Charity components', () => {
+    const ProfileDonateHearts = require('js/components/Settings/Profile/ProfileDonateHeartsComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileDonateHearts {...mockProps} />)
+
+    const charity1 = wrapper.find(Charity).first()
+    expect(charity1.prop('charity')).toEqual(
+      mockProps.app.charities.edges[0].node
+    )
+    const charity2 = wrapper.find(Charity).at(1)
+    expect(charity2.prop('charity')).toEqual(
+      mockProps.app.charities.edges[1].node
+    )
+  })
+})

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsComponent.test.js
@@ -10,30 +10,20 @@ const getMockProps = () => ({
       edges: [
         {
           node: {
-            id: 'some-charity-id',
-            image:
-              'http://static.example.com/img/charities/charity-post-donation-images/some-charity.jpg',
-            impact: 'Your donation helps do something in particular.',
-            name: 'Some Charity',
-            website: 'https://www.example.com/something/',
+            // Other attributes here are passed to child components.
+            id: 'some-id',
           },
         },
         {
           node: {
-            id: 'another-charity-id',
-            image:
-              'http://static.example.com/img/charities/charity-post-donation-images/another-charity.jpg',
-            impact: 'Your donation helps do another thing.',
-            name: 'Some Charity',
-            website: 'https://www.example.com/another-thing/',
+            id: 'some-other-id',
           },
         },
       ],
     },
   },
   user: {
-    // No attributes available to the the top component. They're passed
-    // to child components.
+    // Attributes here are passed to child components.
   },
   showError: jest.fn(),
 })

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsComponent.test.js
@@ -33,14 +33,14 @@ describe('ProfileDonateHearts component', () => {
     const ProfileDonateHearts = require('js/components/Settings/Profile/ProfileDonateHeartsComponent')
       .default
     const mockProps = getMockProps()
-    shallow(<ProfileDonateHearts {...mockProps} />)
+    shallow(<ProfileDonateHearts {...mockProps} />).dive()
   })
 
   it('renders the Charity components', () => {
     const ProfileDonateHearts = require('js/components/Settings/Profile/ProfileDonateHeartsComponent')
       .default
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileDonateHearts {...mockProps} />)
+    const wrapper = shallow(<ProfileDonateHearts {...mockProps} />).dive()
 
     const charity1 = wrapper.find(Charity).first()
     expect(charity1.prop('charity')).toEqual(

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendComponent.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+jest.mock('js/mutations/LogReferralLinkClickMutation')
+jest.mock('js/utils/logger')
+
+const getMockProps = () => ({
+  app: {
+    referralVcReward: 300,
+  },
+  user: {
+    numUsersRecruited: 2,
+  },
+})
+
+describe('ProfileInviteFriendComponent', () => {
+  it('renders without error', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    shallow(<ProfileInviteFriend {...mockProps} />)
+  })
+})

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendComponent.test.js
@@ -25,14 +25,14 @@ describe('ProfileInviteFriendComponent', () => {
     const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
-    shallow(<ProfileInviteFriend {...mockProps} />)
+    shallow(<ProfileInviteFriend {...mockProps} />).dive()
   })
 
   it('renders the InviteFriend component and passes it the "user" prop', () => {
     const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />).dive()
     const inviteFriendElem = wrapper.find(InviteFriend)
     expect(inviteFriendElem.exists()).toBe(true)
     expect(inviteFriendElem.prop('user')).toEqual({
@@ -44,7 +44,7 @@ describe('ProfileInviteFriendComponent', () => {
     const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />).dive()
     const elem = wrapper.find(Stat).first()
     expect(elem.prop('stat')).toEqual(2)
     expect(elem.prop('statText')).toEqual('friends recruited')
@@ -55,7 +55,7 @@ describe('ProfileInviteFriendComponent', () => {
       .default
     const mockProps = getMockProps()
     mockProps.user.numUsersRecruited = 1
-    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />).dive()
     const elem = wrapper.find(Stat).first()
     expect(elem.prop('stat')).toEqual(1)
     expect(elem.prop('statText')).toEqual('friend recruited')
@@ -65,7 +65,7 @@ describe('ProfileInviteFriendComponent', () => {
     const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />).dive()
     const elem = wrapper.find(Stat).at(1)
     expect(elem.prop('stat')).toEqual(300)
     expect(elem.prop('statText')).toEqual(
@@ -77,7 +77,7 @@ describe('ProfileInviteFriendComponent', () => {
     const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />).dive()
     expect(
       wrapper
         .find(Paper)
@@ -94,7 +94,7 @@ describe('ProfileInviteFriendComponent', () => {
     const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />).dive()
     expect(
       wrapper
         .find(Paper)

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendComponent.test.js
@@ -2,6 +2,11 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
+import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
+import Stat from 'js/components/Settings/Profile/StatComponent'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
+import HappyIcon from '@material-ui/icons/Mood'
 
 jest.mock('js/mutations/LogReferralLinkClickMutation')
 jest.mock('js/utils/logger')
@@ -21,5 +26,81 @@ describe('ProfileInviteFriendComponent', () => {
       .default
     const mockProps = getMockProps()
     shallow(<ProfileInviteFriend {...mockProps} />)
+  })
+
+  it('renders the InviteFriend component and passes it the "user" prop', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const inviteFriendElem = wrapper.find(InviteFriend)
+    expect(inviteFriendElem.exists()).toBe(true)
+    expect(inviteFriendElem.prop('user')).toEqual({
+      numUsersRecruited: 2,
+    })
+  })
+
+  it('renders the "friends recruited" statistic', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const elem = wrapper.find(Stat).first()
+    expect(elem.prop('stat')).toEqual(2)
+    expect(elem.prop('statText')).toEqual('friends recruited')
+  })
+
+  it('renders the "friends recruited" statistic with a singular "friend" when numUsersRecruited == 1', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.numUsersRecruited = 1
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const elem = wrapper.find(Stat).first()
+    expect(elem.prop('stat')).toEqual(1)
+    expect(elem.prop('statText')).toEqual('friend recruited')
+  })
+
+  it('renders the "VC reward" statistic', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    const elem = wrapper.find(Stat).at(1)
+    expect(elem.prop('stat')).toEqual(300)
+    expect(elem.prop('statText')).toEqual(
+      'extra Hearts when you recruit a new friend'
+    )
+  })
+
+  it('shows a "thank you" message at the bottom', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    expect(
+      wrapper
+        .find(Paper)
+        .last()
+        .find(Typography)
+        .render()
+        .text()
+    ).toEqual(
+      'Thank you! Every new person raises more money for charity, and we depend on people like you to get the word out.'
+    )
+  })
+
+  it('includes a smiley face icon in the "thank you" message at the bottom', () => {
+    const ProfileInviteFriend = require('js/components/Settings/Profile/ProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriend {...mockProps} />)
+    expect(
+      wrapper
+        .find(Paper)
+        .last()
+        .find(HappyIcon)
+        .exists()
+    ).toBe(true)
   })
 })

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -66,4 +66,6 @@ describe('Profile stats component', () => {
         .text()
     ).toEqual("Hi! Here's all your great work Tabbing, by the numbers.")
   })
+
+  // TODO: add tests for stats and stat-related buttons
 })

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -1,12 +1,11 @@
 /* eslint-env jest */
 
 import React from 'react'
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import { cloneDeep } from 'lodash/lang'
-import { mount, shallow } from 'enzyme'
+import { shallow } from 'enzyme'
 import Stat from 'js/components/Settings/Profile/StatComponent'
+import Typography from '@material-ui/core/Typography'
 
-const mockProps = {
+const getMockProps = () => ({
   user: {
     id: 'some-user-id-here',
     username: 'Bob',
@@ -21,58 +20,50 @@ const mockProps = {
     tabs: 3121,
     vcDonatedAllTime: 2539,
   },
-}
+})
 
 describe('Profile stats component', () => {
   it('renders without error', () => {
     const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
       .default
+    const mockProps = getMockProps()
     shallow(<ProfileStatsComponent {...mockProps} />).dive()
   })
 
   it('has the expected number of stats', () => {
     const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
       .default
+    const mockProps = getMockProps()
     const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
     expect(wrapper.find(Stat).length).toBe(6)
   })
 
-  it('contains the correct greeting when there is a username', () => {
+  it('contains the correct greeting text when there is a username', () => {
     const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
       .default
-    // @material-ui-1-todo: remove MuiThemeProvider wrapper
-    const wrapper = mount(
-      <MuiThemeProvider>
-        <ProfileStatsComponent {...mockProps} />
-      </MuiThemeProvider>
-    )
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
     expect(
       wrapper
-        .find('p')
+        .find(Typography)
         .first()
-        .find('span')
-        .first()
+        .render()
         .text()
-    ).toBe('Hi, Bob!')
+    ).toEqual("Hi, Bob! Here's all your great work Tabbing, by the numbers.")
   })
 
   it('contains the correct greeting when there is no username', () => {
     const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
       .default
-    const newMockProps = cloneDeep(mockProps)
-    delete newMockProps.user.username
-    const wrapper = mount(
-      <MuiThemeProvider>
-        <ProfileStatsComponent {...newMockProps} />
-      </MuiThemeProvider>
-    )
+    const mockProps = getMockProps()
+    mockProps.user.username = undefined
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
     expect(
       wrapper
-        .find('p')
+        .find(Typography)
         .first()
-        .find('span')
-        .first()
+        .render()
         .text()
-    ).toBe('Hi!')
+    ).toEqual("Hi! Here's all your great work Tabbing, by the numbers.")
   })
 })

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -2,8 +2,27 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
+import moment from 'moment'
+import MockDate from 'mockdate'
 import Stat from 'js/components/Settings/Profile/StatComponent'
 import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+
+jest.mock('@material-ui/icons/FavoriteBorder', () => () => '[HEART-ICON] ')
+
+const mockNow = '2019-05-19T13:59:58.000Z'
+
+beforeAll(() => {
+  MockDate.set(moment(mockNow))
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+afterAll(() => {
+  MockDate.reset()
+})
 
 const getMockProps = () => ({
   user: {
@@ -65,6 +84,86 @@ describe('Profile stats component', () => {
         .render()
         .text()
     ).toEqual("Hi! Here's all your great work Tabbing, by the numbers.")
+  })
+
+  it('shows the correct "days since joining" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.joined = '2017-12-25T07:08:11.472Z'
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).first()
+    expect(statElem.prop('stat')).toEqual('510')
+    expect(statElem.prop('statText')).toEqual('days as a Tabber')
+  })
+
+  it('shows the correct "days since joining" stat when it is only one day', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.joined = '2019-05-18T08:00:58.000Z'
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).first()
+    expect(statElem.prop('stat')).toEqual('1')
+    expect(statElem.prop('statText')).toEqual('day as a Tabber')
+  })
+
+  it('shows the correct "tabs all time" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.tabs = 3121
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(1)
+    expect(statElem.prop('stat')).toEqual('3.1K')
+    expect(statElem.prop('statText')).toEqual('tabs all time')
+  })
+
+  it('shows the correct "max tabs in one day" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.maxTabsDay = {
+      date: '2018-01-01T10:50:44.942Z',
+      numTabs: 431,
+    }
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(2)
+    expect(statElem.prop('stat')).toEqual('431')
+    expect(statElem.prop('statText')).toEqual('max tabs in one day')
+    expect(
+      shallow(statElem.prop('extraContent'))
+        .render()
+        .text()
+    ).toEqual('on January 1, 2018')
+  })
+
+  it('shows the correct "level" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.heartsUntilNextLevel = 23
+    mockProps.user.level = 8
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(3)
+    expect(statElem.prop('stat')).toEqual(8)
+    expect(statElem.prop('statText')).toEqual('your level')
+    expect(
+      shallow(statElem.prop('extraContent'))
+        .render()
+        .text()
+    ).toEqual('23[HEART-ICON] until next level')
+  })
+
+  it('shows the correct "friends recruited" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.numUsersRecruited = 2
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(4)
+    expect(statElem.prop('stat')).toEqual('2')
+    expect(statElem.prop('statText')).toEqual('Tabbers recruited')
   })
 
   // TODO: add tests for stats and stat-related buttons

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -6,9 +6,10 @@ import moment from 'moment'
 import MockDate from 'mockdate'
 import Stat from 'js/components/Settings/Profile/StatComponent'
 import Typography from '@material-ui/core/Typography'
-import Button from '@material-ui/core/Button'
+import { goTo, donateURL, inviteFriendsURL } from 'js/navigation/navigation'
 
 jest.mock('@material-ui/icons/FavoriteBorder', () => () => '[HEART-ICON] ')
+jest.mock('js/navigation/navigation')
 
 const mockNow = '2019-05-19T13:59:58.000Z'
 
@@ -166,5 +167,40 @@ describe('Profile stats component', () => {
     expect(statElem.prop('statText')).toEqual('Tabbers recruited')
   })
 
-  // TODO: add tests for stats and stat-related buttons
+  it('goes to the "invite friends" page when clicking the button below the "friends recruited" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(4)
+    expect(statElem.prop('statText')).toEqual('Tabbers recruited')
+    const extraStatContent = shallow(statElem.prop('extraContent'))
+    extraStatContent.at(0).simulate('click')
+    expect(goTo).toHaveBeenCalledTimes(1)
+    expect(goTo).toHaveBeenCalledWith(inviteFriendsURL)
+  })
+
+  it('shows the correct "Hearts donated" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.vcDonatedAllTime = 2539
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(5)
+    expect(statElem.prop('stat')).toEqual('2.5K')
+    expect(statElem.prop('statText')).toEqual('Hearts donated')
+  })
+
+  it('goes to the "donate Hearts" page when clicking the button below the "Hearts donated" stat', () => {
+    const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
+    const statElem = wrapper.find(Stat).at(5)
+    expect(statElem.prop('statText')).toEqual('Hearts donated')
+    const extraStatContent = shallow(statElem.prop('extraContent'))
+    extraStatContent.at(0).simulate('click')
+    expect(goTo).toHaveBeenCalledTimes(1)
+    expect(goTo).toHaveBeenCalledWith(donateURL)
+  })
 })

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsComponent.test.js
@@ -27,13 +27,13 @@ describe('Profile stats component', () => {
   it('renders without error', () => {
     const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
       .default
-    shallow(<ProfileStatsComponent {...mockProps} />)
+    shallow(<ProfileStatsComponent {...mockProps} />).dive()
   })
 
   it('has the expected number of stats', () => {
     const ProfileStatsComponent = require('js/components/Settings/Profile/ProfileStatsComponent')
       .default
-    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />)
+    const wrapper = shallow(<ProfileStatsComponent {...mockProps} />).dive()
     expect(wrapper.find(Stat).length).toBe(6)
   })
 

--- a/web/src/js/components/Settings/Profile/__tests__/StatComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/StatComponent.test.js
@@ -1,0 +1,49 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import Typography from '@material-ui/core/Typography'
+
+const getMockProps = () => ({
+  stat: 12,
+  statText: 'friends recruited',
+})
+
+describe('StatComponent', () => {
+  it('renders without error', () => {
+    const StatComponent = require('js/components/Settings/Profile/StatComponent')
+      .default
+    const mockProps = getMockProps()
+    shallow(<StatComponent {...mockProps} />)
+  })
+
+  it('displays the "stat" value in the expected typography component', () => {
+    const StatComponent = require('js/components/Settings/Profile/StatComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.stat = 142
+    const wrapper = shallow(<StatComponent {...mockProps} />)
+    expect(
+      wrapper
+        .find(Typography)
+        .filterWhere(e => e.prop('variant') === 'h2')
+        .render()
+        .text()
+    ).toEqual('142')
+  })
+
+  it('displays the "statText" value in the expected typography component', () => {
+    const StatComponent = require('js/components/Settings/Profile/StatComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.statText = 'friends recruited'
+    const wrapper = shallow(<StatComponent {...mockProps} />)
+    expect(
+      wrapper
+        .find(Typography)
+        .filterWhere(e => e.prop('variant') === 'body2')
+        .render()
+        .text()
+    ).toEqual('friends recruited')
+  })
+})

--- a/web/src/js/components/Settings/Profile/__tests__/StatComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/StatComponent.test.js
@@ -14,7 +14,7 @@ describe('StatComponent', () => {
     const StatComponent = require('js/components/Settings/Profile/StatComponent')
       .default
     const mockProps = getMockProps()
-    shallow(<StatComponent {...mockProps} />)
+    shallow(<StatComponent {...mockProps} />).dive()
   })
 
   it('displays the "stat" value in the expected typography component', () => {
@@ -22,7 +22,7 @@ describe('StatComponent', () => {
       .default
     const mockProps = getMockProps()
     mockProps.stat = 142
-    const wrapper = shallow(<StatComponent {...mockProps} />)
+    const wrapper = shallow(<StatComponent {...mockProps} />).dive()
     expect(
       wrapper
         .find(Typography)
@@ -37,7 +37,7 @@ describe('StatComponent', () => {
       .default
     const mockProps = getMockProps()
     mockProps.statText = 'friends recruited'
-    const wrapper = shallow(<StatComponent {...mockProps} />)
+    const wrapper = shallow(<StatComponent {...mockProps} />).dive()
     expect(
       wrapper
         .find(Typography)

--- a/web/src/js/components/Settings/SettingsChildWrapperComponent.js
+++ b/web/src/js/components/Settings/SettingsChildWrapperComponent.js
@@ -1,34 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import FadeInAnimation from 'js/components/General/FadeInAnimation'
 
-class SettingsChildWrapper extends React.Component {
-  render() {
-    const { children, loaded } = this.props
-    return (
-      <div
-        style={{
-          padding: 20,
-          minHeight: 400,
-        }}
-      >
-        {loaded ? (
-          children ? (
-            <FadeInAnimation>{children}</FadeInAnimation>
-          ) : null
-        ) : null}
-      </div>
-    )
-  }
+const SettingsChildWrapper = props => {
+  const { children } = props
+  return (
+    <div
+      style={{
+        padding: 20,
+        minHeight: 400,
+      }}
+    >
+      {children}
+    </div>
+  )
 }
 
 SettingsChildWrapper.propTypes = {
   children: PropTypes.element,
-  loaded: PropTypes.bool,
 }
 
-SettingsChildWrapper.defaultProps = {
-  loaded: false,
-}
+SettingsChildWrapper.defaultProps = {}
 
 export default SettingsChildWrapper

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -40,6 +40,7 @@ class SettingsPage extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
+      errorOpen: false,
       errorMessage: null,
     }
   }
@@ -50,18 +51,21 @@ class SettingsPage extends React.Component {
 
   showError(msg) {
     this.setState({
+      errorOpen: true,
       errorMessage: msg,
     })
   }
 
   clearError() {
-    this.showError(null)
+    this.setState({
+      errorOpen: false,
+    })
   }
 
   render() {
     const { authUser, classes } = this.props
+    const { errorMessage, errorOpen } = this.state
     const showError = this.showError
-    const errorMessage = this.state.errorMessage
     const sidebarWidth = 240
     const sidebarLeftMargin = 10
     return (
@@ -206,12 +210,11 @@ class SettingsPage extends React.Component {
             <Redirect from="/newtab/account/*" to="/newtab/account/" />
           </Switch>
         </div>
-        {errorMessage ? (
-          <ErrorMessage
-            message={errorMessage}
-            onRequestClose={this.clearError.bind(this)}
-          />
-        ) : null}
+        <ErrorMessage
+          message={errorMessage}
+          onClose={this.clearError.bind(this)}
+          open={errorOpen}
+        />
       </div>
     )
   }

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -8,7 +8,7 @@ import IconButton from '@material-ui/core/IconButton'
 import List from '@material-ui/core/List'
 import ListSubheader from '@material-ui/core/ListSubheader'
 import Toolbar from '@material-ui/core/Toolbar'
-import CloseIcon from 'material-ui/svg-icons/navigation/close'
+import CloseIcon from '@material-ui/icons/Close'
 
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -38,7 +38,8 @@ class WidgetsSettingsView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading the widget settings :('
-              // FIXME
+
+              // Error will not autohide.
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -45,7 +45,7 @@ class WidgetsSettingsView extends React.Component {
             const showError = this.props.showError
             const dataLoaded = !!props
             return (
-              <SettingsChildWrapper loaded={dataLoaded}>
+              <SettingsChildWrapper>
                 {dataLoaded ? (
                   <WidgetsSettings
                     app={props.app}

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -38,6 +38,7 @@ class WidgetsSettingsView extends React.Component {
             if (error) {
               logger.error(error)
               const errMsg = 'We had a problem loading the widget settings :('
+              // FIXME
               return <ErrorMessage message={errMsg} />
             }
             const showError = this.props.showError

--- a/web/src/js/components/Settings/__tests__/SettingsChildWrapperComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsChildWrapperComponent.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+const mockProps = {
+  children: <div>hi</div>,
+}
+
+describe('SettingsChildWrapper', () => {
+  it('renders without error', () => {
+    const SettingsChildWrapper = require('js/components/Settings/SettingsChildWrapperComponent')
+      .default
+    shallow(<SettingsChildWrapper {...mockProps} />)
+  })
+
+  it('has the expected style for the root component', () => {
+    const SettingsChildWrapper = require('js/components/Settings/SettingsChildWrapperComponent')
+      .default
+    const wrapper = shallow(<SettingsChildWrapper {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      padding: 20,
+      minHeight: 400,
+    })
+  })
+})

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Redirect, Route, Switch } from 'react-router-dom'
+import IconButton from '@material-ui/core/IconButton'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
@@ -13,6 +14,7 @@ import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHea
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import { goToDashboard } from 'js/navigation/navigation'
 
 jest.mock('react-router-dom')
 jest.mock('js/components/Settings/Account/AccountView')
@@ -25,6 +27,7 @@ jest.mock('js/components/Settings/Profile/ProfileInviteFriendView')
 jest.mock('js/components/Settings/SettingsMenuItem')
 jest.mock('js/components/Settings/Widgets/WidgetsSettingsView')
 jest.mock('js/components/General/withUser')
+jest.mock('js/navigation/navigation')
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -395,5 +398,15 @@ describe('SettingsPage', () => {
     expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
       'We made a mistake :('
     )
+  })
+
+  it('goes to the Tab dashboard when clicking the close IconButton', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    expect(goToDashboard).not.toHaveBeenCalled()
+    wrapper.find(IconButton).simulate('click')
+    expect(goToDashboard).toHaveBeenCalled()
   })
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -382,7 +382,7 @@ describe('SettingsPage', () => {
       .dive()
 
     // We should not show an error message yet.
-    expect(wrapper.find(ErrorMessage).exists()).toBe(false)
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
 
     const routeElem = wrapper
       .find(Switch)
@@ -394,7 +394,7 @@ describe('SettingsPage', () => {
     )
     const showErrorFunc = ThisRouteComponentElem.prop('showError')
     showErrorFunc('We made a mistake :(')
-    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
     expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
       'We made a mistake :('
     )


### PR DESCRIPTION
This is part one of adding some settings and profile pages to the search app.

* Update to new MUI components for all pages and components we might use in the search app, because the search app does not support the old version of `material-ui`
* Remove fade-in animation from settings pages
* Make sure the ErrorMessage snack bar component animates as expected
* If an error occurs when loading a settings page, don't auto-hide the error message snack bar
* Add a bunch of tests