### PR TITLE
Make `withUser` compatible with build-time HTML pre-rendering

### DIFF
--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -23,8 +23,13 @@ function getDisplayName(WrappedComponent) {
  * @param {String} options.app - One of "search" or "tab". This determines
  *   app-specific behavior, like the redirect URL. Defaults to "tab".
  * @param {Boolean} options.renderIfNoUser - If true, we will render the
- *   children even if there is no user ID (the user is not signed in).
+ *   children after we determine the user is not signed in.
  *   Defaults to false.
+ * @param {Boolean} options.renderWhileDeterminingAuthState - If true,
+ *   we will render the children before we know whether the user is authed
+ *   or not. This is helpful for pages that need to load particularly quickly
+ *   or pages we prerender at build time. Typically, renderIfNoUser should also
+ *   be set to true if this is true. Defaults to false.
  * @param {Boolean} options.createUserIfPossible - If true, when a user does
  *   not exist, we will create a new anonymous user both in our auth service
  *   and in our database. We might not always create a new user, depending on
@@ -34,6 +39,9 @@ function getDisplayName(WrappedComponent) {
  *   user ID), we will redirect to the appropriate authentication page.
  *   our anonymous user restrictions. It should be false when using withUser
  *   in a page where authentication is optional. Defaults to true.
+ * @param {Boolean} options.setNullUserWhenPrerendering - If true, we will
+ *   not test auth state during build-time prerendering. Instead, we will
+ *   set the authUser value to null. Defaults to true.
  * @return {Function} A higher-order component.
  */
 const withUser = (options = {}) => WrappedComponent => {

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -63,8 +63,6 @@ const withUser = (options = {}) => WrappedComponent => {
 
       // Check the auth state. Optionally, when prerendering, just
       // immediately set a null user value.
-
-      // TODO: add tests
       const { setNullUserWhenPrerendering = true } = options
       if (setNullUserWhenPrerendering && isReactSnapClient()) {
         this.setState({
@@ -173,7 +171,6 @@ const withUser = (options = {}) => WrappedComponent => {
       } = options
       const { authUser, authStateLoaded, userCreationInProgress } = this.state
 
-      // TODO: add tests
       // By default, don't render the children until we've determined the
       // auth state.
       if (

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -63,6 +63,8 @@ const withUser = (options = {}) => WrappedComponent => {
 
       // Check the auth state. Optionally, when prerendering, just
       // immediately set a null user value.
+
+      // TODO: add tests
       const { setNullUserWhenPrerendering = true } = options
       if (setNullUserWhenPrerendering && isReactSnapClient()) {
         this.setState({
@@ -171,6 +173,7 @@ const withUser = (options = {}) => WrappedComponent => {
       } = options
       const { authUser, authStateLoaded, userCreationInProgress } = this.state
 
+      // TODO: add tests
       // By default, don't render the children until we've determined the
       // auth state.
       if (

--- a/web/src/js/components/General/withUser.js
+++ b/web/src/js/components/General/withUser.js
@@ -7,6 +7,7 @@ import {
 import logger from 'js/utils/logger'
 import { makePromiseCancelable } from 'js/utils/utils'
 import { SEARCH_APP, TAB_APP } from 'js/constants'
+import { isReactSnapClient } from 'js/utils/search-utils'
 
 // https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging
 function getDisplayName(WrappedComponent) {
@@ -52,11 +53,21 @@ const withUser = (options = {}) => WrappedComponent => {
     componentDidMount() {
       this.mounted = true
 
-      // Store unsubscribe function.
-      // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged
-      this.authListenerUnsubscribe = onAuthStateChanged(user => {
-        this.determineAuthState(user)
-      })
+      // Check the auth state. Optionally, when prerendering, just
+      // immediately set a null user value.
+      const { setNullUserWhenPrerendering = true } = options
+      if (setNullUserWhenPrerendering && isReactSnapClient()) {
+        this.setState({
+          authUser: null,
+          authStateLoaded: true,
+        })
+      } else {
+        // Store unsubscribe function.
+        // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onAuthStateChanged
+        this.authListenerUnsubscribe = onAuthStateChanged(user => {
+          this.determineAuthState(user)
+        })
+      }
     }
 
     componentWillUnmount() {
@@ -146,13 +157,22 @@ const withUser = (options = {}) => WrappedComponent => {
     }
 
     render() {
-      const { renderIfNoUser = false } = options
+      const {
+        renderWhileDeterminingAuthState = false,
+        renderIfNoUser = false,
+      } = options
       const { authUser, authStateLoaded, userCreationInProgress } = this.state
-      // Don't render the children until we've determined the auth state.
-      if (!authStateLoaded || userCreationInProgress) {
+
+      // By default, don't render the children until we've determined the
+      // auth state.
+      if (
+        !renderWhileDeterminingAuthState &&
+        (!authStateLoaded || userCreationInProgress)
+      ) {
         return null
       }
-      // Return null if the user is not authenticated but the children require
+
+      // Return null if the user is not authenticated and the children require
       // an authenticated user.
       if (!authUser && !renderIfNoUser) {
         return null

--- a/web/src/js/components/Search/SearchPageComponent.js
+++ b/web/src/js/components/Search/SearchPageComponent.js
@@ -742,5 +742,13 @@ export default withStyles(styles, { withTheme: true })(
   withUser({
     app: SEARCH_APP,
     createUserIfPossible: false,
+    // We want to:
+    // - render children immediately (without waiting on any auth determination)
+    // - prerender child HTML assuming no authed user
+    // - redirect to the auth page in production if the user is not signed in
+    redirectToAuthIfIncomplete: true,
+    renderIfNoUser: true,
+    renderWhileDeterminingAuthState: true,
+    setNullUserWhenPrerendering: true,
   })(SearchPage)
 )

--- a/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
+++ b/web/src/js/components/Search/__tests__/SearchPageComponent.test.js
@@ -1732,6 +1732,10 @@ describe('withUser HOC in SearchPageComponent', () => {
     expect(withUser).toHaveBeenCalledWith({
       app: 'search',
       createUserIfPossible: false,
+      redirectToAuthIfIncomplete: true,
+      renderIfNoUser: true,
+      renderWhileDeterminingAuthState: true,
+      setNullUserWhenPrerendering: true,
     })
   })
 


### PR DESCRIPTION
* Add two new options to `withUser`: one to default to using a null user during prerendering, and another to allow rendering HTML before we determine the auth status (for faster rendering)
* Make the search results page render prior to determining the user's auth status
* Make sure we successfully prerender the search results page's HTML