### PR TITLE
Create some profile/settings pages for Search

### DIFF
--- a/web/src/js/authentication/__tests__/helpers.test.js
+++ b/web/src/js/authentication/__tests__/helpers.test.js
@@ -284,7 +284,7 @@ describe('redirectToAuthIfNeeded tests', () => {
       isAnonymous: false,
       emailVerified: true,
     }
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(redirected).toBe(false)
     expect(goTo).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
@@ -302,7 +302,7 @@ describe('redirectToAuthIfNeeded tests', () => {
     }
 
     const { redirectToAuthIfNeeded } = require('js/authentication/helpers')
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(redirected).toBe(false)
     expect(goToDashboard).not.toHaveBeenCalled()
     expect(goTo).not.toHaveBeenCalled()
@@ -315,7 +315,7 @@ describe('redirectToAuthIfNeeded tests', () => {
     const authUser = null
     isInIframe.mockReturnValue(false)
     const { redirectToAuthIfNeeded } = require('js/authentication/helpers')
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(redirected).toBe(true)
     expect(replaceUrl).toHaveBeenCalledWith(
       loginURL,
@@ -336,7 +336,7 @@ describe('redirectToAuthIfNeeded tests', () => {
     }
     isInIframe.mockReturnValue(false)
     const { redirectToAuthIfNeeded } = require('js/authentication/helpers')
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(replaceUrl).toHaveBeenCalledWith(
       loginURL,
       {},
@@ -363,7 +363,7 @@ describe('redirectToAuthIfNeeded tests', () => {
     }
 
     const { redirectToAuthIfNeeded } = require('js/authentication/helpers')
-    redirectToAuthIfNeeded(authUser)
+    redirectToAuthIfNeeded({ authUser })
 
     expect(replaceUrl).toHaveBeenCalledWith(
       authMessageURL,
@@ -390,7 +390,7 @@ describe('redirectToAuthIfNeeded tests', () => {
       emailVerified: false,
     }
     const { redirectToAuthIfNeeded } = require('js/authentication/helpers')
-    redirectToAuthIfNeeded(authUser)
+    redirectToAuthIfNeeded({ authUser })
     expect(replaceUrl).toHaveBeenCalledWith(
       loginURL,
       { mandatory: 'true' },
@@ -416,7 +416,7 @@ describe('redirectToAuthIfNeeded tests', () => {
       emailVerified: false,
     }
     const { redirectToAuthIfNeeded } = require('js/authentication/helpers')
-    redirectToAuthIfNeeded(authUser)
+    redirectToAuthIfNeeded({ authUser })
     expect(replaceUrl).not.toHaveBeenCalled()
   })
 
@@ -431,7 +431,7 @@ describe('redirectToAuthIfNeeded tests', () => {
       isAnonymous: false,
       emailVerified: false,
     }
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(replaceUrl).toHaveBeenCalledWith(missingEmailMessageURL, null, {
       keepURLParams: true,
     })
@@ -449,7 +449,7 @@ describe('redirectToAuthIfNeeded tests', () => {
       isAnonymous: false,
       emailVerified: false,
     }
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(replaceUrl).toHaveBeenCalledWith(verifyEmailURL, null, {
       keepURLParams: true,
     })
@@ -467,7 +467,7 @@ describe('redirectToAuthIfNeeded tests', () => {
       isAnonymous: false,
       emailVerified: true,
     }
-    const redirected = redirectToAuthIfNeeded(authUser)
+    const redirected = redirectToAuthIfNeeded({ authUser })
     expect(replaceUrl).toHaveBeenCalledWith(enterUsernameURL, null, {
       keepURLParams: true,
     })
@@ -488,7 +488,7 @@ describe('redirectToAuthIfNeeded tests', () => {
     const user = {
       username: 'MisterTee',
     }
-    const redirected = redirectToAuthIfNeeded(authUser, user)
+    const redirected = redirectToAuthIfNeeded({ authUser, user })
     expect(setUsernameInLocalStorage).toHaveBeenCalledWith('MisterTee')
     expect(replaceUrl).not.toHaveBeenCalled()
     expect(redirected).toBe(false)

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -139,20 +139,21 @@ export const createAnonymousUserIfPossible = async () => {
  * to an authentication page. If the user is not fully authenticated,
  * redirect and return true. If the user is fully authenticated, do
  * not redirect and return false.
- * @param {object} authUser - The AuthUser object
- * @param {string} authUser.id - The user's ID
- * @param {string} authUser.email - The user's email
- * @param {string} authUser.username - The user's username from local storage
- * @param {boolean} authUser.isAnonymous - Whether the user is anonymous
- * @param {boolean} authUser.emailVerified - Whether the user has verified their email
- * @param {object} user - The user object from our API
- * @param {object} user.username - The user's username from our database. This
+ * @param {Object} params
+ * @param {Object} params.authUser - The AuthUser object
+ * @param {String} params.authUser.id - The user's ID
+ * @param {String} params.authUser.email - The user's email
+ * @param {String} params.authUser.username - The user's username from local storage
+ * @param {Boolean} params.authUser.isAnonymous - Whether the user is anonymous
+ * @param {Boolean} params.authUser.emailVerified - Whether the user has verified their email
+ * @param {Object} params.user - The user object from our API
+ * @param {Object} params.user.username - The user's username from our database. This
  *   may exist when authUser.username does not; for example, if a user clears
  *   their local storage.
  * @return {Boolean} Whether or not we redirected (e.g. true if the
  *   user was not fully authenticated).
  */
-export const redirectToAuthIfNeeded = (authUser, user = null) => {
+export const redirectToAuthIfNeeded = ({ authUser, user = null }) => {
   var redirected = true
 
   // User does not exist. Require login.
@@ -209,11 +210,11 @@ export const redirectToAuthIfNeeded = (authUser, user = null) => {
  * exist. This is idempotent and may be called when returning users sign in.
  * @returns {Promise<object>} user - A promise that resolves into a
  *   user object
- * @returns {string} user.id - The user's ID, the same value as the
+ * @returns {String} user.id - The user's ID, the same value as the
  *   userId argument
- * @returns {string|null} user.email - The user's email, the same value as the
+ * @returns {String|null} user.email - The user's email, the same value as the
  *   email argument
- * @returns {string|null} user.username - The user's username, if already
+ * @returns {String|null} user.username - The user's username, if already
  *   set; or null, if not yet set
  */
 export const createNewUser = () => {

--- a/web/src/js/authentication/helpers.js
+++ b/web/src/js/authentication/helpers.js
@@ -150,15 +150,21 @@ export const createAnonymousUserIfPossible = async () => {
  * @param {Object} params.user.username - The user's username from our database. This
  *   may exist when authUser.username does not; for example, if a user clears
  *   their local storage.
+ * @param {Object} params.urlParams - URL parameter values to append to the auth URL
+ *   when redirecting.
  * @return {Boolean} Whether or not we redirected (e.g. true if the
  *   user was not fully authenticated).
  */
-export const redirectToAuthIfNeeded = ({ authUser, user = null }) => {
+export const redirectToAuthIfNeeded = ({
+  authUser,
+  user = null,
+  urlParams = {},
+}) => {
   var redirected = true
 
   // User does not exist. Require login.
   if (!authUser || !authUser.id) {
-    goToMainLoginPage()
+    goToMainLoginPage(urlParams)
     redirected = true
     // If the user has an anonymous account and is allowed to be
     // anonymous, do nothing. If they're anonymous but are not
@@ -172,21 +178,21 @@ export const redirectToAuthIfNeeded = ({ authUser, user = null }) => {
       if (anonymousUserMandatorySignIn()) {
         // Include the "mandatory" URL parameter so we're able to
         // show an explanation on the sign-in views.
-        goToMainLoginPage({ mandatory: 'true' })
+        goToMainLoginPage({ mandatory: 'true', ...urlParams })
         redirected = true
       } else {
-        goToMainLoginPage()
+        goToMainLoginPage(urlParams)
         redirected = true
       }
     }
     // If the user does not have an email address, show a message
     // asking them to sign in with a different method.
   } else if (!authUser.email) {
-    replaceUrl(missingEmailMessageURL, null, { keepURLParams: true })
+    replaceUrl(missingEmailMessageURL, urlParams, { keepURLParams: true })
     redirected = true
     // User is logged in but their email is not verified.
   } else if (!authUser.emailVerified) {
-    replaceUrl(verifyEmailURL, null, { keepURLParams: true })
+    replaceUrl(verifyEmailURL, urlParams, { keepURLParams: true })
     redirected = true
     // User is logged in but has not set a username.
   } else if (!authUser.username) {
@@ -196,7 +202,7 @@ export const redirectToAuthIfNeeded = ({ authUser, user = null }) => {
       setUsernameInLocalStorage(user.username)
       redirected = false
     } else {
-      replaceUrl(enterUsernameURL, null, { keepURLParams: true })
+      replaceUrl(enterUsernameURL, urlParams, { keepURLParams: true })
       redirected = true
     }
   } else {

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -334,7 +334,7 @@ class Authentication extends React.Component {
                 bottom: 24,
               }}
             >
-              <Paper>
+              <Paper elevation={1}>
                 <div
                   style={{
                     padding: '14px 18px',

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -103,7 +103,7 @@ class Authentication extends React.Component {
       return
     }
     const { authUser, location, user } = this.props
-    const redirected = redirectToAuthIfNeeded(authUser, user)
+    const redirected = redirectToAuthIfNeeded({ authUser, user })
 
     // When anonymous users choose to sign in, do not go back to the
     // dashboard.

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -216,10 +216,10 @@ describe('Authentication.js tests', function() {
       username: 'charles',
     }
     shallow(<Authentication {...mockProps} />)
-    expect(redirectToAuthIfNeeded).toHaveBeenCalledWith(
-      mockProps.authUser,
-      mockProps.user
-    )
+    expect(redirectToAuthIfNeeded).toHaveBeenCalledWith({
+      authUser: mockProps.authUser,
+      user: mockProps.user,
+    })
   })
 
   it('redirects to the app (Tab for a Cause, by default) if the user is fully authenticated', () => {

--- a/web/src/js/components/Donate/CharityComponent.js
+++ b/web/src/js/components/Donate/CharityComponent.js
@@ -50,7 +50,7 @@ class Charity extends React.Component {
                 // The minHeight specification may break flexibility in sizing
                 // but it also prevents shifting content before the image has
                 // loaded.
-                minHeight: 180,
+                // minHeight: 180,
               }}
               src={charity.logo}
               onClick={this.openCharityWebsite.bind(this)}

--- a/web/src/js/components/Donate/DonateHeartsControlsComponent.js
+++ b/web/src/js/components/Donate/DonateHeartsControlsComponent.js
@@ -15,14 +15,14 @@ import DonateVcMutation from 'js/mutations/DonateVcMutation'
 
 const styles = theme => ({
   charityTitleLink: {
-    color: '#9d4ba3', // TODO: use theme
+    color: theme.palette.primary.main,
     textDecoration: 'none',
     cursor: 'pointer',
     whiteSpace: 'nowrap',
   },
   charityImpactText: {
     '& a': {
-      color: '#9d4ba3', // TODO: use theme
+      color: theme.palette.primary.main,
       textDecoration: 'none',
     },
   },

--- a/web/src/js/components/Donate/DonateHeartsControlsComponent.js
+++ b/web/src/js/components/Donate/DonateHeartsControlsComponent.js
@@ -15,14 +15,14 @@ import DonateVcMutation from 'js/mutations/DonateVcMutation'
 
 const styles = theme => ({
   charityTitleLink: {
-    color: '#9d4ba3',
+    color: '#9d4ba3', // TODO: use theme
     textDecoration: 'none',
     cursor: 'pointer',
     whiteSpace: 'nowrap',
   },
   charityImpactText: {
     '& a': {
-      color: '#9d4ba3',
+      color: '#9d4ba3', // TODO: use theme
       textDecoration: 'none',
     },
   },

--- a/web/src/js/components/General/__tests__/withUser.test.js
+++ b/web/src/js/components/General/__tests__/withUser.test.js
@@ -442,6 +442,40 @@ describe('withUser', () => {
     expect(wrapper.find(MockComponent).prop('authUser')).toBeNull()
   })
 
+  it('does not create an anonymous user when the app === "search" and the createUserIfPossible option is true and logs a warning that it is unsupported', async () => {
+    expect.assertions(2)
+
+    const mockConsoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementationOnce(() => {})
+    const mockCreatedUser = {
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: true,
+      emailVerified: false,
+    }
+    createAnonymousUserIfPossible.mockResolvedValue(mockCreatedUser)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({
+      app: SEARCH_APP,
+      createUserIfPossible: true,
+    })(MockComponent)
+    const wrapper = shallow(<WrappedComponent />)
+
+    // User is not authed.
+    __triggerAuthStateChange(null)
+
+    await flushAllPromises()
+    wrapper.update()
+    expect(createAnonymousUserIfPossible).not.toHaveBeenCalled()
+    expect(mockConsoleWarn).toHaveBeenCalledWith(
+      'Anonymous user creation is not yet supported in the Search app.'
+    )
+  })
+
   it('does not render children if we are redirecting to an auth page', async () => {
     expect.assertions(1)
 

--- a/web/src/js/components/General/__tests__/withUser.test.js
+++ b/web/src/js/components/General/__tests__/withUser.test.js
@@ -13,6 +13,7 @@ import {
   redirectToAuthIfNeeded,
 } from 'js/authentication/helpers'
 import logger from 'js/utils/logger'
+import { SEARCH_APP, TAB_APP } from 'js/constants'
 
 jest.mock('js/authentication/user')
 jest.mock('js/authentication/helpers')
@@ -458,6 +459,72 @@ describe('withUser', () => {
     })
     await flushAllPromises()
     expect(wrapper.find(MockComponent).exists()).toBe(false)
+  })
+
+  it('passes the "app" URL parameter value to redirectToAuthIfNeeded, defaulting to "tab" when options.app is not set', async () => {
+    expect.assertions(1)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser()(MockComponent)
+    shallow(<WrappedComponent />)
+    __triggerAuthStateChange({
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: false,
+      emailVerified: false,
+    })
+    await flushAllPromises()
+    expect(redirectToAuthIfNeeded.mock.calls[0][0]).toMatchObject({
+      urlParams: {
+        app: TAB_APP,
+      },
+    })
+  })
+
+  it('passes the "app" URL parameter value to redirectToAuthIfNeeded when options.app === "tab"', async () => {
+    expect.assertions(1)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({ app: TAB_APP })(MockComponent)
+    shallow(<WrappedComponent />)
+    __triggerAuthStateChange({
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: false,
+      emailVerified: false,
+    })
+    await flushAllPromises()
+    expect(redirectToAuthIfNeeded.mock.calls[0][0]).toMatchObject({
+      urlParams: {
+        app: TAB_APP,
+      },
+    })
+  })
+
+  it('passes the "app" URL parameter value to redirectToAuthIfNeeded when options.app === "search"', async () => {
+    expect.assertions(1)
+
+    const withUser = require('js/components/General/withUser').default
+    const MockComponent = () => null
+    const WrappedComponent = withUser({ app: SEARCH_APP })(MockComponent)
+    shallow(<WrappedComponent />)
+    __triggerAuthStateChange({
+      id: 'abc123',
+      email: null,
+      username: null,
+      isAnonymous: false,
+      emailVerified: false,
+    })
+    await flushAllPromises()
+    expect(redirectToAuthIfNeeded.mock.calls[0][0]).toMatchObject({
+      urlParams: {
+        app: SEARCH_APP,
+      },
+    })
   })
 
   it('renders children when we would have redirected to an auth page but the "redirectToAuthIfIncomplete" option is false', async () => {

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -6,7 +6,7 @@ import {
 } from 'js/authentication/helpers'
 import logger from 'js/utils/logger'
 import { makePromiseCancelable } from 'js/utils/utils'
-// import { SEARCH_APP, TAB_APP } from 'js/constants'
+import { TAB_APP } from 'js/constants'
 
 // https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
 function getDisplayName(WrappedComponent) {
@@ -71,6 +71,7 @@ const withUser = (options = {}) => WrappedComponent => {
 
     async determineAuthState(user) {
       const {
+        app = TAB_APP,
         createUserIfPossible = true,
         redirectToAuthIfIncomplete = true,
       } = options
@@ -124,8 +125,8 @@ const withUser = (options = {}) => WrappedComponent => {
       let redirected = false
       if (redirectToAuthIfIncomplete) {
         try {
-          // TODO: redirect to different URLs depending on the app
-          redirected = redirectToAuthIfNeeded({ authUser })
+          const urlParams = { app: app }
+          redirected = redirectToAuthIfNeeded({ authUser, urlParams })
         } catch (e) {
           logger.error(e)
         }

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -6,7 +6,7 @@ import {
 } from 'js/authentication/helpers'
 import logger from 'js/utils/logger'
 import { makePromiseCancelable } from 'js/utils/utils'
-import { TAB_APP } from 'js/constants'
+import { SEARCH_APP, TAB_APP } from 'js/constants'
 
 // https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
 function getDisplayName(WrappedComponent) {
@@ -82,42 +82,46 @@ const withUser = (options = {}) => WrappedComponent => {
       if (!(user && user.id) && createUserIfPossible) {
         // If options.app === 'search', warn that we don't support this
         // logic and don't do anything.
-        // TODO
-
-        // Mark that user creation is in process so that we don't
-        // don't render child components after the user is authed
-        // but before the user exists in our database.
-        this.setState({
-          userCreationInProgress: true,
-        })
-        try {
-          this.userCreatePromise = makePromiseCancelable(
-            createAnonymousUserIfPossible()
+        if (app === SEARCH_APP) {
+          console.warn(
+            'Anonymous user creation is not yet supported in the Search app.'
           )
-          authUser = await this.userCreatePromise.promise
-        } catch (e) {
-          // If the component already unmounted, don't do anything with
-          // the returned data.
-          if (e && e.isCanceled) {
+        } else {
+          // Mark that user creation is in process so that we don't
+          // don't render child components after the user is authed
+          // but before the user exists in our database.
+          this.setState({
+            userCreationInProgress: true,
+          })
+          try {
+            this.userCreatePromise = makePromiseCancelable(
+              createAnonymousUserIfPossible()
+            )
+            authUser = await this.userCreatePromise.promise
+          } catch (e) {
+            // If the component already unmounted, don't do anything with
+            // the returned data.
+            if (e && e.isCanceled) {
+              return
+            }
+            logger.error(e)
+          }
+
+          // This is an antipattern, and canceling our promises on unmount
+          // should handle the problem. However, in practice, the component
+          // sometimes unmounts between the userCreatePromise resolving and
+          // this point, causing an error when we try to update state on the
+          // unmounted component. It shouldn't cause a memory leak, as we've
+          // canceled the promise and unsubscribed the auth listener.
+          // Note that this might be an error in our code, but it's not a
+          // priority to investigate.
+          if (!this.mounted) {
             return
           }
-          logger.error(e)
+          this.setState({
+            userCreationInProgress: false,
+          })
         }
-
-        // This is an antipattern, and canceling our promises on unmount
-        // should handle the problem. However, in practice, the component
-        // sometimes unmounts between the userCreatePromise resolving and
-        // this point, causing an error when we try to update state on the
-        // unmounted component. It shouldn't cause a memory leak, as we've
-        // canceled the promise and unsubscribed the auth listener.
-        // Note that this might be an error in our code, but it's not a
-        // priority to investigate.
-        if (!this.mounted) {
-          return
-        }
-        this.setState({
-          userCreationInProgress: false,
-        })
       }
 
       // If the user must complete the authentication process, optionally

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -6,6 +6,7 @@ import {
 } from 'js/authentication/helpers'
 import logger from 'js/utils/logger'
 import { makePromiseCancelable } from 'js/utils/utils'
+// import { SEARCH_APP, TAB_APP } from 'js/constants'
 
 // https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
 function getDisplayName(WrappedComponent) {
@@ -18,6 +19,8 @@ function getDisplayName(WrappedComponent) {
  * one does not exist and redirects to the authentication page if the user
  * is not fully authenticated.
  * @param {Object} options
+ * @param {String} options.app - One of "search" or "tab". This determines
+ *   app-specific behavior, like the redirect URL. Defaults to "tab".
  * @param {Boolean} options.renderIfNoUser - If true, we will render the
  *   children even if there is no user ID (the user is not signed in).
  *   Defaults to false.
@@ -74,7 +77,12 @@ const withUser = (options = {}) => WrappedComponent => {
       let authUser = user
 
       // If the user doesn't exist, create one if possible.
+      // IMPORTANT: this logic only works for Tab for a Cause, not Search.
       if (!(user && user.id) && createUserIfPossible) {
+        // If options.app === 'search', warn that we don't support this
+        // logic and don't do anything.
+        // TODO
+
         // Mark that user creation is in process so that we don't
         // don't render child components after the user is authed
         // but before the user exists in our database.
@@ -116,6 +124,7 @@ const withUser = (options = {}) => WrappedComponent => {
       let redirected = false
       if (redirectToAuthIfIncomplete) {
         try {
+          // TODO: redirect to different URLs depending on the app
           redirected = redirectToAuthIfNeeded(authUser)
         } catch (e) {
           logger.error(e)

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -125,7 +125,7 @@ const withUser = (options = {}) => WrappedComponent => {
       if (redirectToAuthIfIncomplete) {
         try {
           // TODO: redirect to different URLs depending on the app
-          redirected = redirectToAuthIfNeeded(authUser)
+          redirected = redirectToAuthIfNeeded({ authUser })
         } catch (e) {
           logger.error(e)
         }

--- a/web/src/js/components/Search/SearchApp.js
+++ b/web/src/js/components/Search/SearchApp.js
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { Suspense, lazy } from 'react'
 import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 import defaultSearchTheme from 'js/theme/searchTheme'
+import FullPageLoader from 'js/components/General/FullPageLoader'
 import SearchAuthRedirect from 'js/components/Search/SearchAuthRedirect'
 import SearchPageComponent from 'js/components/Search/SearchPageComponent'
 import SearchPostUninstallView from 'js/components/Search/SearchPostUninstallView'
@@ -12,6 +13,10 @@ import SearchRandomQueryView from 'js/components/Search/SearchRandomQueryView'
 import { SEARCH_PROVIDER_BING, SEARCH_PROVIDER_YAHOO } from 'js/constants'
 import searchFavicon from 'js/assets/logos/search-favicon.png'
 import { SEARCH_APP } from 'js/constants'
+
+const SearchSettingsPageComponent = lazy(() =>
+  import('js/components/Search/Settings/SearchSettingsPageComponent')
+)
 
 const muiTheme = createMuiTheme(defaultSearchTheme)
 
@@ -26,46 +31,57 @@ class SearchApp extends React.Component {
             <link rel="icon" href={searchFavicon} />
           </Helmet>
           <div>
-            {/* Redirect all /search/* URLs to /search/ for now. */}
-            <Switch>
-              <Route exact path="/search" component={SearchPageComponent} />
-              <Route
-                exact
-                path="/search/bing"
-                render={props => (
-                  <SearchPageComponent
-                    {...props}
-                    searchProvider={SEARCH_PROVIDER_BING}
-                  />
-                )}
-              />
-              <Route
-                exact
-                path="/search/yahoo"
-                render={props => (
-                  <SearchPageComponent
-                    {...props}
-                    searchProvider={SEARCH_PROVIDER_YAHOO}
-                  />
-                )}
-              />
-              <Route
-                exact
-                path="/search/uninstalled/"
-                component={SearchPostUninstallView}
-              />
-              <Route
-                exact
-                path="/search/auth/"
-                component={SearchAuthRedirect}
-              />
-              <Route
-                exact
-                path="/search/random/"
-                component={SearchRandomQueryView}
-              />
-              <Redirect from="*" to={{ ...location, pathname: '/search' }} />
-            </Switch>
+            <Suspense
+              fallback={<FullPageLoader app={SEARCH_APP} delay={350} />}
+            >
+              <Switch>
+                <Route exact path="/search" component={SearchPageComponent} />
+                <Route
+                  exact
+                  path="/search/bing"
+                  render={props => (
+                    <SearchPageComponent
+                      {...props}
+                      searchProvider={SEARCH_PROVIDER_BING}
+                    />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/search/yahoo"
+                  render={props => (
+                    <SearchPageComponent
+                      {...props}
+                      searchProvider={SEARCH_PROVIDER_YAHOO}
+                    />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/search/uninstalled/"
+                  component={SearchPostUninstallView}
+                />
+                <Route
+                  exact
+                  path="/search/auth/"
+                  component={SearchAuthRedirect}
+                />
+                <Route
+                  exact
+                  path="/search/random/"
+                  component={SearchRandomQueryView}
+                />
+                <Route
+                  path="/search/account/"
+                  component={SearchSettingsPageComponent}
+                />
+                <Route
+                  path="/search/profile/"
+                  component={SearchSettingsPageComponent}
+                />
+                <Redirect from="*" to={{ ...location, pathname: '/search' }} />
+              </Switch>
+            </Suspense>
           </div>
         </ErrorBoundary>
       </MuiThemeProvider>

--- a/web/src/js/components/Search/SearchMenuQuery.js
+++ b/web/src/js/components/Search/SearchMenuQuery.js
@@ -96,6 +96,7 @@ SearchMenuQuery.defaultProps = {
 
 export default withUser({
   app: SEARCH_APP,
+  createUserIfPossible: false,
   redirectToAuthIfIncomplete: false,
   renderIfNoUser: true,
 })(SearchMenuQuery)

--- a/web/src/js/components/Search/SearchMenuQuery.js
+++ b/web/src/js/components/Search/SearchMenuQuery.js
@@ -6,6 +6,7 @@ import environment from 'js/relay-env'
 import SearchMenuContainer from 'js/components/Search/SearchMenuContainer'
 import withUser from 'js/components/General/withUser'
 import logger from 'js/utils/logger'
+import { SEARCH_APP } from 'js/constants'
 
 // Make a different query for anonymous users than for
 // authenticated users.
@@ -94,6 +95,7 @@ SearchMenuQuery.defaultProps = {
 }
 
 export default withUser({
+  app: SEARCH_APP,
   redirectToAuthIfIncomplete: false,
   renderIfNoUser: true,
 })(SearchMenuQuery)

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
+import Stat from 'js/components/Settings/Profile/StatComponent'
+import HappyIcon from '@material-ui/icons/Mood'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
+
+const spacingPx = 6
+
+const styles = theme => ({
+  container: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    margin: -spacingPx,
+  },
+  inviteFriendPaper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 18,
+    margin: spacingPx,
+    flex: 2,
+    flexBasis: '40%',
+    minWidth: 200,
+  },
+  thankYouPaper: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flex: 1,
+    flexBasis: '50%',
+    minWidth: 200,
+    padding: 20,
+    margin: spacingPx,
+  },
+  happyIcon: {
+    height: 20,
+    width: 20,
+    marginRight: 8,
+    color: theme.palette.action.active,
+  },
+  thankYouText: {
+    color: theme.palette.action.active,
+  },
+})
+
+const SearchProfileInviteFriend = props => {
+  const { app, classes, user } = props
+  const friendWord = user.numUsersRecruited === 1 ? 'friend' : 'friends'
+  const statStyle = {
+    margin: spacingPx,
+    flex: 1,
+    paddingTop: 40,
+    paddingBottom: 40,
+  }
+  return (
+    <span className={classes.container}>
+      <Paper elevation={1} className={classes.inviteFriendPaper}>
+        <InviteFriend
+          user={user}
+          style={{
+            width: '100%',
+            maxWidth: 300,
+          }}
+        />
+      </Paper>
+      <Stat
+        stat={user.numUsersRecruited}
+        statText={`${friendWord} recruited`}
+        style={statStyle}
+      />
+      <Stat
+        stat={app.referralVcReward}
+        statText={'extra Hearts when you recruit a new friend'}
+        style={statStyle}
+      />
+      <Paper className={classes.thankYouPaper}>
+        <HappyIcon className={classes.happyIcon} />
+        <Typography variant={'body2'} className={classes.thankYouText}>
+          Thank you! Every new person raises more money for charity, and we
+          depend on people like you to get the word out.
+        </Typography>
+      </Paper>
+    </span>
+  )
+}
+
+SearchProfileInviteFriend.propTypes = {
+  app: PropTypes.shape({
+    referralVcReward: PropTypes.number.isRequired,
+  }),
+  classes: PropTypes.object.isRequired,
+  user: PropTypes.shape({
+    numUsersRecruited: PropTypes.number.isRequired,
+  }),
+}
+
+export default withStyles(styles)(SearchProfileInviteFriend)

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
@@ -67,7 +67,7 @@ const SearchProfileInviteFriend = props => {
           }}
         />
       </Paper>
-      <Paper className={classes.thankYouPaper}>
+      <Paper elevation={1} className={classes.thankYouPaper}>
         <div className={classes.thankYouHeader}>
           <HappyIcon className={classes.happyIcon} />
           <Typography variant={'h6'}>Thank you!</Typography>

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
@@ -55,12 +55,11 @@ const styles = theme => ({
 // as Tab for a Cause when we make the content more similar.
 const SearchProfileInviteFriend = props => {
   const { classes } = props
-
-  // FIXME: invite URL
   return (
     <span className={classes.container}>
       <Paper elevation={1} className={classes.inviteFriendPaper}>
         <InviteFriend
+          baseURL={'https://search.gladly.io'}
           user={null}
           style={{
             width: '100%',

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
@@ -20,25 +20,31 @@ const styles = theme => ({
     alignItems: 'center',
     padding: 18,
     margin: spacingPx,
-    flex: 2,
-    flexBasis: '40%',
+    flex: 5,
     minWidth: 200,
+    height: 220,
   },
   thankYouPaper: {
     display: 'flex',
+    flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    flex: 1,
-    flexBasis: '50%',
+    textAlign: 'center',
+    flex: 3,
     minWidth: 200,
     padding: 20,
     margin: spacingPx,
   },
   happyIcon: {
-    height: 20,
-    width: 20,
+    height: 26,
+    width: 26,
     marginRight: 8,
-    color: theme.palette.action.active,
+    color: theme.typography.h6.color,
+  },
+  thankYouHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: '0.35em',
   },
   thankYouText: {
     color: theme.palette.action.active,
@@ -49,6 +55,8 @@ const styles = theme => ({
 // as Tab for a Cause when we make the content more similar.
 const SearchProfileInviteFriend = props => {
   const { classes } = props
+
+  // FIXME: invite URL
   return (
     <span className={classes.container}>
       <Paper elevation={1} className={classes.inviteFriendPaper}>
@@ -61,9 +69,12 @@ const SearchProfileInviteFriend = props => {
         />
       </Paper>
       <Paper className={classes.thankYouPaper}>
-        <HappyIcon className={classes.happyIcon} />
+        <div className={classes.thankYouHeader}>
+          <HappyIcon className={classes.happyIcon} />
+          <Typography variant={'h6'}>Thank you!</Typography>
+        </div>
         <Typography variant={'body2'} className={classes.thankYouText}>
-          Thank you! Every new person raises more money for charity, and we
+          You're one of the first people to use Search for a Cause, and we
           depend on people like you to get the word out.
         </Typography>
       </Paper>

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendComponent.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
-import Stat from 'js/components/Settings/Profile/StatComponent'
 import HappyIcon from '@material-ui/icons/Mood'
 import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
@@ -46,36 +45,21 @@ const styles = theme => ({
   },
 })
 
+// Note: we can start using the same ProfileInviteFriend component
+// as Tab for a Cause when we make the content more similar.
 const SearchProfileInviteFriend = props => {
-  const { app, classes, user } = props
-  const friendWord = user.numUsersRecruited === 1 ? 'friend' : 'friends'
-  const statStyle = {
-    margin: spacingPx,
-    flex: 1,
-    paddingTop: 40,
-    paddingBottom: 40,
-  }
+  const { classes } = props
   return (
     <span className={classes.container}>
       <Paper elevation={1} className={classes.inviteFriendPaper}>
         <InviteFriend
-          user={user}
+          user={null}
           style={{
             width: '100%',
             maxWidth: 300,
           }}
         />
       </Paper>
-      <Stat
-        stat={user.numUsersRecruited}
-        statText={`${friendWord} recruited`}
-        style={statStyle}
-      />
-      <Stat
-        stat={app.referralVcReward}
-        statText={'extra Hearts when you recruit a new friend'}
-        style={statStyle}
-      />
       <Paper className={classes.thankYouPaper}>
         <HappyIcon className={classes.happyIcon} />
         <Typography variant={'body2'} className={classes.thankYouText}>
@@ -88,13 +72,7 @@ const SearchProfileInviteFriend = props => {
 }
 
 SearchProfileInviteFriend.propTypes = {
-  app: PropTypes.shape({
-    referralVcReward: PropTypes.number.isRequired,
-  }),
   classes: PropTypes.object.isRequired,
-  user: PropTypes.shape({
-    numUsersRecruited: PropTypes.number.isRequired,
-  }),
 }
 
 export default withStyles(styles)(SearchProfileInviteFriend)

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendView.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendView.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { QueryRenderer } from 'react-relay'
+import environment from 'js/relay-env'
+
+import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
+import SearchProfileInviteFriend from 'js/components/Search/Settings/SearchProfileInviteFriendComponent'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+class ProfileInviteFriendView extends React.Component {
+  render() {
+    return (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+        }}
+      >
+        <QueryRenderer
+          environment={environment}
+          query={null}
+          variables={{}}
+          render={({ error, props }) => {
+            if (error) {
+              logger.error(error)
+              const errMsg = 'We had a problem loading this page :('
+
+              // Error will not autohide.
+              return <ErrorMessage message={errMsg} open />
+            }
+            const showError = this.props.showError
+            return (
+              <SettingsChildWrapper>
+                <SearchProfileInviteFriend showError={showError} />
+              </SettingsChildWrapper>
+            )
+          }}
+        />
+      </div>
+    )
+  }
+}
+
+ProfileInviteFriendView.propTypes = {
+  showError: PropTypes.func.isRequired,
+}
+
+ProfileInviteFriendView.defaultProps = {}
+
+export default ProfileInviteFriendView

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -35,7 +35,7 @@ const styles = theme => ({
   },
 })
 
-const TabSettingsPage = props => {
+const SearchSettingsPage = props => {
   const { authUser, classes } = props
   return (
     <SettingsPage
@@ -151,11 +151,11 @@ const TabSettingsPage = props => {
   )
 }
 
-TabSettingsPage.propTypes = {
+SearchSettingsPage.propTypes = {
   authUser: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }).isRequired,
   classes: PropTypes.object.isRequired,
 }
 
-export default withStyles(styles)(withUser()(TabSettingsPage))
+export default withStyles(styles)(withUser()(SearchSettingsPage))

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -1,0 +1,161 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Redirect, Route, Switch } from 'react-router-dom'
+import { withStyles } from '@material-ui/core/styles'
+import Divider from '@material-ui/core/Divider'
+import List from '@material-ui/core/List'
+import ListSubheader from '@material-ui/core/ListSubheader'
+
+import AccountView from 'js/components/Settings/Account/AccountView'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import SettingsPage from 'js/components/Settings/SettingsPageComponent'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import withUser from 'js/components/General/withUser'
+import {
+  goTo,
+  accountURL,
+  backgroundSettingsURL,
+  dashboardURL,
+  donateURL,
+  inviteFriendsURL,
+  statsURL,
+  widgetSettingsURL,
+} from 'js/navigation/navigation'
+
+const styles = theme => ({
+  list: {
+    marginLeft: 10,
+  },
+  listSubheader: {
+    paddingLeft: 14,
+  },
+})
+
+const TabSettingsPage = props => {
+  const { authUser, classes } = props
+  return (
+    <SettingsPage
+      onClose={() => {
+        goTo(dashboardURL)
+      }}
+      sidebarContent={({ showError }) => (
+        <List className={classes.listSubheader}>
+          <ListSubheader disableSticky className={classes.listSubheader}>
+            Settings
+          </ListSubheader>
+          <SettingsMenuItem key={'widgets'} to={widgetSettingsURL}>
+            Widgets
+          </SettingsMenuItem>
+          <SettingsMenuItem key={'background'} to={backgroundSettingsURL}>
+            Background
+          </SettingsMenuItem>
+          <Divider />
+          <ListSubheader disableSticky className={classes.listSubheader}>
+            Your Profile
+          </ListSubheader>
+          <SettingsMenuItem key={'stats'} to={statsURL}>
+            Your Stats
+          </SettingsMenuItem>
+          <SettingsMenuItem key={'donate'} to={donateURL}>
+            Donate Hearts
+          </SettingsMenuItem>
+          <SettingsMenuItem key={'invite'} to={inviteFriendsURL}>
+            Invite Friends
+          </SettingsMenuItem>
+          <Divider />
+          <SettingsMenuItem key={'account'} to={accountURL}>
+            Account
+          </SettingsMenuItem>
+        </List>
+      )}
+      mainContent={({ showError }) => (
+        <Switch>
+          <Route
+            exact
+            path="/newtab/settings/widgets/"
+            render={props => (
+              <WidgetsSettingsView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+
+          <Route
+            exact
+            path="/newtab/settings/background/"
+            render={props => (
+              <BackgroundSettingsView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/profile/stats/"
+            render={props => (
+              <ProfileStatsView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/profile/donate/"
+            render={props => (
+              <ProfileDonateHearts
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/profile/invite/"
+            render={props => (
+              <ProfileInviteFriend
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          <Route
+            exact
+            path="/newtab/account/"
+            render={props => (
+              <AccountView
+                {...props}
+                authUser={authUser}
+                showError={showError}
+              />
+            )}
+          />
+          {/* Redirect any incorrect paths */}
+          <Redirect from="/newtab/settings/*" to="/newtab/settings/widgets/" />
+          <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
+          <Redirect from="/newtab/account/*" to="/newtab/account/" />
+        </Switch>
+      )}
+    />
+  )
+}
+
+TabSettingsPage.propTypes = {
+  authUser: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  classes: PropTypes.object.isRequired,
+}
+
+export default withStyles(styles)(withUser()(TabSettingsPage))

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -8,7 +8,7 @@ import ListSubheader from '@material-ui/core/ListSubheader'
 
 import AccountView from 'js/components/Settings/Account/AccountView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
-import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SearchProfileInviteFriend from 'js/components/Search/Settings/SearchProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import withUser from 'js/components/General/withUser'
@@ -71,7 +71,7 @@ const SearchSettingsPage = props => {
             exact
             path="/search/profile/invite/"
             render={props => (
-              <ProfileInviteFriend
+              <SearchProfileInviteFriend
                 {...props}
                 authUser={authUser}
                 showError={showError}

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -4,6 +4,7 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 import { withStyles } from '@material-ui/core/styles'
 import Divider from '@material-ui/core/Divider'
 import List from '@material-ui/core/List'
+import ListSubheader from '@material-ui/core/ListSubheader'
 
 import AccountView from 'js/components/Settings/Account/AccountView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
@@ -21,7 +22,7 @@ import {
 
 const styles = theme => ({
   list: {
-    marginLeft: 10,
+    marginLeft: 14,
   },
   listSubheader: {
     paddingLeft: 14,
@@ -36,7 +37,10 @@ const SearchSettingsPage = props => {
         goTo(searchBaseURL)
       }}
       sidebarContent={({ showError }) => (
-        <List className={classes.listSubheader}>
+        <List className={classes.list}>
+          <ListSubheader disableSticky className={classes.listSubheader}>
+            Your Profile
+          </ListSubheader>
           <SettingsMenuItem key={'donate'} to={searchDonateHeartsURL}>
             Donate Hearts
           </SettingsMenuItem>

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -106,5 +106,5 @@ SearchSettingsPage.propTypes = {
 }
 
 export default withStyles(styles)(
-  withUser({ app: SEARCH_APP })(SearchSettingsPage)
+  withUser({ app: SEARCH_APP, createUserIfPossible: false })(SearchSettingsPage)
 )

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -12,6 +12,7 @@ import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFri
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import withUser from 'js/components/General/withUser'
+import { SEARCH_APP } from 'js/constants'
 import {
   goTo,
   searchAccountURL,
@@ -104,4 +105,6 @@ SearchSettingsPage.propTypes = {
   classes: PropTypes.object.isRequired,
 }
 
-export default withStyles(styles)(withUser()(SearchSettingsPage))
+export default withStyles(styles)(
+  withUser({ app: SEARCH_APP })(SearchSettingsPage)
+)

--- a/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
+++ b/web/src/js/components/Search/Settings/SearchSettingsPageComponent.js
@@ -4,26 +4,19 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 import { withStyles } from '@material-ui/core/styles'
 import Divider from '@material-ui/core/Divider'
 import List from '@material-ui/core/List'
-import ListSubheader from '@material-ui/core/ListSubheader'
 
 import AccountView from 'js/components/Settings/Account/AccountView'
-import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
-import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 import withUser from 'js/components/General/withUser'
 import {
   goTo,
-  accountURL,
-  backgroundSettingsURL,
-  dashboardURL,
-  donateURL,
-  inviteFriendsURL,
-  statsURL,
-  widgetSettingsURL,
+  searchAccountURL,
+  searchBaseURL,
+  searchDonateHeartsURL,
+  searchInviteFriendsURL,
 } from 'js/navigation/navigation'
 
 const styles = theme => ({
@@ -40,34 +33,18 @@ const SearchSettingsPage = props => {
   return (
     <SettingsPage
       onClose={() => {
-        goTo(dashboardURL)
+        goTo(searchBaseURL)
       }}
       sidebarContent={({ showError }) => (
         <List className={classes.listSubheader}>
-          <ListSubheader disableSticky className={classes.listSubheader}>
-            Settings
-          </ListSubheader>
-          <SettingsMenuItem key={'widgets'} to={widgetSettingsURL}>
-            Widgets
-          </SettingsMenuItem>
-          <SettingsMenuItem key={'background'} to={backgroundSettingsURL}>
-            Background
-          </SettingsMenuItem>
-          <Divider />
-          <ListSubheader disableSticky className={classes.listSubheader}>
-            Your Profile
-          </ListSubheader>
-          <SettingsMenuItem key={'stats'} to={statsURL}>
-            Your Stats
-          </SettingsMenuItem>
-          <SettingsMenuItem key={'donate'} to={donateURL}>
+          <SettingsMenuItem key={'donate'} to={searchDonateHeartsURL}>
             Donate Hearts
           </SettingsMenuItem>
-          <SettingsMenuItem key={'invite'} to={inviteFriendsURL}>
+          <SettingsMenuItem key={'invite'} to={searchInviteFriendsURL}>
             Invite Friends
           </SettingsMenuItem>
           <Divider />
-          <SettingsMenuItem key={'account'} to={accountURL}>
+          <SettingsMenuItem key={'account'} to={searchAccountURL}>
             Account
           </SettingsMenuItem>
         </List>
@@ -76,41 +53,7 @@ const SearchSettingsPage = props => {
         <Switch>
           <Route
             exact
-            path="/newtab/settings/widgets/"
-            render={props => (
-              <WidgetsSettingsView
-                {...props}
-                authUser={authUser}
-                showError={showError}
-              />
-            )}
-          />
-
-          <Route
-            exact
-            path="/newtab/settings/background/"
-            render={props => (
-              <BackgroundSettingsView
-                {...props}
-                authUser={authUser}
-                showError={showError}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/newtab/profile/stats/"
-            render={props => (
-              <ProfileStatsView
-                {...props}
-                authUser={authUser}
-                showError={showError}
-              />
-            )}
-          />
-          <Route
-            exact
-            path="/newtab/profile/donate/"
+            path="/search/profile/donate/"
             render={props => (
               <ProfileDonateHearts
                 {...props}
@@ -121,7 +64,7 @@ const SearchSettingsPage = props => {
           />
           <Route
             exact
-            path="/newtab/profile/invite/"
+            path="/search/profile/invite/"
             render={props => (
               <ProfileInviteFriend
                 {...props}
@@ -132,7 +75,7 @@ const SearchSettingsPage = props => {
           />
           <Route
             exact
-            path="/newtab/account/"
+            path="/search/account/"
             render={props => (
               <AccountView
                 {...props}
@@ -142,9 +85,8 @@ const SearchSettingsPage = props => {
             )}
           />
           {/* Redirect any incorrect paths */}
-          <Redirect from="/newtab/settings/*" to="/newtab/settings/widgets/" />
-          <Redirect from="/newtab/profile/*" to="/newtab/profile/stats/" />
-          <Redirect from="/newtab/account/*" to="/newtab/account/" />
+          <Redirect from="/search/profile/*" to="/search/profile/donate/" />
+          <Redirect from="/search/account/*" to="/search/account/" />
         </Switch>
       )}
     />

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
@@ -1,0 +1,106 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
+import Stat from 'js/components/Settings/Profile/StatComponent'
+import Paper from '@material-ui/core/Paper'
+import Typography from '@material-ui/core/Typography'
+import HappyIcon from '@material-ui/icons/Mood'
+
+jest.mock('js/mutations/LogReferralLinkClickMutation')
+jest.mock('js/utils/logger')
+
+const getMockProps = () => ({
+  app: {
+    referralVcReward: 300,
+  },
+  user: {
+    numUsersRecruited: 2,
+  },
+})
+
+describe('SearchProfileInviteFriendComponent', () => {
+  it('renders without error', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+  })
+
+  it('renders the InviteFriend component and passes it the "user" prop', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    const inviteFriendElem = wrapper.find(InviteFriend)
+    expect(inviteFriendElem.exists()).toBe(true)
+    expect(inviteFriendElem.prop('user')).toEqual({
+      numUsersRecruited: 2,
+    })
+  })
+
+  it('renders the "friends recruited" statistic', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    const elem = wrapper.find(Stat).first()
+    expect(elem.prop('stat')).toEqual(2)
+    expect(elem.prop('statText')).toEqual('friends recruited')
+  })
+
+  it('renders the "friends recruited" statistic with a singular "friend" when numUsersRecruited == 1', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user.numUsersRecruited = 1
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    const elem = wrapper.find(Stat).first()
+    expect(elem.prop('stat')).toEqual(1)
+    expect(elem.prop('statText')).toEqual('friend recruited')
+  })
+
+  it('renders the "VC reward" statistic', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    const elem = wrapper.find(Stat).at(1)
+    expect(elem.prop('stat')).toEqual(300)
+    expect(elem.prop('statText')).toEqual(
+      'extra Hearts when you recruit a new friend'
+    )
+  })
+
+  it('shows a "thank you" message at the bottom', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find(Paper)
+        .last()
+        .find(Typography)
+        .render()
+        .text()
+    ).toEqual(
+      'Thank you! Every new person raises more money for charity, and we depend on people like you to get the word out.'
+    )
+  })
+
+  it('includes a smiley face icon in the "thank you" message at the bottom', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find(Paper)
+        .last()
+        .find(HappyIcon)
+        .exists()
+    ).toBe(true)
+  })
+})

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
@@ -3,7 +3,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import InviteFriend from 'js/components/Settings/Profile/InviteFriendContainer'
-import Stat from 'js/components/Settings/Profile/StatComponent'
 import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
 import HappyIcon from '@material-ui/icons/Mood'
@@ -11,16 +10,8 @@ import HappyIcon from '@material-ui/icons/Mood'
 jest.mock('js/mutations/LogReferralLinkClickMutation')
 jest.mock('js/utils/logger')
 
-const getMockProps = () => ({
-  app: {
-    referralVcReward: 300,
-  },
-  user: {
-    numUsersRecruited: 2,
-  },
-})
+const getMockProps = () => ({})
 
-//
 describe('SearchProfileInviteFriendComponent', () => {
   it('renders without error', () => {
     const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
@@ -37,6 +28,15 @@ describe('SearchProfileInviteFriendComponent', () => {
     const inviteFriendElem = wrapper.find(InviteFriend)
     expect(inviteFriendElem.exists()).toBe(true)
     expect(inviteFriendElem.prop('user')).toBeNull()
+  })
+
+  it('sets the "baseURL" in the InviteFriend component to search.gladly.io', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    const inviteFriendElem = wrapper.find(InviteFriend)
+    expect(inviteFriendElem.prop('baseURL')).toEqual('https://search.gladly.io')
   })
 
   it('shows a "thank you" message title', () => {

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
@@ -39,7 +39,7 @@ describe('SearchProfileInviteFriendComponent', () => {
     expect(inviteFriendElem.prop('user')).toBeNull()
   })
 
-  it('shows a "thank you" message', () => {
+  it('shows a "thank you" message title', () => {
     const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
@@ -49,14 +49,13 @@ describe('SearchProfileInviteFriendComponent', () => {
         .find(Paper)
         .last()
         .find(Typography)
+        .first()
         .render()
         .text()
-    ).toEqual(
-      'Thank you! Every new person raises more money for charity, and we depend on people like you to get the word out.'
-    )
+    ).toEqual('Thank you!')
   })
 
-  it('includes a smiley face icon in the "thank you" message at the bottom', () => {
+  it('includes a smiley face icon in the "thank you" message title', () => {
     const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
@@ -68,5 +67,23 @@ describe('SearchProfileInviteFriendComponent', () => {
         .find(HappyIcon)
         .exists()
     ).toBe(true)
+  })
+
+  it('shows a "thank you" message', () => {
+    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find(Paper)
+        .last()
+        .find(Typography)
+        .last()
+        .render()
+        .text()
+    ).toEqual(
+      "You're one of the first people to use Search for a Cause, and we depend on people like you to get the word out."
+    )
   })
 })

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendComponent.test.js
@@ -20,6 +20,7 @@ const getMockProps = () => ({
   },
 })
 
+//
 describe('SearchProfileInviteFriendComponent', () => {
   it('renders without error', () => {
     const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
@@ -28,52 +29,17 @@ describe('SearchProfileInviteFriendComponent', () => {
     shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
   })
 
-  it('renders the InviteFriend component and passes it the "user" prop', () => {
+  it('renders the InviteFriend component and passes it a null "user" prop value', () => {
     const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()
     const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
     const inviteFriendElem = wrapper.find(InviteFriend)
     expect(inviteFriendElem.exists()).toBe(true)
-    expect(inviteFriendElem.prop('user')).toEqual({
-      numUsersRecruited: 2,
-    })
+    expect(inviteFriendElem.prop('user')).toBeNull()
   })
 
-  it('renders the "friends recruited" statistic', () => {
-    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
-      .default
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
-    const elem = wrapper.find(Stat).first()
-    expect(elem.prop('stat')).toEqual(2)
-    expect(elem.prop('statText')).toEqual('friends recruited')
-  })
-
-  it('renders the "friends recruited" statistic with a singular "friend" when numUsersRecruited == 1', () => {
-    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.user.numUsersRecruited = 1
-    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
-    const elem = wrapper.find(Stat).first()
-    expect(elem.prop('stat')).toEqual(1)
-    expect(elem.prop('statText')).toEqual('friend recruited')
-  })
-
-  it('renders the "VC reward" statistic', () => {
-    const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
-      .default
-    const mockProps = getMockProps()
-    const wrapper = shallow(<SearchProfileInviteFriend {...mockProps} />).dive()
-    const elem = wrapper.find(Stat).at(1)
-    expect(elem.prop('stat')).toEqual(300)
-    expect(elem.prop('statText')).toEqual(
-      'extra Hearts when you recruit a new friend'
-    )
-  })
-
-  it('shows a "thank you" message at the bottom', () => {
+  it('shows a "thank you" message', () => {
     const SearchProfileInviteFriend = require('js/components/Search/Settings/SearchProfileInviteFriendComponent')
       .default
     const mockProps = getMockProps()

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendView.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendView.test.js
@@ -1,0 +1,142 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { mount, shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import ProfileInviteFriendView from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendContainer'
+import ErrorMessage from 'js/components/General/ErrorMessage'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/components/General/ErrorMessage')
+jest.mock('js/components/General/withUser')
+jest.mock('js/utils/logger')
+jest.mock('js/components/Settings/Profile/ProfileInviteFriendContainer')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({
+  authUser: {
+    id: 'example-user-id',
+    email: 'foo@example.com',
+    username: 'example',
+    isAnonymous: false,
+    emailVerified: true,
+  },
+  showError: jest.fn(),
+})
+
+describe('ProfileInviteFriendView', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<ProfileInviteFriendView {...mockProps} />)
+  })
+
+  it('sets a root style of 100% width and height', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.at(0).prop('style')).toEqual({
+      width: '100%',
+      height: '100%',
+    })
+  })
+
+  it('includes a QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+  })
+
+  it('passes the expected variables to the QueryRenderer', () => {
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'example-user-id', // from the authUser prop
+    })
+  })
+
+  it('does not render the child component before data has returned', () => {
+    // No QueryRenderer response set.
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(ProfileInviteFriend).exists()).toBe(false)
+  })
+
+  it('does not render the child component when there is no data', () => {
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(ProfileInviteFriend).exists()).toBe(false)
+  })
+
+  it('passes the expected props to the child component', () => {
+    const fakeQueryRendererProps = {
+      app: {
+        some: 'value',
+      },
+      user: {
+        id: 'abc123xyz456',
+        vc: 233,
+      },
+    }
+    QueryRenderer.__setQueryResponse({
+      error: null,
+      props: fakeQueryRendererProps,
+      retry: jest.fn(),
+    })
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(ProfileInviteFriend).props()).toEqual({
+      app: fakeQueryRendererProps.app,
+      user: fakeQueryRendererProps.user,
+      showError: mockProps.showError,
+    })
+  })
+
+  it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
+    QueryRenderer.__setQueryResponse({
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'Something went horribly wrong.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: 'HORRIBLY_WRONG_ERROR',
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: jest.fn(),
+    })
+
+    const mockProps = getMockProps()
+    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+
+    // An error should render instead of the view.
+    expect(wrapper.find(ProfileInviteFriend).length).toBe(0)
+    expect(wrapper.find(ErrorMessage).exists()).toBe(true)
+    expect(wrapper.find(ErrorMessage).prop('message')).toBe(
+      'We had a problem loading this page :('
+    )
+    expect(logger.error).toHaveBeenCalled()
+  })
+})

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendView.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendView.test.js
@@ -3,8 +3,8 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 import { QueryRenderer } from 'react-relay'
-import ProfileInviteFriendView from 'js/components/Settings/Profile/ProfileInviteFriendView'
-import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendContainer'
+import SearchProfileInviteFriendView from 'js/components/Search/Settings/SearchProfileInviteFriendView'
+import SearchProfileInviteFriend from 'js/components/Search/Settings/SearchProfileInviteFriendComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
@@ -19,25 +19,18 @@ afterEach(() => {
 })
 
 const getMockProps = () => ({
-  authUser: {
-    id: 'example-user-id',
-    email: 'foo@example.com',
-    username: 'example',
-    isAnonymous: false,
-    emailVerified: true,
-  },
   showError: jest.fn(),
 })
 
-describe('ProfileInviteFriendView', () => {
+describe('SearchProfileInviteFriendView', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()
-    shallow(<ProfileInviteFriendView {...mockProps} />)
+    shallow(<SearchProfileInviteFriendView {...mockProps} />)
   })
 
   it('sets a root style of 100% width and height', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
+    const wrapper = shallow(<SearchProfileInviteFriendView {...mockProps} />)
     expect(wrapper.at(0).prop('style')).toEqual({
       width: '100%',
       height: '100%',
@@ -46,56 +39,43 @@ describe('ProfileInviteFriendView', () => {
 
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
+    const wrapper = shallow(<SearchProfileInviteFriendView {...mockProps} />)
     expect(wrapper.find(QueryRenderer).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
-    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
-      userId: 'example-user-id', // from the authUser prop
-    })
+    const wrapper = mount(<SearchProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({})
   })
 
-  it('does not render the child component before data has returned', () => {
+  it('renders the child component without any data', () => {
     // No QueryRenderer response set.
     const mockProps = getMockProps()
-    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(ProfileInviteFriend).exists()).toBe(false)
+    const wrapper = mount(<SearchProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(SearchProfileInviteFriend).exists()).toBe(true)
   })
 
-  it('does not render the child component when there is no data', () => {
+  it('renders the child component when there is no data', () => {
     QueryRenderer.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
     })
     const mockProps = getMockProps()
-    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(ProfileInviteFriend).exists()).toBe(false)
+    const wrapper = mount(<SearchProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(SearchProfileInviteFriend).exists()).toBe(true)
   })
 
   it('passes the expected props to the child component', () => {
-    const fakeQueryRendererProps = {
-      app: {
-        some: 'value',
-      },
-      user: {
-        id: 'abc123xyz456',
-        vc: 233,
-      },
-    }
     QueryRenderer.__setQueryResponse({
       error: null,
-      props: fakeQueryRendererProps,
+      props: {},
       retry: jest.fn(),
     })
     const mockProps = getMockProps()
-    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(ProfileInviteFriend).props()).toEqual({
-      app: fakeQueryRendererProps.app,
-      user: fakeQueryRendererProps.user,
+    const wrapper = mount(<SearchProfileInviteFriendView {...mockProps} />)
+    expect(wrapper.find(SearchProfileInviteFriend).props()).toEqual({
       showError: mockProps.showError,
     })
   })
@@ -129,10 +109,10 @@ describe('ProfileInviteFriendView', () => {
     })
 
     const mockProps = getMockProps()
-    const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
+    const wrapper = mount(<SearchProfileInviteFriendView {...mockProps} />)
 
     // An error should render instead of the view.
-    expect(wrapper.find(ProfileInviteFriend).length).toBe(0)
+    expect(wrapper.find(SearchProfileInviteFriend).length).toBe(0)
     expect(wrapper.find(ErrorMessage).exists()).toBe(true)
     expect(wrapper.find(ErrorMessage).prop('message')).toBe(
       'We had a problem loading this page :('

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -12,7 +12,7 @@ import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFri
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
-import { goTo, dashboardURL } from 'js/navigation/navigation'
+import { goTo, searchBaseURL } from 'js/navigation/navigation'
 
 jest.mock('react-router-dom')
 jest.mock('js/components/Settings/Account/AccountView')
@@ -65,14 +65,14 @@ describe('SearchSettingsPage', () => {
       .dive()
   })
 
-  it('goes to the Tab dashboard when the SettingsPage "onClose" callback is called', () => {
+  it('goes to the main search results page when the SettingsPage "onClose" callback is called', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
     expect(goTo).not.toHaveBeenCalled()
     wrapper.find(SettingsPage).prop('onClose')()
-    expect(goTo).toHaveBeenCalledWith(dashboardURL)
+    expect(goTo).toHaveBeenCalledWith(searchBaseURL)
   })
 })
 
@@ -83,14 +83,7 @@ describe('SearchSettingsPage: sidebar content', () => {
       .dive()
       .dive()
     const menuItems = wrapper.find(SettingsMenuItem)
-    const expectedMenuItems = [
-      'Widgets',
-      'Background',
-      'Your Stats',
-      'Donate Hearts',
-      'Invite Friends',
-      'Account',
-    ]
+    const expectedMenuItems = ['Donate Hearts', 'Invite Friends', 'Account']
     menuItems.forEach((menuItem, index) => {
       expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
     })
@@ -100,138 +93,6 @@ describe('SearchSettingsPage: sidebar content', () => {
 describe('SearchSettingsPage: main content', () => {
   const getMainContentRenderPropArgs = () => ({
     showError: jest.fn(),
-  })
-
-  it('includes a WidgetsSettingsView route', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected WidgetsSettingsView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(WidgetsSettingsView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      mainContentRenderPropArgs.showError
-    )
-  })
-
-  it('includes a BackgroundSettingsView route', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected BackgroundSettingsView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(BackgroundSettingsView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      mainContentRenderPropArgs.showError
-    )
-  })
-
-  it('includes a ProfileStatsView route', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
-    expect(routeElem.exists()).toBe(true)
-  })
-
-  it('renders the expected ProfileStatsView component with the expected props', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const routeElem = wrapper
-      .find(Switch)
-      .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
-    const ThisRouteComponent = routeElem.prop('render')
-    const ThisRouteComponentElem = shallow(
-      <ThisRouteComponent fakeProp={'abc'} />
-    )
-    expect(ThisRouteComponentElem.type()).toEqual(ProfileStatsView)
-    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
-    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
-      // From the default withUser mock
-      id: 'abc123xyz456',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-    expect(ThisRouteComponentElem.prop('showError')).toEqual(
-      mainContentRenderPropArgs.showError
-    )
   })
 
   it('includes a ProfileDonateHearts route', () => {
@@ -244,7 +105,7 @@ describe('SearchSettingsPage: main content', () => {
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+      .filterWhere(elem => elem.prop('path') === '/search/profile/donate/')
     expect(routeElem.exists()).toBe(true)
   })
 
@@ -258,7 +119,7 @@ describe('SearchSettingsPage: main content', () => {
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+      .filterWhere(elem => elem.prop('path') === '/search/profile/donate/')
     const ThisRouteComponent = routeElem.prop('render')
     const ThisRouteComponentElem = shallow(
       <ThisRouteComponent fakeProp={'abc'} />
@@ -288,7 +149,7 @@ describe('SearchSettingsPage: main content', () => {
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+      .filterWhere(elem => elem.prop('path') === '/search/profile/invite/')
     expect(routeElem.exists()).toBe(true)
   })
 
@@ -302,7 +163,7 @@ describe('SearchSettingsPage: main content', () => {
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+      .filterWhere(elem => elem.prop('path') === '/search/profile/invite/')
     const ThisRouteComponent = routeElem.prop('render')
     const ThisRouteComponentElem = shallow(
       <ThisRouteComponent fakeProp={'abc'} />
@@ -332,7 +193,7 @@ describe('SearchSettingsPage: main content', () => {
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+      .filterWhere(elem => elem.prop('path') === '/search/account/')
     expect(routeElem.exists()).toBe(true)
   })
 
@@ -346,7 +207,7 @@ describe('SearchSettingsPage: main content', () => {
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
-      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+      .filterWhere(elem => elem.prop('path') === '/search/account/')
     const ThisRouteComponent = routeElem.prop('render')
     const ThisRouteComponentElem = shallow(
       <ThisRouteComponent fakeProp={'abc'} />
@@ -366,7 +227,7 @@ describe('SearchSettingsPage: main content', () => {
     )
   })
 
-  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+  it('redirects from any nonexistent profile page to the "donate Hearts" page', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
     const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
@@ -376,36 +237,8 @@ describe('SearchSettingsPage: main content', () => {
     const redirectElem = wrapper
       .find(Switch)
       .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
-  })
-
-  it('redirects from any nonexistent settings page to the widgets settings page', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
-  })
-
-  it('redirects from any nonexistent profile page to the profile stats page', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/profile/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/profile/stats/')
+      .filterWhere(elem => elem.prop('from') === '/search/profile/*')
+    expect(redirectElem.prop('to')).toEqual('/search/profile/donate/')
   })
 
   it('redirects from any nonexistent account page to the main account page', () => {
@@ -418,7 +251,7 @@ describe('SearchSettingsPage: main content', () => {
     const redirectElem = wrapper
       .find(Switch)
       .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/account/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/account/')
+      .filterWhere(elem => elem.prop('from') === '/search/account/*')
+    expect(redirectElem.prop('to')).toEqual('/search/account/')
   })
 })

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -39,7 +39,7 @@ describe('withUser HOC in SearchSettingsPage', () => {
 
     /* eslint-disable-next-line no-unused-expressions */
     require('js/components/Search/Settings/SearchSettingsPageComponent').default
-    expect(withUser).toHaveBeenCalledWith()
+    expect(withUser).toHaveBeenCalledWith({ app: 'search' })
   })
 
   it('wraps the SearchSettingsPage component', () => {

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -5,13 +5,10 @@ import { shallow } from 'enzyme'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import SearchSettingsPage from 'js/components/Search/Settings/SearchSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
-import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
-import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
-import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 import { goTo, searchBaseURL } from 'js/navigation/navigation'
 
 jest.mock('react-router-dom')

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -1,0 +1,424 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Redirect, Route, Switch } from 'react-router-dom'
+import TabSettingsPage from 'js/components/Settings/TabSettingsPageComponent'
+import AccountView from 'js/components/Settings/Account/AccountView'
+import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
+import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
+import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
+import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
+import SettingsPage from 'js/components/Settings/SettingsPageComponent'
+import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
+import { goTo, dashboardURL } from 'js/navigation/navigation'
+
+jest.mock('react-router-dom')
+jest.mock('js/components/Settings/Account/AccountView')
+jest.mock('js/components/Settings/Background/BackgroundSettingsView')
+jest.mock('js/components/Logo/Logo')
+jest.mock('js/components/Settings/Profile/ProfileStatsView')
+jest.mock('js/components/Settings/Profile/ProfileDonateHeartsView')
+jest.mock('js/components/Settings/Profile/ProfileInviteFriendView')
+jest.mock('js/components/Settings/SettingsMenuItem')
+jest.mock('js/components/Settings/Widgets/WidgetsSettingsView')
+jest.mock('js/components/General/withUser')
+jest.mock('js/navigation/navigation')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const getMockProps = () => ({})
+
+describe('withUser HOC in TabSettingsPage', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('is called with the expected options', () => {
+    const withUser = require('js/components/General/withUser').default
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/TabSettingsPageComponent').default
+    expect(withUser).toHaveBeenCalledWith()
+  })
+
+  it('wraps the TabSettingsPage component', () => {
+    const {
+      __mockWithUserWrappedFunction,
+    } = require('js/components/General/withUser')
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Settings/TabSettingsPageComponent').default
+    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
+    expect(wrappedComponent.name).toEqual('TabSettingsPage')
+  })
+})
+
+describe('TabSettingsPage', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+  })
+
+  it('goes to the Tab dashboard when the SettingsPage "onClose" callback is called', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    expect(goTo).not.toHaveBeenCalled()
+    wrapper.find(SettingsPage).prop('onClose')()
+    expect(goTo).toHaveBeenCalledWith(dashboardURL)
+  })
+})
+
+describe('TabSettingsPage: sidebar content', () => {
+  it('renders the expected side menu items', () => {
+    const mockProps = getMockProps()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+    const menuItems = wrapper.find(SettingsMenuItem)
+    const expectedMenuItems = [
+      'Widgets',
+      'Background',
+      'Your Stats',
+      'Donate Hearts',
+      'Invite Friends',
+      'Account',
+    ]
+    menuItems.forEach((menuItem, index) => {
+      expect(menuItem.prop('children')).toEqual(expectedMenuItems[index])
+    })
+  })
+})
+
+describe('TabSettingsPage: main content', () => {
+  const getMainContentRenderPropArgs = () => ({
+    showError: jest.fn(),
+  })
+
+  it('includes a WidgetsSettingsView route', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected WidgetsSettingsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/widgets/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(WidgetsSettingsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      mainContentRenderPropArgs.showError
+    )
+  })
+
+  it('includes a BackgroundSettingsView route', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected BackgroundSettingsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/settings/background/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(BackgroundSettingsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      mainContentRenderPropArgs.showError
+    )
+  })
+
+  it('includes a ProfileStatsView route', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileStatsView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/stats/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileStatsView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      mainContentRenderPropArgs.showError
+    )
+  })
+
+  it('includes a ProfileDonateHearts route', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileDonateHearts component with the expected props', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/donate/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileDonateHearts)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      mainContentRenderPropArgs.showError
+    )
+  })
+
+  it('includes a ProfileInviteFriend route', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected ProfileInviteFriend component with the expected props', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/profile/invite/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(ProfileInviteFriend)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      mainContentRenderPropArgs.showError
+    )
+  })
+
+  it('includes a AccountView route', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+    expect(routeElem.exists()).toBe(true)
+  })
+
+  it('renders the expected AccountView component with the expected props', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const routeElem = wrapper
+      .find(Switch)
+      .find(Route)
+      .filterWhere(elem => elem.prop('path') === '/newtab/account/')
+    const ThisRouteComponent = routeElem.prop('render')
+    const ThisRouteComponentElem = shallow(
+      <ThisRouteComponent fakeProp={'abc'} />
+    )
+    expect(ThisRouteComponentElem.type()).toEqual(AccountView)
+    expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
+    expect(ThisRouteComponentElem.prop('authUser')).toEqual({
+      // From the default withUser mock
+      id: 'abc123xyz456',
+      email: 'foo@example.com',
+      username: 'example',
+      isAnonymous: false,
+      emailVerified: true,
+    })
+    expect(ThisRouteComponentElem.prop('showError')).toEqual(
+      mainContentRenderPropArgs.showError
+    )
+  })
+
+  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
+  })
+
+  it('redirects from any nonexistent settings page to the widgets settings page', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
+  })
+
+  it('redirects from any nonexistent profile page to the profile stats page', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/profile/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/profile/stats/')
+  })
+
+  it('redirects from any nonexistent account page to the main account page', () => {
+    const mockProps = getMockProps()
+    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
+    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+      .dive()
+      .dive()
+      .renderProp('mainContent')(mainContentRenderPropArgs)
+    const redirectElem = wrapper
+      .find(Switch)
+      .find(Redirect)
+      .filterWhere(elem => elem.prop('from') === '/newtab/account/*')
+    expect(redirectElem.prop('to')).toEqual('/newtab/account/')
+  })
+})

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Redirect, Route, Switch } from 'react-router-dom'
-import TabSettingsPage from 'js/components/Settings/TabSettingsPageComponent'
+import SearchSettingsPage from 'js/components/Search/Settings/SearchSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
 import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
@@ -32,7 +32,7 @@ afterEach(() => {
 
 const getMockProps = () => ({})
 
-describe('withUser HOC in TabSettingsPage', () => {
+describe('withUser HOC in SearchSettingsPage', () => {
   beforeEach(() => {
     jest.resetModules()
   })
@@ -41,33 +41,33 @@ describe('withUser HOC in TabSettingsPage', () => {
     const withUser = require('js/components/General/withUser').default
 
     /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/TabSettingsPageComponent').default
+    require('js/components/Search/Settings/SearchSettingsPageComponent').default
     expect(withUser).toHaveBeenCalledWith()
   })
 
-  it('wraps the TabSettingsPage component', () => {
+  it('wraps the SearchSettingsPage component', () => {
     const {
       __mockWithUserWrappedFunction,
     } = require('js/components/General/withUser')
 
     /* eslint-disable-next-line no-unused-expressions */
-    require('js/components/Settings/TabSettingsPageComponent').default
+    require('js/components/Search/Settings/SearchSettingsPageComponent').default
     const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
-    expect(wrappedComponent.name).toEqual('TabSettingsPage')
+    expect(wrappedComponent.name).toEqual('SearchSettingsPage')
   })
 })
 
-describe('TabSettingsPage', () => {
+describe('SearchSettingsPage', () => {
   it('renders without error', () => {
     const mockProps = getMockProps()
-    shallow(<TabSettingsPage {...mockProps} />)
+    shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
   })
 
   it('goes to the Tab dashboard when the SettingsPage "onClose" callback is called', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
     expect(goTo).not.toHaveBeenCalled()
@@ -76,10 +76,10 @@ describe('TabSettingsPage', () => {
   })
 })
 
-describe('TabSettingsPage: sidebar content', () => {
+describe('SearchSettingsPage: sidebar content', () => {
   it('renders the expected side menu items', () => {
     const mockProps = getMockProps()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
     const menuItems = wrapper.find(SettingsMenuItem)
@@ -97,7 +97,7 @@ describe('TabSettingsPage: sidebar content', () => {
   })
 })
 
-describe('TabSettingsPage: main content', () => {
+describe('SearchSettingsPage: main content', () => {
   const getMainContentRenderPropArgs = () => ({
     showError: jest.fn(),
   })
@@ -105,7 +105,7 @@ describe('TabSettingsPage: main content', () => {
   it('includes a WidgetsSettingsView route', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -119,7 +119,7 @@ describe('TabSettingsPage: main content', () => {
   it('renders the expected WidgetsSettingsView component with the expected props', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -149,7 +149,7 @@ describe('TabSettingsPage: main content', () => {
   it('includes a BackgroundSettingsView route', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -163,7 +163,7 @@ describe('TabSettingsPage: main content', () => {
   it('renders the expected BackgroundSettingsView component with the expected props', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -193,7 +193,7 @@ describe('TabSettingsPage: main content', () => {
   it('includes a ProfileStatsView route', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -207,7 +207,7 @@ describe('TabSettingsPage: main content', () => {
   it('renders the expected ProfileStatsView component with the expected props', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -237,7 +237,7 @@ describe('TabSettingsPage: main content', () => {
   it('includes a ProfileDonateHearts route', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -251,7 +251,7 @@ describe('TabSettingsPage: main content', () => {
   it('renders the expected ProfileDonateHearts component with the expected props', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -281,7 +281,7 @@ describe('TabSettingsPage: main content', () => {
   it('includes a ProfileInviteFriend route', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -295,7 +295,7 @@ describe('TabSettingsPage: main content', () => {
   it('renders the expected ProfileInviteFriend component with the expected props', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -325,7 +325,7 @@ describe('TabSettingsPage: main content', () => {
   it('includes a AccountView route', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -339,7 +339,7 @@ describe('TabSettingsPage: main content', () => {
   it('renders the expected AccountView component with the expected props', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -369,7 +369,7 @@ describe('TabSettingsPage: main content', () => {
   it('redirects from any nonexistent settings page to the widgets settings page', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -383,7 +383,7 @@ describe('TabSettingsPage: main content', () => {
   it('redirects from any nonexistent settings page to the widgets settings page', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -397,7 +397,7 @@ describe('TabSettingsPage: main content', () => {
   it('redirects from any nonexistent profile page to the profile stats page', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)
@@ -411,7 +411,7 @@ describe('TabSettingsPage: main content', () => {
   it('redirects from any nonexistent account page to the main account page', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
+    const wrapper = shallow(<SearchSettingsPage {...mockProps} />)
       .dive()
       .dive()
       .renderProp('mainContent')(mainContentRenderPropArgs)

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -39,7 +39,10 @@ describe('withUser HOC in SearchSettingsPage', () => {
 
     /* eslint-disable-next-line no-unused-expressions */
     require('js/components/Search/Settings/SearchSettingsPageComponent').default
-    expect(withUser).toHaveBeenCalledWith({ app: 'search' })
+    expect(withUser).toHaveBeenCalledWith({
+      app: 'search',
+      createUserIfPossible: false,
+    })
   })
 
   it('wraps the SearchSettingsPage component', () => {

--- a/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchSettingsPageComponent.test.js
@@ -6,7 +6,7 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 import SearchSettingsPage from 'js/components/Search/Settings/SearchSettingsPageComponent'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsView'
-import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendView'
+import SearchProfileInviteFriend from 'js/components/Search/Settings/SearchProfileInviteFriendView'
 import SettingsMenuItem from 'js/components/Settings/SettingsMenuItem'
 import SettingsPage from 'js/components/Settings/SettingsPageComponent'
 import { goTo, searchBaseURL } from 'js/navigation/navigation'
@@ -168,7 +168,7 @@ describe('SearchSettingsPage: main content', () => {
     const ThisRouteComponentElem = shallow(
       <ThisRouteComponent fakeProp={'abc'} />
     )
-    expect(ThisRouteComponentElem.type()).toEqual(ProfileInviteFriend)
+    expect(ThisRouteComponentElem.type()).toEqual(SearchProfileInviteFriend)
     expect(ThisRouteComponentElem.prop('fakeProp')).toEqual('abc')
     expect(ThisRouteComponentElem.prop('authUser')).toEqual({
       // From the default withUser mock

--- a/web/src/js/components/Search/__tests__/SearchApp.test.js
+++ b/web/src/js/components/Search/__tests__/SearchApp.test.js
@@ -9,6 +9,7 @@ import SearchAuthRedirect from 'js/components/Search/SearchAuthRedirect'
 import SearchPageComponent from 'js/components/Search/SearchPageComponent'
 import SearchPostUninstallView from 'js/components/Search/SearchPostUninstallView'
 import SearchRandomQueryView from 'js/components/Search/SearchRandomQueryView'
+import SearchSettingsPageComponent from 'js/components/Search/Settings/SearchSettingsPageComponent'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 
 jest.mock('js/components/Search/SearchPageComponent')
@@ -126,5 +127,31 @@ describe('SearchApp', () => {
       .filterWhere(n => n.prop('path') === '/search/random/')
     expect(route.exists()).toBe(true)
     expect(route.prop('component')).toBe(SearchRandomQueryView)
+  })
+
+  it('contains the "profile" route', async () => {
+    const SearchApp = require('js/components/Search/SearchApp').default
+    const wrapper = shallow(<SearchApp />)
+    const route = wrapper
+      .find(Route)
+      .filterWhere(n => n.prop('path') === '/search/profile/')
+    expect(route.exists()).toBe(true)
+
+    // FIXME
+    // expect(route.renderProp('component').type()).toBe(
+    //   SearchSettingsPageComponent
+    // )
+  })
+
+  it('contains the "account" route', async () => {
+    const SearchApp = require('js/components/Search/SearchApp').default
+    const wrapper = shallow(<SearchApp />)
+    const route = wrapper
+      .find(Route)
+      .filterWhere(n => n.prop('path') === '/search/account/')
+    expect(route.exists()).toBe(true)
+
+    // FIXME
+    // expect(route.prop('component')).toBe(SearchSettingsPageComponent)
   })
 })

--- a/web/src/js/components/Search/__tests__/SearchApp.test.js
+++ b/web/src/js/components/Search/__tests__/SearchApp.test.js
@@ -9,7 +9,6 @@ import SearchAuthRedirect from 'js/components/Search/SearchAuthRedirect'
 import SearchPageComponent from 'js/components/Search/SearchPageComponent'
 import SearchPostUninstallView from 'js/components/Search/SearchPostUninstallView'
 import SearchRandomQueryView from 'js/components/Search/SearchRandomQueryView'
-import SearchSettingsPageComponent from 'js/components/Search/Settings/SearchSettingsPageComponent'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
 
 jest.mock('js/components/Search/SearchPageComponent')
@@ -137,10 +136,7 @@ describe('SearchApp', () => {
       .filterWhere(n => n.prop('path') === '/search/profile/')
     expect(route.exists()).toBe(true)
 
-    // FIXME
-    // expect(route.renderProp('component').type()).toBe(
-    //   SearchSettingsPageComponent
-    // )
+    // TODO: test the component type when Enzyme fully supports React.lazy
   })
 
   it('contains the "account" route', async () => {
@@ -151,7 +147,6 @@ describe('SearchApp', () => {
       .filterWhere(n => n.prop('path') === '/search/account/')
     expect(route.exists()).toBe(true)
 
-    // FIXME
-    // expect(route.prop('component')).toBe(SearchSettingsPageComponent)
+    // TODO: test the component type when Enzyme fully supports React.lazy
   })
 })

--- a/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
+++ b/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
@@ -24,6 +24,7 @@ describe('withUser HOC in SearchMenuQuery', () => {
     require('js/components/Search/SearchMenuQuery').default
     expect(withUser).toHaveBeenCalledWith({
       app: 'search',
+      createUserIfPossible: false,
       redirectToAuthIfIncomplete: false,
       renderIfNoUser: true,
     })

--- a/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
+++ b/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
@@ -12,6 +12,35 @@ afterEach(() => {
   jest.resetModules()
 })
 
+describe('withUser HOC in SearchMenuQuery', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('is called with the expected options', () => {
+    const withUser = require('js/components/General/withUser').default
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Search/SearchMenuQuery').default
+    expect(withUser).toHaveBeenCalledWith({
+      app: 'search',
+      redirectToAuthIfIncomplete: false,
+      renderIfNoUser: true,
+    })
+  })
+
+  it('wraps the SearchMenuQuery component', () => {
+    const {
+      __mockWithUserWrappedFunction,
+    } = require('js/components/General/withUser')
+
+    /* eslint-disable-next-line no-unused-expressions */
+    require('js/components/Search/SearchMenuQuery').default
+    const wrappedComponent = __mockWithUserWrappedFunction.mock.calls[0][0]
+    expect(wrappedComponent.name).toEqual('SearchMenuQuery')
+  })
+})
+
 describe('SearchMenuQuery', () => {
   it('renders without error', () => {
     const SearchMenuQuery = require('js/components/Search/SearchMenuQuery')

--- a/web/src/js/components/Settings/Account/AccountComponent.js
+++ b/web/src/js/components/Settings/Account/AccountComponent.js
@@ -68,7 +68,7 @@ class Account extends React.Component {
   render() {
     const { user } = this.props
     return (
-      <Paper>
+      <Paper elevation={1}>
         <Typography variant={'h5'} style={{ padding: 20 }}>
           Account
         </Typography>

--- a/web/src/js/components/Settings/Profile/InviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/InviteFriendComponent.js
@@ -22,12 +22,12 @@ const styles = theme => ({
 
 class InviteFriend extends React.Component {
   getReferralUrl() {
-    const { user } = this.props
+    const { baseURL, user } = this.props
     const username = get(user, 'username')
-    const baseURL = 'https://tab.gladly.io'
+    const rootURL = baseURL || 'https://tab.gladly.io'
     const referralUrl = username
-      ? `${baseURL}/?u=${encodeURIComponent(username)}`
-      : baseURL
+      ? `${rootURL}/?u=${encodeURIComponent(username)}`
+      : rootURL
     return referralUrl
   }
 
@@ -85,6 +85,7 @@ class InviteFriend extends React.Component {
 }
 
 InviteFriend.propTypes = {
+  baseURL: PropTypes.string,
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
     username: PropTypes.string,

--- a/web/src/js/components/Settings/Profile/InviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/InviteFriendComponent.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { get } from 'lodash/object'
 import TextField from '@material-ui/core/TextField'
 import { withStyles } from '@material-ui/core/styles'
 import LogReferralLinkClick from 'js/mutations/LogReferralLinkClickMutation'
@@ -21,9 +22,8 @@ const styles = theme => ({
 
 class InviteFriend extends React.Component {
   getReferralUrl() {
-    const {
-      user: { username },
-    } = this.props
+    const { user } = this.props
+    const username = get(user, 'username')
     const baseURL = 'https://tab.gladly.io'
     const referralUrl = username
       ? `${baseURL}/?u=${encodeURIComponent(username)}`
@@ -40,15 +40,17 @@ class InviteFriend extends React.Component {
     // which helps us gauge attempted but unsuccessful
     // referrals.
     const { user } = this.props
-    return LogReferralLinkClick({
-      userId: user.id,
-    }).catch(e => {
-      logger.error(e)
-    })
+    if (user) {
+      return LogReferralLinkClick({
+        userId: user.id,
+      }).catch(e => {
+        logger.error(e)
+      })
+    }
   }
 
   render() {
-    const { classes } = this.props
+    const { classes, user } = this.props
     const referralUrl = this.getReferralUrl()
 
     return (
@@ -61,7 +63,7 @@ class InviteFriend extends React.Component {
         value={referralUrl}
         label={'Share this link'}
         helperText={
-          this.props.user.username
+          get(user, 'username')
             ? `and you'll get 350 Hearts for every person who joins!`
             : `and have a bigger positive impact!`
         }

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -9,12 +9,18 @@ import Typography from '@material-ui/core/Typography'
 const spacingPx = 6
 
 const styles = theme => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
   messageContainer: {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: 14,
+    padding: '14px 18px',
     marginBottom: 2 * spacingPx,
+    marginLeft: 'auto',
+    marginRight: 'auto',
   },
   messageText: {
     color: theme.palette.action.active,
@@ -29,7 +35,7 @@ const styles = theme => ({
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'center',
-    marginBottom: 34,
+    marginBottom: 40,
   },
 })
 
@@ -37,7 +43,7 @@ class ProfileDonateHearts extends React.Component {
   render() {
     const { app, classes, user } = this.props
     return (
-      <div key={'charities-container-key'}>
+      <div className={classes.container}>
         <Paper className={classes.messageContainer}>
           <InfoIcon className={classes.infoIcon} />
           <Typography variant={'body2'} className={classes.messageText}>

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsComponent.js
@@ -44,7 +44,7 @@ class ProfileDonateHearts extends React.Component {
     const { app, classes, user } = this.props
     return (
       <div className={classes.container}>
-        <Paper className={classes.messageContainer}>
+        <Paper elevation={1} className={classes.messageContainer}>
           <InfoIcon className={classes.infoIcon} />
           <Typography variant={'body2'} className={classes.messageText}>
             When you donate Hearts, you're telling us to give more of the money

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendComponent.js
@@ -76,7 +76,7 @@ const ProfileInviteFriend = props => {
         statText={'extra Hearts when you recruit a new friend'}
         style={statStyle}
       />
-      <Paper className={classes.thankYouPaper}>
+      <Paper elevation={1} className={classes.thankYouPaper}>
         <HappyIcon className={classes.happyIcon} />
         <Typography variant={'body2'} className={classes.thankYouText}>
           Thank you! Every new person raises more money for charity, and we

--- a/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsComponent.js
@@ -69,7 +69,7 @@ const ProfileStats = props => {
   const greeting = user.username ? `Hi, ${user.username}!` : 'Hi!'
   return (
     <div>
-      <Paper className={classes.messageContainer}>
+      <Paper elevation={1} className={classes.messageContainer}>
         <ChartIcon className={classes.chartIcon} />
         <Typography variant={'body2'} className={classes.messageText}>
           <span className={classes.greetingText}>{greeting}</span>

--- a/web/src/js/components/Settings/Profile/StatComponent.js
+++ b/web/src/js/components/Settings/Profile/StatComponent.js
@@ -39,6 +39,7 @@ const Stat = props => {
   const { classes, extraContent, stat, statText, style } = props
   return (
     <Paper
+      elevation={1}
       className={classes.root}
       style={{
         ...style,

--- a/web/src/js/components/Settings/Profile/__tests__/InviteFriendComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/InviteFriendComponent.test.js
@@ -10,6 +10,7 @@ jest.mock('js/mutations/LogReferralLinkClickMutation')
 jest.mock('js/utils/logger')
 
 const getMockProps = () => ({
+  baseURL: undefined,
   user: {
     id: 'abc-123',
     username: 'bob',
@@ -33,7 +34,7 @@ describe('Invite friend component', () => {
     shallow(<InviteFriendComponent {...mockProps} />)
   })
 
-  it('contains the correct referral URL', () => {
+  it('contains the correct referral URL, using tab.gladly.io by default', () => {
     const InviteFriendComponent = require('js/components/Settings/Profile/InviteFriendComponent')
       .default
     const mockProps = getMockProps()
@@ -45,6 +46,20 @@ describe('Invite friend component', () => {
         .first()
         .prop('value')
     ).toBe('https://tab.gladly.io/?u=bob')
+  })
+
+  it('contains the correct referral URL when passed a custom "baseURL" prop value', () => {
+    const InviteFriendComponent = require('js/components/Settings/Profile/InviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.baseURL = 'https://foo.example.com'
+    const wrapper = mount(<InviteFriendComponent {...mockProps} />)
+    expect(
+      wrapper
+        .find(TextField)
+        .first()
+        .prop('value')
+    ).toBe('https://foo.example.com/?u=bob')
   })
 
   it('encodes the referral URL correctly when the username contains a space', () => {

--- a/web/src/js/components/Settings/Profile/__tests__/InviteFriendComponent.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/InviteFriendComponent.test.js
@@ -143,6 +143,41 @@ describe('Invite friend component', () => {
     ).toBe(`and have a bigger positive impact!`)
   })
 
+  it('contains the correct referral URL when there is no user', () => {
+    const InviteFriendComponent = require('js/components/Settings/Profile/InviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user = null
+    const wrapper = mount(<InviteFriendComponent {...mockProps} />)
+    const referralUrl = 'https://tab.gladly.io'
+    expect(
+      wrapper
+        .find(TextField)
+        .first()
+        .prop('value')
+    ).toBe(referralUrl)
+  })
+
+  it('contains the correct description text when there is no user', () => {
+    const InviteFriendComponent = require('js/components/Settings/Profile/InviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user = undefined
+    const wrapper = mount(<InviteFriendComponent {...mockProps} />)
+    expect(
+      wrapper
+        .find(TextField)
+        .first()
+        .prop('label')
+    ).toBe(`Share this link`)
+    expect(
+      wrapper
+        .find(TextField)
+        .first()
+        .prop('helperText')
+    ).toBe(`and have a bigger positive impact!`)
+  })
+
   it('logs when the user clicks on their referral link', () => {
     const InviteFriendComponent = require('js/components/Settings/Profile/InviteFriendComponent')
       .default
@@ -156,6 +191,20 @@ describe('Invite friend component', () => {
     expect(LogReferralLinkClick).toHaveBeenCalledWith({
       userId: 'abc-123',
     })
+  })
+
+  it('does not log a referral link click if the user does not exist', () => {
+    const InviteFriendComponent = require('js/components/Settings/Profile/InviteFriendComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.user = null
+    const wrapper = shallow(<InviteFriendComponent {...mockProps} />).dive()
+    const onClickCallback = wrapper
+      .find(TextField)
+      .first()
+      .prop('onClick')
+    onClickCallback()
+    expect(LogReferralLinkClick).not.toHaveBeenCalled()
   })
 
   it('logs an error if LogReferralLinkClick throws', async () => {

--- a/web/src/js/components/Settings/TabSettingsPageComponent.js
+++ b/web/src/js/components/Settings/TabSettingsPageComponent.js
@@ -28,7 +28,7 @@ import {
 
 const styles = theme => ({
   list: {
-    marginLeft: 10,
+    marginLeft: 14,
   },
   listSubheader: {
     paddingLeft: 14,
@@ -43,7 +43,7 @@ const TabSettingsPage = props => {
         goTo(dashboardURL)
       }}
       sidebarContent={({ showError }) => (
-        <List className={classes.listSubheader}>
+        <List className={classes.list}>
           <ListSubheader disableSticky className={classes.listSubheader}>
             Settings
           </ListSubheader>

--- a/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
+++ b/web/src/js/components/Settings/__tests__/TabSettingsPageComponent.test.js
@@ -380,20 +380,6 @@ describe('TabSettingsPage: main content', () => {
     expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
   })
 
-  it('redirects from any nonexistent settings page to the widgets settings page', () => {
-    const mockProps = getMockProps()
-    const mainContentRenderPropArgs = getMainContentRenderPropArgs()
-    const wrapper = shallow(<TabSettingsPage {...mockProps} />)
-      .dive()
-      .dive()
-      .renderProp('mainContent')(mainContentRenderPropArgs)
-    const redirectElem = wrapper
-      .find(Switch)
-      .find(Redirect)
-      .filterWhere(elem => elem.prop('from') === '/newtab/settings/*')
-    expect(redirectElem.prop('to')).toEqual('/newtab/settings/widgets/')
-  })
-
   it('redirects from any nonexistent profile page to the profile stats page', () => {
     const mockProps = getMockProps()
     const mainContentRenderPropArgs = getMainContentRenderPropArgs()

--- a/web/src/js/navigation/__tests__/navigation.test.js
+++ b/web/src/js/navigation/__tests__/navigation.test.js
@@ -86,6 +86,18 @@ describe('goTo', () => {
     })
   })
 
+  it('uses the new parameter value if one is provided that conflicts with an existing URL parameter and options.keepURLParams is true ', () => {
+    getUrlParameters.mockReturnValue({
+      dupe: 'versionToIgnore',
+    })
+    const { goTo } = require('js/navigation/navigation')
+    goTo('/some/path/', { dupe: 'versionToUse' }, { keepURLParams: true })
+    expect(mockBrowserHistory.push).toHaveBeenCalledWith({
+      pathname: '/some/path/',
+      search: '?dupe=versionToUse',
+    })
+  })
+
   it('calls externalRedirect when the new URL is on a different app', () => {
     const { goTo } = require('js/navigation/navigation')
     isURLForDifferentApp.mockReturnValueOnce(true)
@@ -159,6 +171,18 @@ describe('replaceUrl', () => {
     expect(mockBrowserHistory.replace).toHaveBeenCalledWith({
       pathname: '/some/path/',
       search: '?plzIncludeMe=thx&someParam=abc&foo=blah',
+    })
+  })
+
+  it('uses the new parameter value if one is provided that conflicts with an existing URL parameter and options.keepURLParams is true ', () => {
+    getUrlParameters.mockReturnValue({
+      dupe: 'versionToIgnore',
+    })
+    const { replaceUrl } = require('js/navigation/navigation')
+    replaceUrl('/some/path/', { dupe: 'versionToUse' }, { keepURLParams: true })
+    expect(mockBrowserHistory.replace).toHaveBeenCalledWith({
+      pathname: '/some/path/',
+      search: '?dupe=versionToUse',
     })
   })
 

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -139,6 +139,9 @@ export const accountURL = '/newtab/account/'
 // Search
 export const searchBaseURL = '/search'
 export const searchAuthURL = '/search/auth/'
+export const searchDonateHeartsURL = '/search/profile/donate/'
+export const searchInviteFriendsURL = '/search/profile/invite/'
+export const searchAccountURL = '/search/account/'
 
 // Homepage
 


### PR DESCRIPTION
This PR is part three of adding some settings and profile pages to the search app.

* Create three search app pages: `/search/profile/donate/`, `/search/profile/invite/`, and `/search/account/`
* Create a separate "invite friends" page for Search, because referrer rewards aren't yet supported
* Redirect to auth if an unauthenticated user tries to visit a Search settings page
* In the `withUser` higher-order component, use an "app" option argument to redirect to the appropriate auth page with either Search or Tab branding
* Use consistent shadowing for Paper components in the settings pages
* Tweak styling on the "donate Hears" page
