### PR TITLE
Make sure visited search result links have a different color

### DIFF
--- a/web/src/js/components/Search/SearchResultsBing.js
+++ b/web/src/js/components/Search/SearchResultsBing.js
@@ -115,7 +115,7 @@ const SearchResultsBing = props => {
           // Set a min-height during queries to prevent the footer
           // from flickering before the search results return.
           minHeight:
-            isEmptyQuery || (queryReturned && !isQueryInProgress) ? 0 : 1000,
+            isEmptyQuery || (queryReturned && !isQueryInProgress) ? 0 : 4000,
         },
         style
       )}

--- a/web/src/js/components/Search/TextAdSearchResult.js
+++ b/web/src/js/components/Search/TextAdSearchResult.js
@@ -5,6 +5,8 @@ import { find } from 'lodash/collection'
 import { get } from 'lodash/object'
 import LinkWithActionBeforeNavigate from 'js/components/General/LinkWithActionBeforeNavigate'
 
+// TODO: use same colors as WebPageSearchResult
+
 export const SiteLink = props => {
   const {
     classes,

--- a/web/src/js/components/Search/TextAdSearchResult.js
+++ b/web/src/js/components/Search/TextAdSearchResult.js
@@ -4,8 +4,10 @@ import { withStyles } from '@material-ui/core/styles'
 import { find } from 'lodash/collection'
 import { get } from 'lodash/object'
 import LinkWithActionBeforeNavigate from 'js/components/General/LinkWithActionBeforeNavigate'
-
-// TODO: use same colors as WebPageSearchResult
+import {
+  linkColor,
+  linkColorVisited,
+} from 'js/components/Search/searchResultsStyles'
 
 export const SiteLink = props => {
   const {
@@ -71,14 +73,17 @@ const styles = () => ({
   },
   titleLink: {
     textDecoration: 'none',
+    color: linkColor,
     '&:hover': {
       textDecoration: 'underline',
+    },
+    '&:visited': {
+      color: linkColorVisited,
     },
   },
   // Note: we cannot truncate the title.
   title: {
     fontFamily: 'Roboto, arial, sans-serif',
-    color: '#1a0dab',
     margin: 0,
     fontSize: 18,
     fontWeight: 400,

--- a/web/src/js/components/Search/WebPageSearchResult.js
+++ b/web/src/js/components/Search/WebPageSearchResult.js
@@ -2,9 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import { clipTextToNearestWord } from 'js/utils/search-utils'
-
-const linkColor = '#1a0dab'
-const linkColorVisited = '#670199'
+import {
+  linkColor,
+  linkColorVisited,
+} from 'js/components/Search/searchResultsStyles'
 
 const styles = () => ({
   container: {

--- a/web/src/js/components/Search/WebPageSearchResult.js
+++ b/web/src/js/components/Search/WebPageSearchResult.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import { clipTextToNearestWord } from 'js/utils/search-utils'
 
+const linkColor = '#1a0dab'
+const linkColorVisited = '#670199'
+
 const styles = () => ({
   container: {
     fontFamily: 'arial, sans-serif',
@@ -10,13 +13,16 @@ const styles = () => ({
   },
   titleLink: {
     textDecoration: 'none',
+    color: linkColor,
     '&:hover': {
       textDecoration: 'underline',
+    },
+    '&:visited': {
+      color: linkColorVisited,
     },
   },
   title: {
     fontFamily: 'Roboto, arial, sans-serif',
-    color: '#1a0dab',
     margin: 0,
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',

--- a/web/src/js/components/Search/__tests__/SearchResultsBing.test.js
+++ b/web/src/js/components/Search/__tests__/SearchResultsBing.test.js
@@ -147,7 +147,7 @@ describe('SearchResultsBing: tests for non-results display', () => {
     mockProps.isQueryInProgress = true // waiting for a response
     mockProps.queryReturned = false
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(wrapper.get(0).props.style.minHeight).toBe(1000)
+    expect(wrapper.get(0).props.style.minHeight).toBe(4000)
   })
 
   it('removes the a min-height from the results container when the search is successful', () => {
@@ -180,7 +180,7 @@ describe('SearchResultsBing: tests for non-results display', () => {
     mockProps.isQueryInProgress = false
     mockProps.queryReturned = false
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(wrapper.get(0).props.style.minHeight).toBe(1000)
+    expect(wrapper.get(0).props.style.minHeight).toBe(4000)
   })
 
   it('removes the a min-height from the results container when the query is empty', () => {

--- a/web/src/js/components/Search/getMockBingSearchResults.js
+++ b/web/src/js/components/Search/getMockBingSearchResults.js
@@ -21,7 +21,7 @@ export default () =>
           {
             _type: 'Ads/TextAd',
             id: 'https://www.bingapis.com/api/v7/#Ads.0',
-            url: 'https://www.bing.com/fake-ad-click-id-0',
+            url: 'https://www.amazon.com/s?k=cow',
             urlPingSuffix: 'Foo,1234',
             description:
               'Hoof It On Over and Shop High Performance Cow-Puters on Amazon',
@@ -29,7 +29,7 @@ export default () =>
             position: 'Mainline',
             impressionToken: '1',
             title: 'Cow-puters on A-moo-zon.com - Official Site',
-            displayUrl: 'www.example.com/cow',
+            displayUrl: 'www.amazon.com',
             isAdult: false,
             phoneNumber: '',
             extensions: [

--- a/web/src/js/components/Search/searchResultsStyles.js
+++ b/web/src/js/components/Search/searchResultsStyles.js
@@ -1,0 +1,2 @@
+export const linkColor = '#1a0dab'
+export const linkColorVisited = '#670199'


### PR DESCRIPTION
* Make visited links (web results or text ads) a purple-ish color
* Fix a bug where the active links were underlined in red
* Prevent the scroll position from jumping around when returning to the search results page from another website