### PR TITLE
Don't set search state that's derived from the `location` prop

### DIFF
--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -185,12 +185,11 @@ class SearchPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { location } = this.props
-    const currentQuery = parseUrlSearchString(location.search).q
-    const prevQuery = parseUrlSearchString(prevProps.location.search).q
-    if (currentQuery !== prevQuery) {
+    const { location: { search: previousSearchStr = '' } = {} } = prevProps
+    const previousQuery = this.getSearchQueryFromURL(previousSearchStr)
+    const currentQuery = this.getSearchQueryFromURL()
+    if (currentQuery !== previousQuery) {
       this.setState({
-        query: currentQuery,
         searchText: currentQuery,
       })
     }
@@ -212,12 +211,13 @@ class SearchPage extends React.Component {
   /**
    * @return {String} The decoded search query
    */
-  getSearchQueryFromURL() {
+  getSearchQueryFromURL(searchStr) {
     if (isReactSnapClient()) {
       return ''
     }
     const { location: { search = '' } = {} } = this.props
-    return parseUrlSearchString(search).q || ''
+    const searchStrToParse = searchStr ? searchStr : search
+    return parseUrlSearchString(searchStrToParse).q || ''
   }
 
   // TODO: documentation

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -195,9 +195,11 @@ class SearchPage extends React.Component {
     }
   }
 
-  // TODO: documentation
   /**
-   * @return {Number} The search results page inded
+   * Get the integer value of the search results page number from the
+   * "page" URL parameter. During prerendering, or if the parameter is
+   * not set or is not an integer, return 1.
+   * @return {Number} The search results page index
    */
   getPageNumberFromURL() {
     if (isReactSnapClient()) {
@@ -207,8 +209,14 @@ class SearchPage extends React.Component {
     return parseInt(parseUrlSearchString(search).page, 10) || 1
   }
 
-  // TODO: documentation
   /**
+   * Get the search query string from the "q" URL parameter.
+   * By default, get it from the current location; or, if passed a
+   * searchStr parameter, get it from that search string. During
+   * prerendering, or if the parameter is not set, return an empty
+   * string
+   * @param {String} searchStr - The URL parameter string,
+   *   such as '?myParam=foo&another=bar'
    * @return {String} The decoded search query
    */
   getSearchQueryFromURL(searchStr) {
@@ -220,7 +228,12 @@ class SearchPage extends React.Component {
     return parseUrlSearchString(searchStrToParse).q || ''
   }
 
-  // TODO: documentation
+  /**
+   * Get the integer value of the search's source from the "src"
+   * URL parameter. During prerendering, or if the parameter is
+   * not set, return null.
+   * @return {String|null} The source of the search query
+   */
   getSearchSourceFromURL() {
     if (isReactSnapClient()) {
       return null

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -94,16 +94,14 @@ class SearchPage extends React.Component {
       // Important: set all client-specific state in componentDidMount,
       // because we do HTML prerendering with these values.
       browser: null,
-      showIntroMessage: false,
+      defaultSearchProvider: getSearchProvider(),
       isAdBlockerEnabled: false,
       isSearchExtensionInstalled: true, // assume installed until confirmed
-      query: '',
-      searchFeatureEnabled: isSearchPageEnabled(),
-      defaultSearchProvider: getSearchProvider(),
-      searchRedirectToThirdParty: shouldRedirectSearchToThirdParty(),
-      searchSource: null,
-      searchText: '',
       mounted: false, // i.e. we've mounted to a real user, not pre-rendering
+      searchFeatureEnabled: isSearchPageEnabled(),
+      searchRedirectToThirdParty: shouldRedirectSearchToThirdParty(),
+      searchText: '',
+      showIntroMessage: false,
     }
 
     this.isExtInstalledCancelablePromise = null
@@ -119,10 +117,7 @@ class SearchPage extends React.Component {
       // Cannot use pushState now that the apps are separate.
       externalRedirect(dashboardURL)
     }
-    const { location } = this.props
-
-    // Wait until after mount to update prerendered state.
-    const query = parseUrlSearchString(location.search).q || ''
+    const query = this.getSearchQueryFromURL()
 
     // Redirect to Google if enabled.
     if (this.state.searchRedirectToThirdParty) {
@@ -131,15 +126,9 @@ class SearchPage extends React.Component {
 
     this.setState({
       // We always derive the query and page values URL parameter
-      // values. We keep these in state so that we update the
-      // prerendered components after mount, because at prerender
-      // time we do not know search state. We can remove this
-      // from state if we switch to server-side rendering.
+      // values.
       mounted: true, // in other words, this is not React Snap prerendering
       browser: detectSupportedBrowser(),
-      query: query,
-      page: this.getPageNumberFromSearchString(location.search),
-      searchSource: parseUrlSearchString(location.search).src || null,
       searchText: query,
       showIntroMessage: !hasUserDismissedSearchIntro(),
     })
@@ -205,29 +194,39 @@ class SearchPage extends React.Component {
         searchText: currentQuery,
       })
     }
-
-    // Check if the page number has changed.
-    const currentPage = this.getPageNumberFromSearchString(location.search)
-    const prevPage = this.getPageNumberFromSearchString(
-      prevProps.location.search
-    )
-    if (currentPage !== prevPage) {
-      this.setState({
-        page: currentPage,
-      })
-    }
   }
 
+  // TODO: documentation
   /**
-   * Take a search string, such as ?abc=hi&p=12, and return the
-   * integer value of the "page" URL parameter. If the parameter is
-   * not set or is not an integer, return 1.
-   * @param {String} searchStr - The URL parameter string,
-   *   such as '?myParam=foo&another=bar'
    * @return {Number} The search results page inded
    */
-  getPageNumberFromSearchString(searchStr) {
-    return parseInt(parseUrlSearchString(searchStr).page, 10) || 1
+  getPageNumberFromURL() {
+    if (isReactSnapClient()) {
+      return 1
+    }
+    const { location: { search = '' } = {} } = this.props
+    return parseInt(parseUrlSearchString(search).page, 10) || 1
+  }
+
+  // TODO: documentation
+  /**
+   * @return {String} The decoded search query
+   */
+  getSearchQueryFromURL() {
+    if (isReactSnapClient()) {
+      return ''
+    }
+    const { location: { search = '' } = {} } = this.props
+    return parseUrlSearchString(search).q || ''
+  }
+
+  // TODO: documentation
+  getSearchSourceFromURL() {
+    if (isReactSnapClient()) {
+      return null
+    }
+    const { location: { search = '' } = {} } = this.props
+    return parseUrlSearchString(search).src || null
   }
 
   search() {
@@ -237,9 +236,6 @@ class SearchPage extends React.Component {
         page: 1,
         q: newQuery,
         src: 'self',
-      })
-      this.setState({
-        searchSource: 'self',
       })
     }
   }
@@ -257,14 +253,16 @@ class SearchPage extends React.Component {
       isSearchExtensionInstalled,
       isAdBlockerEnabled,
       mounted,
-      page,
-      query,
       showIntroMessage,
       defaultSearchProvider,
-      searchSource,
       searchText,
     } = this.state
+
+    const page = this.getPageNumberFromURL()
+    const query = this.getSearchQueryFromURL()
     const queryEncoded = query ? encodeURI(query) : ''
+    const searchSource = this.getSearchSourceFromURL()
+
     const searchResultsPaddingLeft = 150
     if (!this.state.searchFeatureEnabled) {
       return null

--- a/web/src/js/components/Search/SearchResultsBing.js
+++ b/web/src/js/components/Search/SearchResultsBing.js
@@ -196,58 +196,59 @@ const SearchResultsBing = props => {
           </div>
         </div>
       )}
-      <div
-        data-test-id={'pagination-container'}
-        className={classes.paginationContainer}
-        style={{
-          display: !SHOW_PAGINATION || noResultsToDisplay ? 'none' : 'flex',
-        }}
-      >
-        {page > MIN_PAGE ? (
-          <Button
-            data-test-id={'pagination-previous'}
-            className={classes.paginationButton}
-            onClick={() => {
-              onPageChange(page - 1)
-            }}
-          >
-            PREVIOUS
-          </Button>
-        ) : null}
-        {paginationIndices.map(pageNum => (
-          <Button
-            key={`page-${pageNum}`}
-            className={classes.paginationButton}
-            data-test-id={`pagination-${pageNum}`}
-            {...pageNum === page && {
-              color: 'secondary',
-              disabled: true,
-            }}
-            style={{
-              ...(pageNum === page && {
-                color: 'rgba(0, 0, 0, 0.87)',
-                borderBottom: '2px solid rgba(0, 0, 0, 0.87)',
-              }),
-            }}
-            onClick={() => {
-              onPageChange(pageNum)
-            }}
-          >
-            {pageNum}
-          </Button>
-        ))}
-        {page < MAX_PAGE ? (
-          <Button
-            data-test-id={'pagination-next'}
-            className={classes.paginationButton}
-            onClick={() => {
-              onPageChange(page + 1)
-            }}
-          >
-            NEXT
-          </Button>
-        ) : null}
-      </div>
+      {!!page && SHOW_PAGINATION && !noResultsToDisplay ? (
+        <div
+          data-test-id={'pagination-container'}
+          className={classes.paginationContainer}
+        >
+          {page > MIN_PAGE ? (
+            <Button
+              key={'pagination-previous'}
+              data-test-id={'pagination-previous'}
+              className={classes.paginationButton}
+              onClick={() => {
+                onPageChange(page - 1)
+              }}
+            >
+              PREVIOUS
+            </Button>
+          ) : null}
+          {paginationIndices.map(pageNum => (
+            <Button
+              key={`page-${pageNum}`}
+              className={classes.paginationButton}
+              data-test-id={`pagination-${pageNum}`}
+              {...pageNum === page && {
+                color: 'secondary',
+                disabled: true,
+              }}
+              style={{
+                ...(pageNum === page && {
+                  color: 'rgba(0, 0, 0, 0.87)',
+                  borderBottom: '2px solid rgba(0, 0, 0, 0.87)',
+                }),
+              }}
+              onClick={() => {
+                onPageChange(pageNum)
+              }}
+            >
+              {pageNum}
+            </Button>
+          ))}
+          {page < MAX_PAGE ? (
+            <Button
+              key={'pagination-next'}
+              data-test-id={'pagination-next'}
+              className={classes.paginationButton}
+              onClick={() => {
+                onPageChange(page + 1)
+              }}
+            >
+              NEXT
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -1406,24 +1406,6 @@ describe('Search results from Yahoo', () => {
     expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
   })
 
-  // FIXME
-  // it('[yahoo] passes "self" as the "searchSource" the SearchResults component when entering a new search on the page', () => {
-  //   const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-  //     .default
-  //   const mockProps = getMockProps()
-  //   mockProps.location.search = ''
-  //   const wrapper = mount(<SearchPageComponent {...mockProps} />)
-  //   expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
-  //   const searchInput = wrapper
-  //     .find(Input)
-  //     .first()
-  //     .find('input')
-  //   searchInput
-  //     .simulate('change', { target: { value: 'register to vote' } })
-  //     .simulate('keypress', { key: 'Enter' })
-  //   expect(wrapper.find(SearchResults).prop('searchSource')).toEqual('self')
-  // })
-
   // This is important for prerendering scripts for search results.
   it('[yahoo] renders the SearchResults component on mount even if there is no query', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -262,63 +262,6 @@ describe('Search page component', () => {
     })
   })
 
-  it('sets the "query" state to the value of the "q" URL param on mount', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location = {
-      search: '?q=yumtacos',
-    }
-    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
-    expect(wrapper.state('query')).toEqual('yumtacos')
-  })
-
-  it('does not set the "query" state to the value of the "q" URL param when prerendering with React Snap', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location = {
-      search: '?q=yumtacos',
-    }
-    isReactSnapClient.mockReturnValue(true)
-    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
-    expect(wrapper.state('query')).toEqual('')
-  })
-
-  it('sets the "page" state to the value of the "page" URL param on mount', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location = {
-      search: '?page=14',
-    }
-    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
-    expect(wrapper.state('page')).toEqual(14)
-  })
-
-  it('does not set the "page" state to the value of the "page" URL param when prerendering with React Snap', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location = {
-      search: '?page=14',
-    }
-    isReactSnapClient.mockReturnValue(true)
-    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
-    expect(wrapper.state('page')).toBeUndefined()
-  })
-
-  it('sets the "page" state to 1 if the value of the "page" URL param is not a valid integer', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location = {
-      search: '?age=foo',
-    }
-    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
-    expect(wrapper.state('page')).toEqual(1)
-  })
-
   it('sets the "p" query parameter to the page number when clicking to a new results page', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
@@ -1242,6 +1185,42 @@ describe('Search results from Bing', () => {
     expect(wrapper.find(SearchResultsQueryBing).prop('page')).toBe(12)
   })
 
+  it('[bing] passes an empty "query" value to SearchResultsQueryBing when prerendering with React Snap', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location = {
+      search: '?q=yumtacos',
+    }
+    isReactSnapClient.mockReturnValue(true)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResultsQueryBing).prop('query')).toEqual('')
+  })
+
+  it('[bing] passes a "page" value of 1 to to SearchResultsQueryBing when prerendering with React Snap', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location = {
+      search: '?q=yumtacos&page=12',
+    }
+    isReactSnapClient.mockReturnValue(true)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResultsQueryBing).prop('page')).toEqual(1)
+  })
+
+  it('[bing] passes a "searchSource" value of null to to SearchResultsQueryBing when prerendering with React Snap', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location = {
+      search: '?q=yumtacos&src=chrome',
+    }
+    isReactSnapClient.mockReturnValue(true)
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toBeNull()
+  })
+
   it('[bing] passes "1" as the default page number to the SearchResultsQueryBing component when the "page" URL param is not set', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
@@ -1251,7 +1230,16 @@ describe('Search results from Bing', () => {
     expect(wrapper.find(SearchResultsQueryBing).prop('page')).toBe(1)
   })
 
-  it('[bing] passes the search source to the SearchResultsQueryBing component when the "page" URL param is set', () => {
+  it('[bing] passes "1" as the default page number to the SearchResultsQueryBing component when the "page" URL param is not a valid integer', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=foo&page=hello'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResultsQueryBing).prop('page')).toBe(1)
+  })
+
+  it('[bing] passes the search source to the SearchResultsQueryBing component when the "src" URL param is set', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default
     const mockProps = getMockProps()
@@ -1271,24 +1259,27 @@ describe('Search results from Bing', () => {
     expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toBeNull()
   })
 
-  it('[bing] passes "self" as the "searchSource" the SearchResultsQueryBing component when entering a new search on the page', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location.search = ''
-    const wrapper = mount(<SearchPageComponent {...mockProps} />)
-    expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toBeNull()
-    const searchInput = wrapper
-      .find(Input)
-      .first()
-      .find('input')
-    searchInput
-      .simulate('change', { target: { value: 'register to vote' } })
-      .simulate('keypress', { key: 'Enter' })
-    expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toEqual(
-      'self'
-    )
-  })
+  // FIXME
+  // it('[bing] passes "self" as the "searchSource" the SearchResultsQueryBing component when entering a new search on the page', () => {
+  //   const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+  //     .default
+  //   const mockProps = getMockProps()
+  //   mockProps.location.search = ''
+  //   const wrapper = mount(<SearchPageComponent {...mockProps} />)
+  //   expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toBeNull()
+  //   const searchInput = wrapper
+  //     .find(Input)
+  //     .first()
+  //     .find('input')
+  //   searchInput
+  //     .simulate('change', { target: { value: 'register to vote' } })
+  //     .simulate('keypress', { key: 'Enter' })
+  //   console.log('=========')
+  //   expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toEqual(
+  //     'self'
+  //   )
+  //   console.log('=========')
+  // })
 
   // This is important for prerendering scripts for search results.
   it('[bing] renders the SearchResultsQueryBing component on mount even if there is no query', () => {
@@ -1399,22 +1390,23 @@ describe('Search results from Yahoo', () => {
     expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
   })
 
-  it('[yahoo] passes "self" as the "searchSource" the SearchResults component when entering a new search on the page', () => {
-    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-      .default
-    const mockProps = getMockProps()
-    mockProps.location.search = ''
-    const wrapper = mount(<SearchPageComponent {...mockProps} />)
-    expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
-    const searchInput = wrapper
-      .find(Input)
-      .first()
-      .find('input')
-    searchInput
-      .simulate('change', { target: { value: 'register to vote' } })
-      .simulate('keypress', { key: 'Enter' })
-    expect(wrapper.find(SearchResults).prop('searchSource')).toEqual('self')
-  })
+  // FIXME
+  // it('[yahoo] passes "self" as the "searchSource" the SearchResults component when entering a new search on the page', () => {
+  //   const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+  //     .default
+  //   const mockProps = getMockProps()
+  //   mockProps.location.search = ''
+  //   const wrapper = mount(<SearchPageComponent {...mockProps} />)
+  //   expect(wrapper.find(SearchResults).prop('searchSource')).toBeNull()
+  //   const searchInput = wrapper
+  //     .find(Input)
+  //     .first()
+  //     .find('input')
+  //   searchInput
+  //     .simulate('change', { target: { value: 'register to vote' } })
+  //     .simulate('keypress', { key: 'Enter' })
+  //   expect(wrapper.find(SearchResults).prop('searchSource')).toEqual('self')
+  // })
 
   // This is important for prerendering scripts for search results.
   it('[yahoo] renders the SearchResults component on mount even if there is no query', () => {

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -1259,27 +1259,43 @@ describe('Search results from Bing', () => {
     expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toBeNull()
   })
 
-  // FIXME
-  // it('[bing] passes "self" as the "searchSource" the SearchResultsQueryBing component when entering a new search on the page', () => {
-  //   const SearchPageComponent = require('js/components/Search/SearchPageComponent')
-  //     .default
-  //   const mockProps = getMockProps()
-  //   mockProps.location.search = ''
-  //   const wrapper = mount(<SearchPageComponent {...mockProps} />)
-  //   expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toBeNull()
-  //   const searchInput = wrapper
-  //     .find(Input)
-  //     .first()
-  //     .find('input')
-  //   searchInput
-  //     .simulate('change', { target: { value: 'register to vote' } })
-  //     .simulate('keypress', { key: 'Enter' })
-  //   console.log('=========')
-  //   expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toEqual(
-  //     'self'
-  //   )
-  //   console.log('=========')
-  // })
+  it('[bing] passes the new "page" to the SearchResultsQueryBing component when the URL param changes', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=hello&page=34'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResultsQueryBing).prop('page')).toEqual(34)
+    wrapper.setProps({
+      ...mockProps,
+      location: {
+        ...mockProps.location,
+        search: '?q=what+is+a+waffle+house&page=28',
+      },
+    })
+    expect(wrapper.find(SearchResultsQueryBing).prop('page')).toEqual(28)
+  })
+
+  it('[bing] passes the new "src" to the SearchResultsQueryBing component when the URL param changes', () => {
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=hello&src=chrome'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toEqual(
+      'chrome'
+    )
+    wrapper.setProps({
+      ...mockProps,
+      location: {
+        ...mockProps.location,
+        search: '?q=hello&src=ff',
+      },
+    })
+    expect(wrapper.find(SearchResultsQueryBing).prop('searchSource')).toEqual(
+      'ff'
+    )
+  })
 
   // This is important for prerendering scripts for search results.
   it('[bing] renders the SearchResultsQueryBing component on mount even if there is no query', () => {

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -293,6 +293,24 @@ describe('Search page component', () => {
     expect(wrapper.find(Input).prop('value')).toBe('blahblah')
   })
 
+  it('updates the the search text in the box when the search query URL param value changes', () => {
+    isSearchPageEnabled.mockReturnValue(true)
+    const SearchPageComponent = require('js/components/Search/SearchPageComponent')
+      .default
+    const mockProps = getMockProps()
+    mockProps.location.search = '?q=blahblah'
+    const wrapper = shallow(<SearchPageComponent {...mockProps} />).dive()
+    expect(wrapper.find(Input).prop('value')).toBe('blahblah')
+    wrapper.setProps(
+      Object.assign({}, mockProps, {
+        location: {
+          search: '?q=something%20here',
+        },
+      })
+    )
+    expect(wrapper.find(Input).prop('value')).toBe('something here')
+  })
+
   it('clicking the search button updates the "q" URL parameter, sets the page to 1, and sets the "src" to "self"', () => {
     const SearchPageComponent = require('js/components/Search/SearchPageComponent')
       .default

--- a/web/src/js/components/Search/__tests__/SearchResultsBing.test.js
+++ b/web/src/js/components/Search/__tests__/SearchResultsBing.test.js
@@ -621,10 +621,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     mockProps.query = 'ice cream'
     mockProps.page = 1
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-        .display
-    ).toEqual('flex')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      true
+    )
   })
 
   it('does not show the pagination container when it is not enabled', () => {
@@ -635,10 +634,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     mockProps.query = 'ice cream'
     mockProps.page = 1
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-        .display
-    ).toEqual('none')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      false
+    )
   })
 
   it('hides the pagination container when there is an empty query', () => {
@@ -650,9 +648,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
 
     // The pagination container should not be hidden.
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'flex')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      true
+    )
 
     wrapper.setProps({
       query: '',
@@ -660,9 +658,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     })
 
     // The pagination container should be hidden now.
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'none')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      false
+    )
   })
 
   it('hides the pagination container when the search query is in progress', () => {
@@ -683,9 +681,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     mockProps.queryReturned = false
     mockProps.isEmptyQuery = false
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'none')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      false
+    )
   })
 
   it('hides the pagination container when the search query is in progress and results are still available from the previous page', () => {
@@ -721,9 +719,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     mockProps.queryReturned = false
     mockProps.isEmptyQuery = false
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'none')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      false
+    )
   })
 
   it('hides the pagination container when there are no search results', () => {
@@ -744,9 +742,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     mockProps.queryReturned = true
     mockProps.isEmptyQuery = false
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'none')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      false
+    )
   })
 
   it('hides the pagination container when there is an error', () => {
@@ -758,9 +756,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
 
     // The pagination container should not be hidden.
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'flex')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      true
+    )
 
     wrapper.setProps({
       query: '',
@@ -768,9 +766,9 @@ describe('SearchResultsBing: tests for pagination', () => {
     })
 
     // The pagination container should be hidden now.
-    expect(
-      wrapper.find('[data-test-id="pagination-container"]').prop('style')
-    ).toHaveProperty('display', 'none')
+    expect(wrapper.find('[data-test-id="pagination-container"]').exists()).toBe(
+      false
+    )
   })
 
   it('does not render the "previous page" pagination button when on the first page', () => {
@@ -804,6 +802,26 @@ describe('SearchResultsBing: tests for pagination', () => {
     expect(wrapper.find('[data-test-id="pagination-previous"]').exists()).toBe(
       true
     )
+  })
+
+  it('renders the "previous page" pagination button after changing from the first page', () => {
+    const SearchResultsBing = require('js/components/Search/SearchResultsBing')
+      .default
+    const mockProps = getMockProps()
+    mockProps.page = 1
+    const wrapper = shallow(<SearchResultsBing {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="pagination-previous"]').exists()).toBe(
+      false
+    )
+    wrapper.setProps({
+      page: 4,
+    })
+    expect(wrapper.find('[data-test-id="pagination-previous"]').exists()).toBe(
+      true
+    )
+    expect(
+      wrapper.find('[data-test-id="pagination-previous"]').prop('disabled')
+    ).not.toBe(true)
   })
 
   it('does render the 9999th pagination button when on the final page (page 9999)', () => {


### PR DESCRIPTION
We've been keeping the search query, search result page number, and search source in state in the SearchPageComponent when it's actually state derived from the `location.search` URL parameter values. It adds complexity and might be causing bugs. Remove these from state altogether.