### PR TITLE
Make the settings page more modular

### DIFF
--- a/web/src/js/components/App/App.js
+++ b/web/src/js/components/App/App.js
@@ -25,8 +25,8 @@ import { parseUrlSearchString, validateAppName } from 'js/utils/utils'
 const AuthenticationView = lazy(() =>
   import('js/components/Authentication/AuthenticationView')
 )
-const SettingsPageComponent = lazy(() =>
-  import('js/components/Settings/SettingsPageComponent')
+const TabSettingsPageComponent = lazy(() =>
+  import('js/components/Settings/TabSettingsPageComponent')
 )
 const FirstTabView = lazy(() => import('js/components/Dashboard/FirstTabView'))
 const PostUninstallView = lazy(() =>
@@ -100,15 +100,15 @@ class App extends React.Component {
                   <Route exact path="/newtab/" component={DashboardView} />
                   <Route
                     path="/newtab/settings/"
-                    component={SettingsPageComponent}
+                    component={TabSettingsPageComponent}
                   />
                   <Route
                     path="/newtab/account/"
-                    component={SettingsPageComponent}
+                    component={TabSettingsPageComponent}
                   />
                   <Route
                     path="/newtab/profile/"
-                    component={SettingsPageComponent}
+                    component={TabSettingsPageComponent}
                   />
                   <Route
                     exact

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import AppBar from '@material-ui/core/AppBar'
@@ -35,63 +35,43 @@ const styles = theme => ({
   },
 })
 
-class SettingsPage extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      errorOpen: false,
-      errorMessage: null,
-    }
+const SettingsPage = props => {
+  const { classes, mainContent, sidebarContent } = props
+  const [errorMessage, setErrorMessage] = useState(null)
+  const [isErrorOpen, setIsErrorOpen] = useState(false)
+  const showError = msg => {
+    setIsErrorOpen(true)
+    setErrorMessage(msg)
+  }
+  const clearError = () => {
+    setIsErrorOpen(false)
   }
 
-  goToHome() {
-    goToDashboard()
-  }
-
-  showError(msg) {
-    this.setState({
-      errorOpen: true,
-      errorMessage: msg,
-    })
-  }
-
-  clearError() {
-    this.setState({
-      errorOpen: false,
-    })
-  }
-
-  render() {
-    const { classes, mainContent, sidebarContent } = this.props
-    const { errorMessage, errorOpen } = this.state
-    const showError = this.showError.bind(this)
-
-    return (
-      <div className={classes.container}>
-        <AppBar color={'primary'} position={'sticky'}>
-          <Toolbar>
-            <div style={{ flex: 1 }}>
-              <Logo color={'white'} />
-            </div>
-            <IconButton onClick={this.goToHome.bind(this)}>
-              <CloseIcon className={classes.closeIcon} />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-        <div className={classes.sidebarContentContainer}>
-          {sidebarContent({ showError })}
-        </div>
-        <div className={classes.mainContentContainer}>
-          {mainContent({ showError })}
-        </div>
-        <ErrorMessage
-          message={errorMessage}
-          onClose={this.clearError.bind(this)}
-          open={errorOpen}
-        />
+  return (
+    <div className={classes.container}>
+      <AppBar color={'primary'} position={'sticky'}>
+        <Toolbar>
+          <div style={{ flex: 1 }}>
+            <Logo color={'white'} />
+          </div>
+          <IconButton onClick={goToDashboard}>
+            <CloseIcon className={classes.closeIcon} />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <div className={classes.sidebarContentContainer}>
+        {sidebarContent({ showError })}
       </div>
-    )
-  }
+      <div className={classes.mainContentContainer}>
+        {mainContent({ showError })}
+      </div>
+      <ErrorMessage
+        message={errorMessage}
+        onClose={clearError}
+        open={isErrorOpen}
+      />
+    </div>
+  )
 }
 
 SettingsPage.propTypes = {

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -10,8 +10,29 @@ import ErrorMessage from 'js/components/General/ErrorMessage'
 import Logo from 'js/components/Logo/Logo'
 import { goToDashboard } from 'js/navigation/navigation'
 
+const sidebarWidth = 240
 const styles = theme => ({
-  // TODO
+  container: {
+    color: '#fff',
+    backgroundColor: '#F2F2F2',
+    minWidth: '100vw',
+    minHeight: '100vh',
+  },
+  closeIcon: {
+    color: '#fff',
+    width: 28,
+    height: 28,
+  },
+  sidebarContentContainer: {
+    width: sidebarWidth,
+    position: 'fixed',
+  },
+  mainContentContainer: {
+    marginLeft: sidebarWidth,
+    boxSizing: 'border-box',
+    display: 'flex',
+    justifyContent: 'center',
+  },
 })
 
 class SettingsPage extends React.Component {
@@ -47,47 +68,20 @@ class SettingsPage extends React.Component {
     // TODO: maybe pass via render props
     // const showError = this.showError
 
-    const sidebarWidth = 240
     return (
-      <div
-        data-test-id={'app-settings-id'}
-        key={'settings-view-key'}
-        style={{
-          color: '#fff',
-          backgroundColor: '#F2F2F2',
-          minWidth: '100vw',
-          minHeight: '100vh',
-        }}
-      >
+      <div className={classes.container}>
         <AppBar color={'primary'} position={'sticky'}>
           <Toolbar>
             <div style={{ flex: 1 }}>
               <Logo color={'white'} />
             </div>
             <IconButton onClick={this.goToHome.bind(this)}>
-              <CloseIcon
-                style={{
-                  color: '#fff',
-                  width: 28,
-                  height: 28,
-                }}
-              />
+              <CloseIcon className={classes.closeIcon} />
             </IconButton>
           </Toolbar>
         </AppBar>
-        <div style={{ width: sidebarWidth, position: 'fixed' }}>
-          {sidebarContent}
-        </div>
-        <div
-          style={{
-            marginLeft: sidebarWidth,
-            boxSizing: 'border-box',
-            display: 'flex',
-            justifyContent: 'center',
-          }}
-        >
-          {mainContent}
-        </div>
+        <div className={classes.sidebarContentContainer}>{sidebarContent}</div>
+        <div className={classes.mainContentContainer}>{mainContent}</div>
         <ErrorMessage
           message={errorMessage}
           onClose={this.clearError.bind(this)}

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -64,9 +64,7 @@ class SettingsPage extends React.Component {
   render() {
     const { classes, mainContent, sidebarContent } = this.props
     const { errorMessage, errorOpen } = this.state
-
-    // TODO: maybe pass via render props
-    // const showError = this.showError
+    const showError = this.showError.bind(this)
 
     return (
       <div className={classes.container}>
@@ -80,8 +78,12 @@ class SettingsPage extends React.Component {
             </IconButton>
           </Toolbar>
         </AppBar>
-        <div className={classes.sidebarContentContainer}>{sidebarContent}</div>
-        <div className={classes.mainContentContainer}>{mainContent}</div>
+        <div className={classes.sidebarContentContainer}>
+          {sidebarContent({ showError })}
+        </div>
+        <div className={classes.mainContentContainer}>
+          {mainContent({ showError })}
+        </div>
         <ErrorMessage
           message={errorMessage}
           onClose={this.clearError.bind(this)}
@@ -93,8 +95,8 @@ class SettingsPage extends React.Component {
 }
 
 SettingsPage.propTypes = {
-  mainContent: PropTypes.node.isRequired,
-  sidebarContent: PropTypes.node.isRequired,
+  mainContent: PropTypes.func.isRequired,
+  sidebarContent: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
 }
 

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -1,39 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Redirect, Route, Switch } from 'react-router-dom'
 import { withStyles } from '@material-ui/core/styles'
 import AppBar from '@material-ui/core/AppBar'
-import Divider from '@material-ui/core/Divider'
 import IconButton from '@material-ui/core/IconButton'
-import List from '@material-ui/core/List'
-import ListSubheader from '@material-ui/core/ListSubheader'
 import Toolbar from '@material-ui/core/Toolbar'
 import CloseIcon from '@material-ui/icons/Close'
 
-import AccountView from 'js/components/Settings/Account/AccountView'
-import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import Logo from 'js/components/Logo/Logo'
-import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
-import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
-import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
-import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
-import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
-import withUser from 'js/components/General/withUser'
-import {
-  goToDashboard,
-  accountURL,
-  backgroundSettingsURL,
-  donateURL,
-  inviteFriendsURL,
-  statsURL,
-  widgetSettingsURL,
-} from 'js/navigation/navigation'
+import { goToDashboard } from 'js/navigation/navigation'
 
 const styles = theme => ({
-  listSubheader: {
-    paddingLeft: 14,
-  },
+  // TODO
 })
 
 class SettingsPage extends React.Component {
@@ -63,11 +41,13 @@ class SettingsPage extends React.Component {
   }
 
   render() {
-    const { authUser, classes } = this.props
+    const { classes, mainContent, sidebarContent } = this.props
     const { errorMessage, errorOpen } = this.state
-    const showError = this.showError
+
+    // TODO: maybe pass via render props
+    // const showError = this.showError
+
     const sidebarWidth = 240
-    const sidebarLeftMargin = 10
     return (
       <div
         data-test-id={'app-settings-id'}
@@ -96,34 +76,7 @@ class SettingsPage extends React.Component {
           </Toolbar>
         </AppBar>
         <div style={{ width: sidebarWidth, position: 'fixed' }}>
-          <List style={{ marginLeft: sidebarLeftMargin }}>
-            <ListSubheader disableSticky className={classes.listSubheader}>
-              Settings
-            </ListSubheader>
-            <SettingsMenuItem key={'widgets'} to={widgetSettingsURL}>
-              Widgets
-            </SettingsMenuItem>
-            <SettingsMenuItem key={'background'} to={backgroundSettingsURL}>
-              Background
-            </SettingsMenuItem>
-            <Divider />
-            <ListSubheader disableSticky className={classes.listSubheader}>
-              Your Profile
-            </ListSubheader>
-            <SettingsMenuItem key={'stats'} to={statsURL}>
-              Your Stats
-            </SettingsMenuItem>
-            <SettingsMenuItem key={'donate'} to={donateURL}>
-              Donate Hearts
-            </SettingsMenuItem>
-            <SettingsMenuItem key={'invite'} to={inviteFriendsURL}>
-              Invite Friends
-            </SettingsMenuItem>
-            <Divider />
-            <SettingsMenuItem key={'account'} to={accountURL}>
-              Account
-            </SettingsMenuItem>
-          </List>
+          {sidebarContent}
         </div>
         <div
           style={{
@@ -133,82 +86,7 @@ class SettingsPage extends React.Component {
             justifyContent: 'center',
           }}
         >
-          <Switch>
-            <Route
-              exact
-              path="/newtab/settings/widgets/"
-              render={props => (
-                <WidgetsSettingsView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-
-            <Route
-              exact
-              path="/newtab/settings/background/"
-              render={props => (
-                <BackgroundSettingsView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/profile/stats/"
-              render={props => (
-                <ProfileStatsView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/profile/donate/"
-              render={props => (
-                <ProfileDonateHearts
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/profile/invite/"
-              render={props => (
-                <ProfileInviteFriend
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/account/"
-              render={props => (
-                <AccountView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            {/* Redirect any incorrect paths */}
-            <Redirect
-              from="/newtab/settings/*"
-              to="/newtab/settings/widgets/"
-            />
-            <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
-            <Redirect from="/newtab/account/*" to="/newtab/account/" />
-          </Switch>
+          {mainContent}
         </div>
         <ErrorMessage
           message={errorMessage}
@@ -221,10 +99,9 @@ class SettingsPage extends React.Component {
 }
 
 SettingsPage.propTypes = {
-  authUser: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-  }).isRequired,
+  mainContent: PropTypes.node.isRequired,
+  sidebarContent: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
 }
 
-export default withStyles(styles)(withUser()(SettingsPage))
+export default withStyles(styles)(SettingsPage)

--- a/web/src/js/components/Settings/SettingsPageComponent.js
+++ b/web/src/js/components/Settings/SettingsPageComponent.js
@@ -8,7 +8,6 @@ import CloseIcon from '@material-ui/icons/Close'
 
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import Logo from 'js/components/Logo/Logo'
-import { goToDashboard } from 'js/navigation/navigation'
 
 const sidebarWidth = 240
 const styles = theme => ({
@@ -36,7 +35,7 @@ const styles = theme => ({
 })
 
 const SettingsPage = props => {
-  const { classes, mainContent, sidebarContent } = props
+  const { classes, mainContent, onClose, sidebarContent } = props
   const [errorMessage, setErrorMessage] = useState(null)
   const [isErrorOpen, setIsErrorOpen] = useState(false)
   const showError = msg => {
@@ -54,7 +53,7 @@ const SettingsPage = props => {
           <div style={{ flex: 1 }}>
             <Logo color={'white'} />
           </div>
-          <IconButton onClick={goToDashboard}>
+          <IconButton onClick={onClose}>
             <CloseIcon className={classes.closeIcon} />
           </IconButton>
         </Toolbar>
@@ -77,6 +76,7 @@ const SettingsPage = props => {
 SettingsPage.propTypes = {
   mainContent: PropTypes.func.isRequired,
   sidebarContent: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
 }
 

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -2,26 +2,20 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import { withStyles } from '@material-ui/core/styles'
-import AppBar from '@material-ui/core/AppBar'
 import Divider from '@material-ui/core/Divider'
-import IconButton from '@material-ui/core/IconButton'
 import List from '@material-ui/core/List'
 import ListSubheader from '@material-ui/core/ListSubheader'
-import Toolbar from '@material-ui/core/Toolbar'
-import CloseIcon from '@material-ui/icons/Close'
 
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-import ErrorMessage from 'js/components/General/ErrorMessage'
-import Logo from 'js/components/Logo/Logo'
 import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 import withUser from 'js/components/General/withUser'
 import {
-  goToDashboard,
   accountURL,
   backgroundSettingsURL,
   donateURL,
@@ -36,188 +30,131 @@ const styles = theme => ({
   },
 })
 
-class TabSettingsPage extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      errorOpen: false,
-      errorMessage: null,
-    }
+const TabSettingsPage = props => {
+  const { authUser, classes } = props
+
+  // FIXME
+  // const { errorMessage, errorOpen } = this.state
+  // const showError = this.showError
+  const showError = () => {
+    console.error('Fix me!')
   }
 
-  goToHome() {
-    goToDashboard()
-  }
+  // FIXME
+  // const onClose = () => {
+  //   console.error('Fix me!')
+  // }
 
-  showError(msg) {
-    this.setState({
-      errorOpen: true,
-      errorMessage: msg,
-    })
-  }
-
-  clearError() {
-    this.setState({
-      errorOpen: false,
-    })
-  }
-
-  render() {
-    const { authUser, classes } = this.props
-    const { errorMessage, errorOpen } = this.state
-    const showError = this.showError
-    const sidebarWidth = 240
-    const sidebarLeftMargin = 10
-    return (
-      <div
-        data-test-id={'app-settings-id'}
-        key={'settings-view-key'}
-        style={{
-          color: '#fff',
-          backgroundColor: '#F2F2F2',
-          minWidth: '100vw',
-          minHeight: '100vh',
-        }}
-      >
-        <AppBar color={'primary'} position={'sticky'}>
-          <Toolbar>
-            <div style={{ flex: 1 }}>
-              <Logo color={'white'} />
-            </div>
-            <IconButton onClick={this.goToHome.bind(this)}>
-              <CloseIcon
-                style={{
-                  color: '#fff',
-                  width: 28,
-                  height: 28,
-                }}
+  const sidebarLeftMargin = 10
+  return (
+    <SettingsPage
+      sidebarContent={
+        <List style={{ marginLeft: sidebarLeftMargin }}>
+          <ListSubheader disableSticky className={classes.listSubheader}>
+            Settings
+          </ListSubheader>
+          <SettingsMenuItem key={'widgets'} to={widgetSettingsURL}>
+            Widgets
+          </SettingsMenuItem>
+          <SettingsMenuItem key={'background'} to={backgroundSettingsURL}>
+            Background
+          </SettingsMenuItem>
+          <Divider />
+          <ListSubheader disableSticky className={classes.listSubheader}>
+            Your Profile
+          </ListSubheader>
+          <SettingsMenuItem key={'stats'} to={statsURL}>
+            Your Stats
+          </SettingsMenuItem>
+          <SettingsMenuItem key={'donate'} to={donateURL}>
+            Donate Hearts
+          </SettingsMenuItem>
+          <SettingsMenuItem key={'invite'} to={inviteFriendsURL}>
+            Invite Friends
+          </SettingsMenuItem>
+          <Divider />
+          <SettingsMenuItem key={'account'} to={accountURL}>
+            Account
+          </SettingsMenuItem>
+        </List>
+      }
+      mainContent={
+        <Switch>
+          <Route
+            exact
+            path="/newtab/settings/widgets/"
+            render={props => (
+              <WidgetsSettingsView
+                {...props}
+                authUser={authUser}
+                showError={showError}
               />
-            </IconButton>
-          </Toolbar>
-        </AppBar>
-        <div style={{ width: sidebarWidth, position: 'fixed' }}>
-          <List style={{ marginLeft: sidebarLeftMargin }}>
-            <ListSubheader disableSticky className={classes.listSubheader}>
-              Settings
-            </ListSubheader>
-            <SettingsMenuItem key={'widgets'} to={widgetSettingsURL}>
-              Widgets
-            </SettingsMenuItem>
-            <SettingsMenuItem key={'background'} to={backgroundSettingsURL}>
-              Background
-            </SettingsMenuItem>
-            <Divider />
-            <ListSubheader disableSticky className={classes.listSubheader}>
-              Your Profile
-            </ListSubheader>
-            <SettingsMenuItem key={'stats'} to={statsURL}>
-              Your Stats
-            </SettingsMenuItem>
-            <SettingsMenuItem key={'donate'} to={donateURL}>
-              Donate Hearts
-            </SettingsMenuItem>
-            <SettingsMenuItem key={'invite'} to={inviteFriendsURL}>
-              Invite Friends
-            </SettingsMenuItem>
-            <Divider />
-            <SettingsMenuItem key={'account'} to={accountURL}>
-              Account
-            </SettingsMenuItem>
-          </List>
-        </div>
-        <div
-          style={{
-            marginLeft: sidebarWidth,
-            boxSizing: 'border-box',
-            display: 'flex',
-            justifyContent: 'center',
-          }}
-        >
-          <Switch>
-            <Route
-              exact
-              path="/newtab/settings/widgets/"
-              render={props => (
-                <WidgetsSettingsView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
+            )}
+          />
 
-            <Route
-              exact
-              path="/newtab/settings/background/"
-              render={props => (
-                <BackgroundSettingsView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/profile/stats/"
-              render={props => (
-                <ProfileStatsView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/profile/donate/"
-              render={props => (
-                <ProfileDonateHearts
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/profile/invite/"
-              render={props => (
-                <ProfileInviteFriend
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            <Route
-              exact
-              path="/newtab/account/"
-              render={props => (
-                <AccountView
-                  {...props}
-                  authUser={authUser}
-                  showError={showError.bind(this)}
-                />
-              )}
-            />
-            {/* Redirect any incorrect paths */}
-            <Redirect
-              from="/newtab/settings/*"
-              to="/newtab/settings/widgets/"
-            />
-            <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
-            <Redirect from="/newtab/account/*" to="/newtab/account/" />
-          </Switch>
-        </div>
-        <ErrorMessage
-          message={errorMessage}
-          onClose={this.clearError.bind(this)}
-          open={errorOpen}
-        />
-      </div>
-    )
-  }
+          <Route
+            exact
+            path="/newtab/settings/background/"
+            render={props => (
+              <BackgroundSettingsView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/profile/stats/"
+            render={props => (
+              <ProfileStatsView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/profile/donate/"
+            render={props => (
+              <ProfileDonateHearts
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/profile/invite/"
+            render={props => (
+              <ProfileInviteFriend
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/account/"
+            render={props => (
+              <AccountView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          {/* Redirect any incorrect paths */}
+          <Redirect from="/newtab/settings/*" to="/newtab/settings/widgets/" />
+          <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
+          <Redirect from="/newtab/account/*" to="/newtab/account/" />
+        </Switch>
+      }
+    />
+  )
 }
 
 TabSettingsPage.propTypes = {

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -25,6 +25,9 @@ import {
 } from 'js/navigation/navigation'
 
 const styles = theme => ({
+  list: {
+    marginLeft: 10,
+  },
   listSubheader: {
     paddingLeft: 14,
   },
@@ -37,12 +40,10 @@ const TabSettingsPage = props => {
   // const onClose = () => {
   //   console.error('Fix me!')
   // }
-
-  const sidebarLeftMargin = 10
   return (
     <SettingsPage
       sidebarContent={({ showError }) => (
-        <List style={{ marginLeft: sidebarLeftMargin }}>
+        <List className={classes.listSubheader}>
           <ListSubheader disableSticky className={classes.listSubheader}>
             Settings
           </ListSubheader>

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -34,13 +34,6 @@ const TabSettingsPage = props => {
   const { authUser, classes } = props
 
   // FIXME
-  // const { errorMessage, errorOpen } = this.state
-  // const showError = this.showError
-  const showError = () => {
-    console.error('Fix me!')
-  }
-
-  // FIXME
   // const onClose = () => {
   //   console.error('Fix me!')
   // }
@@ -48,7 +41,7 @@ const TabSettingsPage = props => {
   const sidebarLeftMargin = 10
   return (
     <SettingsPage
-      sidebarContent={
+      sidebarContent={({ showError }) => (
         <List style={{ marginLeft: sidebarLeftMargin }}>
           <ListSubheader disableSticky className={classes.listSubheader}>
             Settings
@@ -77,8 +70,8 @@ const TabSettingsPage = props => {
             Account
           </SettingsMenuItem>
         </List>
-      }
-      mainContent={
+      )}
+      mainContent={({ showError }) => (
         <Switch>
           <Route
             exact
@@ -152,7 +145,7 @@ const TabSettingsPage = props => {
           <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
           <Redirect from="/newtab/account/*" to="/newtab/account/" />
         </Switch>
-      }
+      )}
     />
   )
 }

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -36,7 +36,7 @@ const styles = theme => ({
   },
 })
 
-class SettingsPage extends React.Component {
+class TabSettingsPage extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -220,11 +220,11 @@ class SettingsPage extends React.Component {
   }
 }
 
-SettingsPage.propTypes = {
+TabSettingsPage.propTypes = {
   authUser: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }).isRequired,
   classes: PropTypes.object.isRequired,
 }
 
-export default withStyles(styles)(withUser()(SettingsPage))
+export default withStyles(styles)(withUser()(TabSettingsPage))

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -1,0 +1,230 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Redirect, Route, Switch } from 'react-router-dom'
+import { withStyles } from '@material-ui/core/styles'
+import AppBar from '@material-ui/core/AppBar'
+import Divider from '@material-ui/core/Divider'
+import IconButton from '@material-ui/core/IconButton'
+import List from '@material-ui/core/List'
+import ListSubheader from '@material-ui/core/ListSubheader'
+import Toolbar from '@material-ui/core/Toolbar'
+import CloseIcon from '@material-ui/icons/Close'
+
+import AccountView from 'js/components/Settings/Account/AccountView'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import Logo from 'js/components/Logo/Logo'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import withUser from 'js/components/General/withUser'
+import {
+  goToDashboard,
+  accountURL,
+  backgroundSettingsURL,
+  donateURL,
+  inviteFriendsURL,
+  statsURL,
+  widgetSettingsURL,
+} from 'js/navigation/navigation'
+
+const styles = theme => ({
+  listSubheader: {
+    paddingLeft: 14,
+  },
+})
+
+class SettingsPage extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      errorOpen: false,
+      errorMessage: null,
+    }
+  }
+
+  goToHome() {
+    goToDashboard()
+  }
+
+  showError(msg) {
+    this.setState({
+      errorOpen: true,
+      errorMessage: msg,
+    })
+  }
+
+  clearError() {
+    this.setState({
+      errorOpen: false,
+    })
+  }
+
+  render() {
+    const { authUser, classes } = this.props
+    const { errorMessage, errorOpen } = this.state
+    const showError = this.showError
+    const sidebarWidth = 240
+    const sidebarLeftMargin = 10
+    return (
+      <div
+        data-test-id={'app-settings-id'}
+        key={'settings-view-key'}
+        style={{
+          color: '#fff',
+          backgroundColor: '#F2F2F2',
+          minWidth: '100vw',
+          minHeight: '100vh',
+        }}
+      >
+        <AppBar color={'primary'} position={'sticky'}>
+          <Toolbar>
+            <div style={{ flex: 1 }}>
+              <Logo color={'white'} />
+            </div>
+            <IconButton onClick={this.goToHome.bind(this)}>
+              <CloseIcon
+                style={{
+                  color: '#fff',
+                  width: 28,
+                  height: 28,
+                }}
+              />
+            </IconButton>
+          </Toolbar>
+        </AppBar>
+        <div style={{ width: sidebarWidth, position: 'fixed' }}>
+          <List style={{ marginLeft: sidebarLeftMargin }}>
+            <ListSubheader disableSticky className={classes.listSubheader}>
+              Settings
+            </ListSubheader>
+            <SettingsMenuItem key={'widgets'} to={widgetSettingsURL}>
+              Widgets
+            </SettingsMenuItem>
+            <SettingsMenuItem key={'background'} to={backgroundSettingsURL}>
+              Background
+            </SettingsMenuItem>
+            <Divider />
+            <ListSubheader disableSticky className={classes.listSubheader}>
+              Your Profile
+            </ListSubheader>
+            <SettingsMenuItem key={'stats'} to={statsURL}>
+              Your Stats
+            </SettingsMenuItem>
+            <SettingsMenuItem key={'donate'} to={donateURL}>
+              Donate Hearts
+            </SettingsMenuItem>
+            <SettingsMenuItem key={'invite'} to={inviteFriendsURL}>
+              Invite Friends
+            </SettingsMenuItem>
+            <Divider />
+            <SettingsMenuItem key={'account'} to={accountURL}>
+              Account
+            </SettingsMenuItem>
+          </List>
+        </div>
+        <div
+          style={{
+            marginLeft: sidebarWidth,
+            boxSizing: 'border-box',
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+        >
+          <Switch>
+            <Route
+              exact
+              path="/newtab/settings/widgets/"
+              render={props => (
+                <WidgetsSettingsView
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
+              )}
+            />
+
+            <Route
+              exact
+              path="/newtab/settings/background/"
+              render={props => (
+                <BackgroundSettingsView
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
+              )}
+            />
+            <Route
+              exact
+              path="/newtab/profile/stats/"
+              render={props => (
+                <ProfileStatsView
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
+              )}
+            />
+            <Route
+              exact
+              path="/newtab/profile/donate/"
+              render={props => (
+                <ProfileDonateHearts
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
+              )}
+            />
+            <Route
+              exact
+              path="/newtab/profile/invite/"
+              render={props => (
+                <ProfileInviteFriend
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
+              )}
+            />
+            <Route
+              exact
+              path="/newtab/account/"
+              render={props => (
+                <AccountView
+                  {...props}
+                  authUser={authUser}
+                  showError={showError.bind(this)}
+                />
+              )}
+            />
+            {/* Redirect any incorrect paths */}
+            <Redirect
+              from="/newtab/settings/*"
+              to="/newtab/settings/widgets/"
+            />
+            <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
+            <Redirect from="/newtab/account/*" to="/newtab/account/" />
+          </Switch>
+        </div>
+        <ErrorMessage
+          message={errorMessage}
+          onClose={this.clearError.bind(this)}
+          open={errorOpen}
+        />
+      </div>
+    )
+  }
+}
+
+SettingsPage.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  classes: PropTypes.object.isRequired,
+}
+
+export default withStyles(styles)(withUser()(SettingsPage))

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -37,11 +37,6 @@ const styles = theme => ({
 
 const TabSettingsPage = props => {
   const { authUser, classes } = props
-
-  // FIXME
-  // const onClose = () => {
-  //   console.error('Fix me!')
-  // }
   return (
     <SettingsPage
       onClose={() => {

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -16,8 +16,10 @@ import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 import withUser from 'js/components/General/withUser'
 import {
+  goTo,
   accountURL,
   backgroundSettingsURL,
+  dashboardURL,
   donateURL,
   inviteFriendsURL,
   statsURL,
@@ -42,6 +44,9 @@ const TabSettingsPage = props => {
   // }
   return (
     <SettingsPage
+      onClose={() => {
+        goTo(dashboardURL)
+      }}
       sidebarContent={({ showError }) => (
         <List className={classes.listSubheader}>
           <ListSubheader disableSticky className={classes.listSubheader}>

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -2,409 +2,61 @@
 
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Redirect, Route, Switch } from 'react-router-dom'
 import IconButton from '@material-ui/core/IconButton'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
-import AccountView from 'js/components/Settings/Account/AccountView'
-import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-import ErrorMessage from 'js/components/General/ErrorMessage'
-// import Logo from 'js/components/Logo/Logo'
-import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
-import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
-import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
-import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
-import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+// import ErrorMessage from 'js/components/General/ErrorMessage'
 import { goToDashboard } from 'js/navigation/navigation'
 
-jest.mock('react-router-dom')
-jest.mock('js/components/Settings/Account/AccountView')
-jest.mock('js/components/Settings/Background/BackgroundSettingsView')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/Logo/Logo')
-jest.mock('js/components/Settings/Profile/ProfileStatsView')
-jest.mock('js/components/Settings/Profile/ProfileDonateHeartsView')
-jest.mock('js/components/Settings/Profile/ProfileInviteFriendView')
-jest.mock('js/components/Settings/SettingsMenuItem')
-jest.mock('js/components/Settings/Widgets/WidgetsSettingsView')
-jest.mock('js/components/General/withUser')
 jest.mock('js/navigation/navigation')
 
 afterEach(() => {
   jest.clearAllMocks()
 })
 
-const getMockProps = () => ({})
-
-describe('withUser HOC in SettingsPage', () => {
-  beforeEach(() => {
-    jest.resetModules()
-  })
-
-  it('is called with the expected options', () => {
-    const withUser = require('js/components/General/withUser').default
-
-    /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/SettingsPageComponent').default
-    expect(withUser).toHaveBeenCalledWith()
-  })
-
-  it('wraps the SettingsPage component', () => {
-    const {
-      __mockWithUserWrappedFunction,
-    } = require('js/components/General/withUser')
-
-    /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/SettingsPageComponent').default
-    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
-    expect(wrappedComponent.name).toEqual('SettingsPage')
-  })
+const getMockProps = () => ({
+  mainContent: <div>hi</div>,
+  sidebarContent: (
+    <ul>
+      <li>thing</li>
+    </ul>
+  ),
 })
 
 describe('SettingsPage', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()
-    shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
+    shallow(<SettingsPage {...mockProps} />).dive()
   })
 
-  it('renders the expected side menu items', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const menuItems = wrapper.find(SettingsMenuItem)
-    const expectedMenuItems = [
-      'Widgets',
-      'Background',
-      'Your Stats',
-      'Donate Hearts',
-      'Invite Friends',
-      'Account',
-    ]
-    menuItems.forEach((menuItem, index) => {
-      expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
-    })
-  })
-
-  it('includes a WidgetsSettingsView route', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected WidgetsSettingsView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(WidgetsSettingsView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
-    )
-  })
-
-  it('includes a BackgroundSettingsView route', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected BackgroundSettingsView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(BackgroundSettingsView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
-    )
-  })
-
-  it('includes a ProfileStatsView route', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected ProfileStatsView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(ProfileStatsView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
-    )
-  })
-
-  it('includes a ProfileDonateHearts route', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected ProfileDonateHearts component with the expected props', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(ProfileDonateHearts)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
-    )
-  })
-
-  it('includes a ProfileInviteFriend route', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected ProfileInviteFriend component with the expected props', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(ProfileInviteFriend)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
-    )
-  })
-
-  it('includes a AccountView route', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected AccountView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(AccountView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
-    )
-  })
-
-  it('redirects from any nonexistent settings page to the widgets settings page', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
-  })
-
-  it('redirects from any nonexistent settings page to the widgets settings page', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
-  })
-
-  it('redirects from any nonexistent profile page to the profile stats page', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/profile/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/profile/stats/')
-  })
-
-  it('redirects from any nonexistent account page to the main account page', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/account/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/account/')
-  })
-
-  it('displays an error message when a child route calls the showError prop', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-
-    // We should not show an error message yet.
-    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
-
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    const showErrorFunc = ThisRouteComponentElem.prop('showError')
-    showErrorFunc('We made a mistake :(')
-    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
-    expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
-      'We made a mistake :('
-    )
-  })
+  //   it('displays an error message when a child route calls the showError prop', () => {
+  //     const mockProps = getMockProps()
+  //     const wrapper = shallow(<SettingsPage {...mockProps} />)
+  //       .dive()
+  //
+  //     // We should not show an error message yet.
+  //     expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
+  //
+  //     const routeElem = wrapper
+  //       .find(Switch)
+  //       .find(Route)
+  //       .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+  //     const ThisRouteComponent = routeElem.prop('render')
+  //     const ThisRouteComponentElem = shallow(
+  //       <ThisRouteComponent fakeProp={'abc'} />
+  //     )
+  //     const showErrorFunc = ThisRouteComponentElem.prop('showError')
+  //     showErrorFunc('We made a mistake :(')
+  //     expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
+  //     expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
+  //       'We made a mistake :('
+  //     )
+  //   })
 
   it('goes to the Tab dashboard when clicking the close IconButton', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
-      .dive()
-      .dive()
+    const wrapper = shallow(<SettingsPage {...mockProps} />).dive()
     expect(goToDashboard).not.toHaveBeenCalled()
     wrapper.find(IconButton).simulate('click')
     expect(goToDashboard).toHaveBeenCalled()

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -5,7 +5,6 @@ import { shallow } from 'enzyme'
 import IconButton from '@material-ui/core/IconButton'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
-import { goToDashboard } from 'js/navigation/navigation'
 
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/Logo/Logo')
@@ -17,6 +16,7 @@ afterEach(() => {
 
 const getMockProps = () => ({
   mainContent: () => <div>hi</div>,
+  onClose: jest.fn(),
   sidebarContent: () => (
     <ul>
       <li>thing</li>
@@ -68,11 +68,11 @@ describe('SettingsPage', () => {
     )
   })
 
-  it('goes to the Tab dashboard when clicking the close IconButton', () => {
+  it('calls the "onClose" prop when clicking the close IconButton', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<SettingsPage {...mockProps} />).dive()
-    expect(goToDashboard).not.toHaveBeenCalled()
+    expect(mockProps.onClose).not.toHaveBeenCalled()
     wrapper.find(IconButton).simulate('click')
-    expect(goToDashboard).toHaveBeenCalled()
+    expect(mockProps.onClose).toHaveBeenCalled()
   })
 })

--- a/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/SettingsPageComponent.test.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import IconButton from '@material-ui/core/IconButton'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
-// import ErrorMessage from 'js/components/General/ErrorMessage'
+import ErrorMessage from 'js/components/General/ErrorMessage'
 import { goToDashboard } from 'js/navigation/navigation'
 
 jest.mock('js/components/General/ErrorMessage')
@@ -16,8 +16,8 @@ afterEach(() => {
 })
 
 const getMockProps = () => ({
-  mainContent: <div>hi</div>,
-  sidebarContent: (
+  mainContent: () => <div>hi</div>,
+  sidebarContent: () => (
     <ul>
       <li>thing</li>
     </ul>
@@ -30,29 +30,43 @@ describe('SettingsPage', () => {
     shallow(<SettingsPage {...mockProps} />).dive()
   })
 
-  //   it('displays an error message when a child route calls the showError prop', () => {
-  //     const mockProps = getMockProps()
-  //     const wrapper = shallow(<SettingsPage {...mockProps} />)
-  //       .dive()
-  //
-  //     // We should not show an error message yet.
-  //     expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
-  //
-  //     const routeElem = wrapper
-  //       .find(Switch)
-  //       .find(Route)
-  //       .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-  //     const ThisRouteComponent = routeElem.prop('render')
-  //     const ThisRouteComponentElem = shallow(
-  //       <ThisRouteComponent fakeProp={'abc'} />
-  //     )
-  //     const showErrorFunc = ThisRouteComponentElem.prop('showError')
-  //     showErrorFunc('We made a mistake :(')
-  //     expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
-  //     expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
-  //       'We made a mistake :('
-  //     )
-  //   })
+  it('displays an error message when a "mainContent" child calls the showError prop', () => {
+    const mockProps = getMockProps()
+    mockProps.mainContent = ({ showError }) => (
+      <div id="main-content-error-test" showError={showError} />
+    )
+    const wrapper = shallow(<SettingsPage {...mockProps} />).dive()
+
+    // We should not show an error message yet.
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
+
+    wrapper.find('div#main-content-error-test').prop('showError')(
+      'We made a mistake :('
+    )
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
+      'We made a mistake :('
+    )
+  })
+
+  it('displays an error message when a "sidebarContent" child calls the showError prop', () => {
+    const mockProps = getMockProps()
+    mockProps.sidebarContent = ({ showError }) => (
+      <div id="sidebar-content-error-test" showError={showError} />
+    )
+    const wrapper = shallow(<SettingsPage {...mockProps} />).dive()
+
+    // We should not show an error message yet.
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
+
+    wrapper.find('div#sidebar-content-error-test').prop('showError')(
+      'We made a mistake :('
+    )
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
+      'We made a mistake :('
+    )
+  })
 
   it('goes to the Tab dashboard when clicking the close IconButton', () => {
     const mockProps = getMockProps()

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import IconButton from '@material-ui/core/IconButton'
-import SettingsPage from 'js/components/Settings/SettingsPageComponent'
+import TabSettingsPage from 'js/components/Settings/TabSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
 import ErrorMessage from 'js/components/General/ErrorMessage'
@@ -35,7 +35,7 @@ afterEach(() => {
 
 const getMockProps = () => ({})
 
-describe('withUser HOC in SettingsPage', () => {
+describe('withUser HOC in TabSettingsPage', () => {
   beforeEach(() => {
     jest.resetModules()
   })
@@ -44,33 +44,33 @@ describe('withUser HOC in SettingsPage', () => {
     const withUser = require('js/components/General/withUser').default
 
     /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/SettingsPageComponent').default
+    require('js/components/Settings/TabSettingsPageComponent').default
     expect(withUser).toHaveBeenCalledWith()
   })
 
-  it('wraps the SettingsPage component', () => {
+  it('wraps the TabSettingsPage component', () => {
     const {
       __mockWithUserWrappedFunction,
     } = require('js/components/General/withUser')
 
     /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/SettingsPageComponent').default
+    require('js/components/Settings/TabSettingsPageComponent').default
     const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
-    expect(wrappedComponent.name).toEqual('SettingsPage')
+    expect(wrappedComponent.name).toEqual('TabSettingsPage')
   })
 })
 
-describe('SettingsPage', () => {
+describe('TabSettingsPage', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()
-    shallow(<SettingsPage {...mockProps} />)
+    shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
   })
 
   it('renders the expected side menu items', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const menuItems = wrapper.find(SettingsMenuItem)
@@ -89,7 +89,7 @@ describe('SettingsPage', () => {
 
   it('includes a WidgetsSettingsView route', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -101,7 +101,7 @@ describe('SettingsPage', () => {
 
   it('renders the expected WidgetsSettingsView component with the expected props', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -129,7 +129,7 @@ describe('SettingsPage', () => {
 
   it('includes a BackgroundSettingsView route', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -141,7 +141,7 @@ describe('SettingsPage', () => {
 
   it('renders the expected BackgroundSettingsView component with the expected props', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -169,7 +169,7 @@ describe('SettingsPage', () => {
 
   it('includes a ProfileStatsView route', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -181,7 +181,7 @@ describe('SettingsPage', () => {
 
   it('renders the expected ProfileStatsView component with the expected props', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -209,7 +209,7 @@ describe('SettingsPage', () => {
 
   it('includes a ProfileDonateHearts route', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -221,7 +221,7 @@ describe('SettingsPage', () => {
 
   it('renders the expected ProfileDonateHearts component with the expected props', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -249,7 +249,7 @@ describe('SettingsPage', () => {
 
   it('includes a ProfileInviteFriend route', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -261,7 +261,7 @@ describe('SettingsPage', () => {
 
   it('renders the expected ProfileInviteFriend component with the expected props', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -289,7 +289,7 @@ describe('SettingsPage', () => {
 
   it('includes a AccountView route', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -301,7 +301,7 @@ describe('SettingsPage', () => {
 
   it('renders the expected AccountView component with the expected props', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const routeElem = wrapper
@@ -329,7 +329,7 @@ describe('SettingsPage', () => {
 
   it('redirects from any nonexistent settings page to the widgets settings page', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const redirectElem = wrapper
@@ -341,7 +341,7 @@ describe('SettingsPage', () => {
 
   it('redirects from any nonexistent settings page to the widgets settings page', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const redirectElem = wrapper
@@ -353,7 +353,7 @@ describe('SettingsPage', () => {
 
   it('redirects from any nonexistent profile page to the profile stats page', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const redirectElem = wrapper
@@ -365,7 +365,7 @@ describe('SettingsPage', () => {
 
   it('redirects from any nonexistent account page to the main account page', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const redirectElem = wrapper
@@ -377,7 +377,7 @@ describe('SettingsPage', () => {
 
   it('displays an error message when a child route calls the showError prop', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
 
@@ -402,7 +402,7 @@ describe('SettingsPage', () => {
 
   it('goes to the Tab dashboard when clicking the close IconButton', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<SettingsPage {...mockProps} />)
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
     expect(goToDashboard).not.toHaveBeenCalled()

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -7,8 +7,6 @@ import IconButton from '@material-ui/core/IconButton'
 import TabSettingsPage from 'js/components/Settings/TabSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-import ErrorMessage from 'js/components/General/ErrorMessage'
-// import Logo from 'js/components/Logo/Logo'
 import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
@@ -19,7 +17,6 @@ import { goToDashboard } from 'js/navigation/navigation'
 jest.mock('react-router-dom')
 jest.mock('js/components/Settings/Account/AccountView')
 jest.mock('js/components/Settings/Background/BackgroundSettingsView')
-jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/Logo/Logo')
 jest.mock('js/components/Settings/Profile/ProfileStatsView')
 jest.mock('js/components/Settings/Profile/ProfileDonateHeartsView')
@@ -375,38 +372,14 @@ describe('TabSettingsPage', () => {
     expect(redirectElem.prop('to')).toEqual('/newtab/account/')
   })
 
-  it('displays an error message when a child route calls the showError prop', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-
-    // We should not show an error message yet.
-    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
-
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    const showErrorFunc = ThisRouteComponentElem.prop('showError')
-    showErrorFunc('We made a mistake :(')
-    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
-    expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
-      'We made a mistake :('
-    )
-  })
-
-  it('goes to the Tab dashboard when clicking the close IconButton', () => {
-    const mockProps = getMockProps()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-    expect(goToDashboard).not.toHaveBeenCalled()
-    wrapper.find(IconButton).simulate('click')
-    expect(goToDashboard).toHaveBeenCalled()
-  })
+  // FIXME
+  // it('goes to the Tab dashboard when clicking the close IconButton', () => {
+  //   const mockProps = getMockProps()
+  //   const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+  //     .dive()
+  //     .dive()
+  //   expect(goToDashboard).not.toHaveBeenCalled()
+  //   wrapper.find(IconButton).simulate('click')
+  //   expect(goToDashboard).toHaveBeenCalled()
+  // })
 })

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -65,6 +65,19 @@ describe('TabSettingsPage', () => {
       .dive()
   })
 
+  // FIXME
+  // it('goes to the Tab dashboard when clicking the close IconButton', () => {
+  //   const mockProps = getMockProps()
+  //   const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+  //     .dive()
+  //     .dive()
+  //   expect(goToDashboard).not.toHaveBeenCalled()
+  //   wrapper.find(IconButton).simulate('click')
+  //   expect(goToDashboard).toHaveBeenCalled()
+  // })
+})
+
+describe('TabSettingsPage: sidebar content', () => {
   it('renders the expected side menu items', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
@@ -83,7 +96,10 @@ describe('TabSettingsPage', () => {
       expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
     })
   })
+})
 
+// TODO: need to test showError logic
+describe('TabSettingsPage: main content', () => {
   it('includes a WidgetsSettingsView route', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
@@ -371,15 +387,4 @@ describe('TabSettingsPage', () => {
       .filterWhere(elem => elem.prop('from') === '/newtab/account/*')
     expect(redirectElem.prop('to')).toEqual('/newtab/account/')
   })
-
-  // FIXME
-  // it('goes to the Tab dashboard when clicking the close IconButton', () => {
-  //   const mockProps = getMockProps()
-  //   const wrapper = shallow(<TabSettingsPage {...mockProps} />)
-  //     .dive()
-  //     .dive()
-  //   expect(goToDashboard).not.toHaveBeenCalled()
-  //   wrapper.find(IconButton).simulate('click')
-  //   expect(goToDashboard).toHaveBeenCalled()
-  // })
 })

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Redirect, Route, Switch } from 'react-router-dom'
-import IconButton from '@material-ui/core/IconButton'
+// import IconButton from '@material-ui/core/IconButton'
 import TabSettingsPage from 'js/components/Settings/TabSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
@@ -12,7 +12,7 @@ import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHea
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
-import { goToDashboard } from 'js/navigation/navigation'
+// import { goToDashboard } from 'js/navigation/navigation'
 
 jest.mock('react-router-dom')
 jest.mock('js/components/Settings/Account/AccountView')
@@ -98,13 +98,18 @@ describe('TabSettingsPage: sidebar content', () => {
   })
 })
 
-// TODO: need to test showError logic
 describe('TabSettingsPage: main content', () => {
+  const getMainContentRenderPropArgs = () => ({
+    showError: jest.fn(),
+  })
+
   it('includes a WidgetsSettingsView route', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -114,9 +119,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('renders the expected WidgetsSettingsView component with the expected props', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -136,15 +143,17 @@ describe('TabSettingsPage: main content', () => {
       emailVerified: true,
     })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
+      mainContentRenderPropArgs.showError
     )
   })
 
   it('includes a BackgroundSettingsView route', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -154,9 +163,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('renders the expected BackgroundSettingsView component with the expected props', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -176,15 +187,17 @@ describe('TabSettingsPage: main content', () => {
       emailVerified: true,
     })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
+      mainContentRenderPropArgs.showError
     )
   })
 
   it('includes a ProfileStatsView route', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -194,9 +207,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('renders the expected ProfileStatsView component with the expected props', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -216,15 +231,17 @@ describe('TabSettingsPage: main content', () => {
       emailVerified: true,
     })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
+      mainContentRenderPropArgs.showError
     )
   })
 
   it('includes a ProfileDonateHearts route', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -234,9 +251,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('renders the expected ProfileDonateHearts component with the expected props', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -256,15 +275,17 @@ describe('TabSettingsPage: main content', () => {
       emailVerified: true,
     })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
+      mainContentRenderPropArgs.showError
     )
   })
 
   it('includes a ProfileInviteFriend route', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -274,9 +295,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('renders the expected ProfileInviteFriend component with the expected props', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -296,15 +319,17 @@ describe('TabSettingsPage: main content', () => {
       emailVerified: true,
     })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
+      mainContentRenderPropArgs.showError
     )
   })
 
   it('includes a AccountView route', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -314,9 +339,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('renders the expected AccountView component with the expected props', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
@@ -336,15 +363,17 @@ describe('TabSettingsPage: main content', () => {
       emailVerified: true,
     })
     expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      expect.any(Function)
+      mainContentRenderPropArgs.showError
     )
   })
 
   it('redirects from any nonexistent settings page to the widgets settings page', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const redirectElem = wrapper
       .find(Switch)
       .find(Redirect)
@@ -354,9 +383,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('redirects from any nonexistent settings page to the widgets settings page', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const redirectElem = wrapper
       .find(Switch)
       .find(Redirect)
@@ -366,9 +397,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('redirects from any nonexistent profile page to the profile stats page', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const redirectElem = wrapper
       .find(Switch)
       .find(Redirect)
@@ -378,9 +411,11 @@ describe('TabSettingsPage: main content', () => {
 
   it('redirects from any nonexistent account page to the main account page', () => {
     const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<TabSettingsPage {...mockProps} />)
       .dive()
       .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
     const redirectElem = wrapper
       .find(Switch)
       .find(Redirect)

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -1,0 +1,412 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Redirect, Route, Switch } from 'react-router-dom'
+import IconButton from '@material-ui/core/IconButton'
+import SettingsPage from 'js/components/Settings/SettingsPageComponent'
+import AccountView from 'js/components/Settings/Account/AccountView'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+// import Logo from 'js/components/Logo/Logo'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import { goToDashboard } from 'js/navigation/navigation'
+
+jest.mock('react-router-dom')
+jest.mock('js/components/Settings/Account/AccountView')
+jest.mock('js/components/Settings/Background/BackgroundSettingsView')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/Logo/Logo')
+jest.mock('js/components/Settings/Profile/ProfileStatsView')
+jest.mock('js/components/Settings/Profile/ProfileDonateHeartsView')
+jest.mock('js/components/Settings/Profile/ProfileInviteFriendView')
+jest.mock('js/components/Settings/SettingsMenuItem')
+jest.mock('js/components/Settings/Widgets/WidgetsSettingsView')
+jest.mock('js/components/General/withUser')
+jest.mock('js/navigation/navigation')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({})
+
+describe('withUser HOC in SettingsPage', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('is called with the expected options', () => {
+    const withUser = require('js/components/General/withUser').default
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/SettingsPageComponent').default
+    expect(withUser).toHaveBeenCalledWith()
+  })
+
+  it('wraps the SettingsPage component', () => {
+    const {
+      __mockWithUserWrappedFunction,
+    } = require('js/components/General/withUser')
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/SettingsPageComponent').default
+    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
+    expect(wrappedComponent.name).toEqual('SettingsPage')
+  })
+})
+
+describe('SettingsPage', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+  })
+
+  it('renders the expected side menu items', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const menuItems = wrapper.find(SettingsMenuItem)
+    const expectedMenuItems = [
+      'Widgets',
+      'Background',
+      'Your Stats',
+      'Donate Hearts',
+      'Invite Friends',
+      'Account',
+    ]
+    menuItems.forEach((menuItem, index) => {
+      expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
+    })
+  })
+
+  it('includes a WidgetsSettingsView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected WidgetsSettingsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(WidgetsSettingsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a BackgroundSettingsView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected BackgroundSettingsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(BackgroundSettingsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a ProfileStatsView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileStatsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileStatsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a ProfileDonateHearts route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileDonateHearts component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileDonateHearts)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a ProfileInviteFriend route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileInviteFriend component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileInviteFriend)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('includes a AccountView route', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected AccountView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(AccountView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
+  })
+
+  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
+  })
+
+  it('redirects from any nonexistent profile page to the profile stats page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/profile/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/profile/stats/')
+  })
+
+  it('redirects from any nonexistent account page to the main account page', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/account/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/account/')
+  })
+
+  it('displays an error message when a child route calls the showError prop', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+
+    // We should not show an error message yet.
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(false)
+
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    const showErrorFunc = ThisRouteComponentElem.prop('showError')
+    showErrorFunc('We made a mistake :(')
+    expect(wrapper.find(ErrorMessage).prop('open')).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toEqual(
+      'We made a mistake :('
+    )
+  })
+
+  it('goes to the Tab dashboard when clicking the close IconButton', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    expect(goToDashboard).not.toHaveBeenCalled()
+    wrapper.find(IconButton).simulate('click')
+    expect(goToDashboard).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -3,7 +3,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Redirect, Route, Switch } from 'react-router-dom'
-// import IconButton from '@material-ui/core/IconButton'
 import TabSettingsPage from 'js/components/Settings/TabSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
@@ -11,8 +10,9 @@ import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
-// import { goToDashboard } from 'js/navigation/navigation'
+import { goTo, dashboardURL } from 'js/navigation/navigation'
 
 jest.mock('react-router-dom')
 jest.mock('js/components/Settings/Account/AccountView')
@@ -65,16 +65,15 @@ describe('TabSettingsPage', () => {
       .dive()
   })
 
-  // FIXME
-  // it('goes to the Tab dashboard when clicking the close IconButton', () => {
-  //   const mockProps = getMockProps()
-  //   const wrapper = shallow(<TabSettingsPage {...mockProps} />)
-  //     .dive()
-  //     .dive()
-  //   expect(goToDashboard).not.toHaveBeenCalled()
-  //   wrapper.find(IconButton).simulate('click')
-  //   expect(goToDashboard).toHaveBeenCalled()
-  // })
+  it('goes to the Tab dashboard when the SettingsPage "onClose" callback is called', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    expect(goTo).not.toHaveBeenCalled()
+    wrapper.find(SettingsPage).prop('onClose')()
+    expect(goTo).toHaveBeenCalledWith(dashboardURL)
+  })
 })
 
 describe('TabSettingsPage: sidebar content', () => {


### PR DESCRIPTION
This PR is part two of adding some settings and profile pages to the search app.

This PR should not change anything for the end user. It refactors the SettingsPage component into an app-agnostic wrapper for content and creates a settings page specifically for Tab for a Cause.
