### PR TITLE
Fix a bug where searching a new query fails on a slow network/CPU

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -123,6 +123,7 @@
           queryRequest: {
             status: 'NONE',
             displayedResults: false,
+            query: null,
             responseData: null,
           },
           extension: {

--- a/web/src/js/components/Search/__tests__/fetchBingSearchResults.test.js
+++ b/web/src/js/components/Search/__tests__/fetchBingSearchResults.test.js
@@ -553,6 +553,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'NONE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: null,
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -561,11 +562,26 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 
+  it('[completed request with data]: fetches new data when the query is different', async () => {
+    expect.assertions(1)
+    window.searchforacause.queryRequest = {
+      status: 'COMPLETE',
+      displayedResults: false,
+      query: 'how cold is frozen stuff',
+      responseData: { some: 'data' },
+    }
+    const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
+      .default
+    await fetchBingSearchResults({ query: 'science facts' }) // different query
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
   it('[completed request with data]: does not fetch new data', async () => {
     expect.assertions(1)
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: { some: 'data' },
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -579,6 +595,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: { some: 'data', abc: 123 },
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -592,6 +609,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: { some: 'data', abc: 123 },
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -605,6 +623,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: true, // already displayed these results
+      query: 'blue whales',
       responseData: { some: 'data' },
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -618,6 +637,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: { some: 'data', abc: 123 },
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -633,6 +653,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: { some: 'data', abc: 123 },
     }
     global.fetch.mockImplementation(() =>
@@ -657,6 +678,7 @@ describe('fetchBingSearchResults: using previously-fetched data', () => {
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: null,
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -675,6 +697,7 @@ describe('fetchBingSearchResults: using data from in-progress requests', () => {
     window.searchforacause.queryRequest = {
       status: 'IN_PROGRESS',
       displayedResults: false,
+      query: 'how to make boiled water',
       responseData: null,
     }
     const fetchBingSearchResults = require('js/components/Search/fetchBingSearchResults')
@@ -697,6 +720,7 @@ describe('fetchBingSearchResults: using data from in-progress requests', () => {
     window.searchforacause.queryRequest = {
       status: 'IN_PROGRESS',
       displayedResults: false,
+      query: 'how to make boiled water',
       responseData: null,
     }
     const spyRemoveEventListener = jest.spyOn(window, 'removeEventListener')
@@ -751,6 +775,27 @@ describe('prefetchSearchResults: storing "prefetched" request data to the search
         msEdgeClientID: 'abc-123',
       },
     })
+  })
+
+  it('stores the search query to the search global', async () => {
+    expect.assertions(1)
+    getUrlParameters.mockReturnValue({
+      q: 'how to make boiled water',
+    })
+    global.fetch.mockImplementation(() =>
+      Promise.resolve(
+        mockFetchResponse({
+          json: () => Promise.resolve({ some: 'thing' }),
+        })
+      )
+    )
+    const {
+      prefetchSearchResults,
+    } = require('js/components/Search/fetchBingSearchResults')
+    await prefetchSearchResults()
+    expect(window.searchforacause.queryRequest.query).toEqual(
+      'how to make boiled water'
+    )
   })
 
   it('stores null data to the search global when fetching fails', async () => {
@@ -813,6 +858,7 @@ describe('prefetchSearchResults: storing "prefetched" request data to the search
     window.searchforacause.queryRequest = {
       status: 'COMPLETE',
       displayedResults: false,
+      query: 'blue whales',
       responseData: { some: 'data', abc: 123 },
     }
     global.fetch.mockImplementation(() =>

--- a/web/src/js/components/Search/fetchBingSearchResults.js
+++ b/web/src/js/components/Search/fetchBingSearchResults.js
@@ -109,17 +109,6 @@ const getPreviouslyFetchedData = async () => {
         queryCompleteHandler,
         false
       )
-
-      // Set a max time to wait.
-      const msToWaitBeforeRetrying = 800
-      setTimeout(() => {
-        window.removeEventListener(
-          eventNameResultsFetched,
-          queryCompleteHandler,
-          false
-        )
-        resolve(null)
-      }, msToWaitBeforeRetrying)
     })
   }
 

--- a/web/src/js/components/Search/fetchBingSearchResults.js
+++ b/web/src/js/components/Search/fetchBingSearchResults.js
@@ -34,10 +34,18 @@ export const prefetchSearchResults = async () => {
   const searchGlobalObj = getSearchGlobal()
   set(searchGlobalObj, 'queryRequest.status', QUERY_IN_PROGRESS)
 
+  let query = null
+  try {
+    const urlParams = getUrlParameters()
+    const query = urlParams.q || null
+    set(searchGlobalObj, 'queryRequest.query', query)
+  } catch (e) {}
+
   // Fetch search results.
   let results = null
   try {
     results = await fetchBingSearchResults({
+      query,
       ignoreStoredData: true,
     })
     if (DEBUG) {
@@ -64,9 +72,11 @@ export const prefetchSearchResults = async () => {
  * requests. The previous request may happen via another JS entry point
  * that we prioritize to speed up fetching the search results. If there
  * is no valid data, return null.
+ * @param {Object} options
+ * @param {String} options.query - The search query, unencoded.
  * @return {Promise<Object|null>}
  */
-const getPreviouslyFetchedData = async () => {
+const getPreviouslyFetchedData = async ({ query = null }) => {
   if (DEBUG) {
     console.log('App fetch: getting previously-fetched data')
   }
@@ -82,6 +92,12 @@ const getPreviouslyFetchedData = async () => {
   // If we already used the search results data, don't re-use it.
   // Return null so we fetch fresh data.
   else if (queryRequest.displayedResults) {
+    return null
+  }
+
+  // If this query is different from the query in stored results,
+  // don't use the stored results.
+  else if (query !== queryRequest.query) {
     return null
   }
 
@@ -163,7 +179,7 @@ const fetchBingSearchResults = async ({
   // progress, use that request's data.
   if (!ignoreStoredData) {
     try {
-      const priorFetchedData = await getPreviouslyFetchedData()
+      const priorFetchedData = await getPreviouslyFetchedData({ query })
       if (priorFetchedData) {
         // Save that we've used this data already so that we fetch fresh
         // data the next time the user queries.

--- a/web/src/js/utils/test-utils.js
+++ b/web/src/js/utils/test-utils.js
@@ -236,6 +236,7 @@ export const getDefaultSearchGlobal = () => ({
   queryRequest: {
     status: 'NONE',
     displayedResults: false,
+    query: null,
     responseData: null,
   },
   extension: {


### PR DESCRIPTION
Remove an ill-advised pre-fetched search results query timeout and retry. This can break the second query a user makes on the page, leaving them with the same results as the first query, because we would use the pre-fetched query results for the "first" time on the second search.

As a precaution, also add query matching to ignore fetched queries if the query somehow changes.