### PR TITLE
New search introduction button

### DIFF
--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -180,11 +180,13 @@ class Dashboard extends React.Component {
 
     // Whether to show a search introduction message or button.
     // Show the search introduction message to all users who:
-    // * haven't already clicked it
+    // * haven't already searched
+    // * haven't already clicked the intro message
     // * haven't already interacted with the intro in our previous experiment
     // * have opened at least three tabs but fewer than 100 tabs
     const showSearchIntro =
       user &&
+      user.searches < 1 &&
       !userClickedSearchIntroV1 &&
       !(
         user.experimentActions.searchIntro === 'CLICK' ||
@@ -194,11 +196,16 @@ class Dashboard extends React.Component {
       user.tabs < 100
 
     // Show the sparkly search introduction button to all users who:
+    // * haven't already searched
     // * aren't seeing the search intro message
-    // * haven't already clicked it
+    // * haven't already clicked the intro button
     // * have opened at least 150 tabs
     const showSparklySearchIntroButton =
-      user && !showSearchIntro && !userClickedSearchIntroV2 && user.tabs > 150
+      user &&
+      user.searches < 1 &&
+      !showSearchIntro &&
+      !userClickedSearchIntroV2 &&
+      user.tabs > 150
 
     // Determine if the user is in an experimental group for
     // the "referral notification" experiment.
@@ -608,6 +615,7 @@ Dashboard.propTypes = {
       searchIntro: PropTypes.string,
     }).isRequired,
     joined: PropTypes.string.isRequired,
+    searches: PropTypes.number.isRequired,
     tabs: PropTypes.number.isRequired,
   }),
   app: PropTypes.shape({

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -256,6 +256,7 @@ class Dashboard extends React.Component {
             >
               <UserMenu
                 app={app}
+                browser={browser}
                 user={user}
                 isUserAnonymous={this.state.isUserAnonymous}
               />

--- a/web/src/js/components/Dashboard/DashboardContainer.js
+++ b/web/src/js/components/Dashboard/DashboardContainer.js
@@ -18,6 +18,7 @@ export default createFragmentContainer(Dashboard, {
         searchIntro
       }
       joined
+      searches
       tabs
       ...WidgetsContainer_user
       ...UserBackgroundImageContainer_user

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -16,11 +16,21 @@ import HeartsDropdown from 'js/components/Dashboard/HeartsDropdownContainer'
 import SettingsButton from 'js/components/Dashboard/SettingsButtonComponent'
 import SettingsDropdown from 'js/components/Dashboard/SettingsDropdownComponent'
 import { logout } from 'js/authentication/user'
-import { goTo, loginURL } from 'js/navigation/navigation'
+import {
+  goTo,
+  loginURL,
+  searchChromeExtensionPage,
+  searchFirefoxExtensionPage,
+} from 'js/navigation/navigation'
 import logger from 'js/utils/logger'
 import DashboardPopover from 'js/components/Dashboard/DashboardPopover'
 import { inviteFriendsURL } from 'js/navigation/navigation'
 import Link from 'js/components/General/Link'
+import {
+  CHROME_BROWSER,
+  FIREFOX_BROWSER,
+  UNSUPPORTED_BROWSER,
+} from 'js/constants'
 
 const Sparkle = lazy(() => import('react-sparkle'))
 
@@ -53,7 +63,7 @@ class UserMenu extends React.Component {
   }
 
   render() {
-    const { app, classes, user, isUserAnonymous } = this.props
+    const { app, browser, classes, user, isUserAnonymous } = this.props
     return (
       <MuiThemeProvider
         theme={{
@@ -144,7 +154,15 @@ class UserMenu extends React.Component {
             data-test-id={'search-intro-button-sparkle'}
             style={{ position: 'relative' }}
           >
-            <Link to={inviteFriendsURL}>
+            <Link
+              to={
+                browser === CHROME_BROWSER
+                  ? searchChromeExtensionPage
+                  : browser === FIREFOX_BROWSER
+                  ? searchFirefoxExtensionPage
+                  : searchChromeExtensionPage
+              }
+            >
               <Button
                 variant={'text'}
                 color={'default'}
@@ -253,6 +271,11 @@ class UserMenu extends React.Component {
 
 UserMenu.propTypes = {
   app: PropTypes.shape({}).isRequired,
+  browser: PropTypes.oneOf([
+    CHROME_BROWSER,
+    FIREFOX_BROWSER,
+    UNSUPPORTED_BROWSER,
+  ]).isRequired,
   classes: PropTypes.object.isRequired,
   isUserAnonymous: PropTypes.bool,
   user: PropTypes.shape({}).isRequired,

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -63,7 +63,15 @@ class UserMenu extends React.Component {
   }
 
   render() {
-    const { app, browser, classes, user, isUserAnonymous } = this.props
+    const {
+      app,
+      browser,
+      classes,
+      user,
+      isUserAnonymous,
+      onClickSparklySearchIntroButton,
+      showSparklySearchIntroButton,
+    } = this.props
     return (
       <MuiThemeProvider
         theme={{
@@ -150,40 +158,44 @@ class UserMenu extends React.Component {
             justifyContent: 'flex-end',
           }}
         >
-          <div
-            data-test-id={'search-intro-button-sparkle'}
-            style={{ position: 'relative' }}
-          >
-            <Link
-              to={
-                browser === CHROME_BROWSER
-                  ? searchChromeExtensionPage
-                  : browser === FIREFOX_BROWSER
-                  ? searchFirefoxExtensionPage
-                  : searchChromeExtensionPage
-              }
+          {showSparklySearchIntroButton ? (
+            <div
+              data-test-id={'search-intro-button-sparkle'}
+              style={{ position: 'relative' }}
             >
-              <Button
-                variant={'text'}
-                color={'default'}
-                style={{
-                  marginRight: 16,
-                  color: 'rgba(255, 255, 255, 0.8)',
-                }}
+              <Link
+                to={
+                  browser === CHROME_BROWSER
+                    ? searchChromeExtensionPage
+                    : browser === FIREFOX_BROWSER
+                    ? searchFirefoxExtensionPage
+                    : searchChromeExtensionPage
+                }
+                target={'blank'}
+                onClick={onClickSparklySearchIntroButton}
               >
-                Double your impact
-              </Button>
-            </Link>
-            <Suspense fallback={null}>
-              <Sparkle
-                color={'#FFEBA2'}
-                count={12}
-                fadeOutSpeed={34}
-                overflowPx={8}
-                flicker={false}
-              />
-            </Suspense>
-          </div>
+                <Button
+                  variant={'text'}
+                  color={'default'}
+                  style={{
+                    marginRight: 16,
+                    color: 'rgba(255, 255, 255, 0.8)',
+                  }}
+                >
+                  Double your impact
+                </Button>
+              </Link>
+              <Suspense fallback={null}>
+                <Sparkle
+                  color={'#FFEBA2'}
+                  count={12}
+                  fadeOutSpeed={34}
+                  overflowPx={8}
+                  flicker={false}
+                />
+              </Suspense>
+            </div>
+          ) : null}
           <MoneyRaised
             app={app}
             dropdown={({ open, onClose, anchorElement }) => (
@@ -278,11 +290,15 @@ UserMenu.propTypes = {
   ]).isRequired,
   classes: PropTypes.object.isRequired,
   isUserAnonymous: PropTypes.bool,
+  onClickSparklySearchIntroButton: PropTypes.func,
+  showSparklySearchIntroButton: PropTypes.bool,
   user: PropTypes.shape({}).isRequired,
 }
 
 UserMenu.defaultProps = {
   isUserAnonymous: false,
+  onClickSparklySearchIntroButton: () => {},
+  showSparklySearchIntroButton: false,
 }
 
 export default withStyles(styles)(UserMenu)

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -160,7 +160,7 @@ class UserMenu extends React.Component {
         >
           {showSparklySearchIntroButton ? (
             <div
-              data-test-id={'search-intro-button-sparkle'}
+              data-test-id={'search-intro-sparkly-button'}
               style={{ position: 'relative' }}
             >
               <Link

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Suspense, lazy } from 'react'
 import PropTypes from 'prop-types'
 import { get } from 'lodash/object'
 import {
@@ -21,6 +21,8 @@ import logger from 'js/utils/logger'
 import DashboardPopover from 'js/components/Dashboard/DashboardPopover'
 import { inviteFriendsURL } from 'js/navigation/navigation'
 import Link from 'js/components/General/Link'
+
+const Sparkle = lazy(() => import('react-sparkle'))
 
 const defaultTheme = createMuiTheme(theme)
 
@@ -138,6 +140,32 @@ class UserMenu extends React.Component {
             justifyContent: 'flex-end',
           }}
         >
+          <div
+            data-test-id={'search-intro-button-sparkle'}
+            style={{ position: 'relative' }}
+          >
+            <Link to={inviteFriendsURL}>
+              <Button
+                variant={'text'}
+                color={'default'}
+                style={{
+                  marginRight: 16,
+                  color: 'rgba(255, 255, 255, 0.8)',
+                }}
+              >
+                Double your impact
+              </Button>
+            </Link>
+            <Suspense fallback={null}>
+              <Sparkle
+                color={'#FFEBA2'}
+                count={12}
+                fadeOutSpeed={34}
+                overflowPx={8}
+                flicker={false}
+              />
+            </Suspense>
+          </div>
           <MoneyRaised
             app={app}
             dropdown={({ open, onClose, anchorElement }) => (

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -99,6 +99,7 @@ const mockProps = {
   user: {
     id: 'abc-123',
     joined: '2017-04-10T14:00:00.000',
+    searches: 0,
     tabs: 12,
     experimentActions: {},
   },
@@ -739,6 +740,16 @@ describe('Dashboard component: search intro message', () => {
     )
   })
 
+  it('does not render the search intro notification if the user has already searched', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.searches = 1
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    const elem = wrapper.find('[data-test-id="search-intro-notif"]')
+    expect(elem.exists()).toBe(false)
+  })
+
   it('does not render the search intro notification when the user has previously clicked it in the experiment', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
@@ -896,15 +907,29 @@ describe('Dashboard component: sparkly search intro button', () => {
     hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(false)
   })
 
-  it('shows the sparkly search intro button when the user has not already clicked it and has opened more than 150 tabs', () => {
+  it('shows the sparkly search intro button when the user has not already clicked it, has opened more than 150 tabs, and has not already searched', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const modifiedProps = cloneDeep(mockProps)
     modifiedProps.user.tabs = 160
+    modifiedProps.user.searches = 0
     hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(false)
     const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
     expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
       true
+    )
+  })
+
+  it('does not shows the sparkly search intro button when the user has already searched', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    modifiedProps.user.searches = 1
+    hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(false)
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      false
     )
   })
 

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -45,6 +45,8 @@ import {
   hasUserDismissedNotificationRecently,
   hasUserClickedNewTabSearchIntroNotif,
   setUserClickedNewTabSearchIntroNotif,
+  hasUserClickedNewTabSearchIntroNotifV2,
+  setUserClickedNewTabSearchIntroNotifV2,
 } from 'js/utils/local-user-data-mgr'
 import { showGlobalNotification } from 'js/utils/feature-flags'
 import { getUserExperimentGroup } from 'js/utils/experiments'
@@ -649,7 +651,7 @@ describe('Dashboard component: global notification', () => {
   })
 })
 
-describe('Dashboard component: search intro experiment', () => {
+describe('Dashboard component: search intro message', () => {
   beforeEach(() => {
     getUserExperimentGroup.mockReturnValue('none')
     hasUserClickedNewTabSearchIntroNotif.mockReturnValue(false)
@@ -714,6 +716,26 @@ describe('Dashboard component: search intro experiment', () => {
     })
     expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
       true
+    )
+  })
+
+  it('does not render the search intro notification when the user has opened more than 99 tabs', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 99
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
+      true
+    )
+    wrapper.setProps({
+      user: {
+        ...modifiedProps.user,
+        tabs: 100,
+      },
+    })
+    expect(wrapper.find('[data-test-id="search-intro-notif"]').exists()).toBe(
+      false
     )
   })
 
@@ -858,12 +880,117 @@ describe('Dashboard component: search intro experiment', () => {
     expect(LogUserExperimentActionsMutation).not.toHaveBeenCalled()
   })
 
-  it('does not sets the "useGlobalDismissalTime" on the experiment notification', () => {
+  it('does not set the "useGlobalDismissalTime" on the experiment notification', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default
     const wrapper = shallow(<DashboardComponent {...mockProps} />)
     const elem = wrapper.find('[data-test-id="search-intro-notif"]')
     expect(elem.prop('useGlobalDismissalTime')).toBe(false)
+  })
+})
+
+describe('Dashboard component: sparkly search intro button', () => {
+  beforeEach(() => {
+    getUserExperimentGroup.mockReturnValue('none')
+    hasUserClickedNewTabSearchIntroNotif.mockReturnValue(false)
+    hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(false)
+  })
+
+  it('shows the sparkly search intro button when the user has not already clicked it and has opened more than 150 tabs', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(false)
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      true
+    )
+  })
+
+  it('does not show the sparkly search intro button when the user has opened fewer than 151 tabs', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 150
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      false
+    )
+    wrapper.setProps({
+      user: {
+        ...modifiedProps.user,
+        tabs: 151,
+      },
+    })
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      true
+    )
+  })
+
+  it('does not show the search intro button when the user has previously clicked it', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(true)
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      false
+    )
+  })
+
+  it('hides the search intro button when the UserMenu onClickSparklySearchIntroButton callback is called', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    hasUserClickedNewTabSearchIntroNotifV2.mockReturnValue(false)
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      true
+    )
+    wrapper.find(UserMenu).prop('onClickSparklySearchIntroButton')()
+    wrapper.update()
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      false
+    )
+  })
+
+  it('saves the search intro click action to local storage when the UserMenu onClickSparklySearchIntroButton callback is called', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    wrapper.find(UserMenu).prop('onClickSparklySearchIntroButton')()
+    expect(setUserClickedNewTabSearchIntroNotifV2).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the search intro button when the UserMenu onClickSparklySearchIntroButton callback is called', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      true
+    )
+    wrapper.find(UserMenu).prop('onClickSparklySearchIntroButton')()
+    expect(wrapper.find(UserMenu).prop('showSparklySearchIntroButton')).toBe(
+      false
+    )
+  })
+
+  it('passes the browser name to the UserMenu component', async () => {
+    expect.assertions(1)
+    detectSupportedBrowser.mockReturnValue(FIREFOX_BROWSER)
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const modifiedProps = cloneDeep(mockProps)
+    modifiedProps.user.tabs = 160
+    const wrapper = shallow(<DashboardComponent {...modifiedProps} />)
+    expect(wrapper.find(UserMenu).prop('browser')).toEqual('firefox')
   })
 })
 

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -10,7 +10,13 @@ import MoneyRaised from 'js/components/MoneyRaised/MoneyRaisedContainer'
 import Hearts from 'js/components/Dashboard/HeartsContainer'
 import SettingsButton from 'js/components/Dashboard/SettingsButtonComponent'
 import { logout } from 'js/authentication/user'
-import { goTo, inviteFriendsURL, loginURL } from 'js/navigation/navigation'
+import {
+  goTo,
+  inviteFriendsURL,
+  loginURL,
+  searchChromeExtensionPage,
+  searchFirefoxExtensionPage,
+} from 'js/navigation/navigation'
 import logger from 'js/utils/logger'
 import Link from 'js/components/General/Link'
 
@@ -28,6 +34,8 @@ const getMockProps = () => {
     user: {},
     app: {},
     isUserAnonymous: false,
+    showSparklySearchIntroButton: false,
+    onClickSparklySearchIntroButton: jest.fn(),
   }
 }
 
@@ -451,5 +459,103 @@ describe('User menu component: settings dropdown component', () => {
     })
     const onLogoutClickFunc = dropdownElem.prop('onLogoutClick')
     onLogoutClickFunc()
+  })
+})
+
+describe('User menu component: sparkly search intro button', () => {
+  it('shows the sparkly intro button if the showSparklySearchIntroButton prop is true', () => {
+    const mockProps = getMockProps()
+    mockProps.showSparklySearchIntroButton = true
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper.find('[data-test-id="search-intro-sparkly-button"]').exists()
+    ).toBe(true)
+  })
+
+  it('does not show the sparkly intro button if the showSparklySearchIntroButton prop is false', () => {
+    const mockProps = getMockProps()
+    mockProps.showSparklySearchIntroButton = false
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper.find('[data-test-id="search-intro-sparkly-button"]').exists()
+    ).toBe(false)
+  })
+
+  it('contains the expected text', () => {
+    const mockProps = getMockProps()
+    mockProps.showSparklySearchIntroButton = true
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-sparkly-button"]')
+        .find(Link)
+        .render()
+        .text()
+    ).toEqual('Double your impact')
+  })
+
+  it('links to the Chrome Web Store when the browser prop === "chrome"', () => {
+    const mockProps = getMockProps()
+    mockProps.browser = 'chrome'
+    mockProps.showSparklySearchIntroButton = true
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-sparkly-button"]')
+        .find(Link)
+        .prop('to')
+    ).toEqual(searchChromeExtensionPage)
+  })
+
+  it('links to the Firefox Addons page when the browser prop === "firefox"', () => {
+    const mockProps = getMockProps()
+    mockProps.browser = 'firefox'
+    mockProps.showSparklySearchIntroButton = true
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-sparkly-button"]')
+        .find(Link)
+        .prop('to')
+    ).toEqual(searchFirefoxExtensionPage)
+  })
+
+  it('links to the Chrome Web Store when the browser prop === "unsupported"', () => {
+    const mockProps = getMockProps()
+    mockProps.browser = 'other'
+    mockProps.showSparklySearchIntroButton = true
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="search-intro-sparkly-button"]')
+        .find(Link)
+        .prop('to')
+    ).toEqual(searchChromeExtensionPage)
+  })
+
+  it('calls the onClickSparklySearchIntroButton prop when clicked', () => {
+    const mockProps = getMockProps()
+    mockProps.showSparklySearchIntroButton = true
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(mockProps.onClickSparklySearchIntroButton).not.toHaveBeenCalled()
+    wrapper
+      .find('[data-test-id="search-intro-sparkly-button"]')
+      .find(Link)
+      .simulate('click')
+    expect(mockProps.onClickSparklySearchIntroButton).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -24,6 +24,7 @@ jest.mock('js/utils/logger')
 
 const getMockProps = () => {
   return {
+    browser: 'chrome',
     user: {},
     app: {},
     isUserAnonymous: false,

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -71,6 +71,8 @@ export const STORAGE_DISMISSED_AD_EXPLANATION =
   'tab.newUser.dismissedAdExplanation'
 export const STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO =
   'tab.newUser.clickedNewTabSearchIntro'
+export const STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO_V2 =
+  'tab.newUser.clickedNewTabSearchIntroV2'
 
 // tab.experiments: values related to split-testing features
 // We may assign other values to localStorage with the tab.experiments.*

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -357,6 +357,31 @@ describe('local user data manager', () => {
     expect(hasUserClickedNewTabSearchIntroNotif()).toBe(false)
   })
 
+  // setUserClickedNewTabSearchIntroNotifV2 method
+  it('marks the new tab search intro notification(v2) click in localStorage', () => {
+    const {
+      setUserClickedNewTabSearchIntroNotifV2,
+    } = require('js/utils/local-user-data-mgr')
+    setUserClickedNewTabSearchIntroNotifV2()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith(
+      'tab.newUser.clickedNewTabSearchIntroV2',
+      'true'
+    )
+  })
+
+  // hasUserClickedNewTabSearchIntroNotifV2
+  it('gets the new tab search intro notification(v2) click from localStorage', () => {
+    localStorageMgr.setItem('tab.newUser.clickedNewTabSearchIntroV2', 'true')
+    const {
+      hasUserClickedNewTabSearchIntroNotifV2,
+    } = require('js/utils/local-user-data-mgr')
+    expect(hasUserClickedNewTabSearchIntroNotifV2()).toBe(true)
+    localStorageMgr.setItem('tab.newUser.clickedNewTabSearchIntroV2', 'blah')
+    expect(hasUserClickedNewTabSearchIntroNotifV2()).toBe(false)
+    localStorageMgr.removeItem('tab.newUser.clickedNewTabSearchIntroV2')
+    expect(hasUserClickedNewTabSearchIntroNotifV2()).toBe(false)
+  })
+
   // setCampaignDismissTime method
   it('sets the notification dismiss time timestamp in localStorage', () => {
     const { setCampaignDismissTime } = require('js/utils/local-user-data-mgr')

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -12,6 +12,7 @@ import {
   STORAGE_NOTIFICATIONS_DISMISS_TIME,
   STORAGE_CAMPAIGN_DISMISS_TIME,
   STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO,
+  STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO_V2,
 } from 'js/constants'
 
 /**
@@ -231,6 +232,27 @@ export const setUserClickedNewTabSearchIntroNotif = () => {
 export const hasUserClickedNewTabSearchIntroNotif = () => {
   return (
     localStorageMgr.getItem(STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO) === 'true'
+  )
+}
+
+/**
+ * Marks that the user has clicked or dismissed the notification on the
+ * new tab page that introduces Search for a Cause.
+ * @returns {undefined}
+ */
+export const setUserClickedNewTabSearchIntroNotifV2 = () => {
+  localStorageMgr.setItem(STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO_V2, 'true')
+}
+
+/**
+ * Gets whether the user has clicked/dismissed the notification on the
+ * new tab page that introduces Search for a Cause.
+ * @returns {Boolean} Whether the user has clicked/dismissed the notification
+ *   introducing Search.
+ */
+export const hasUserClickedNewTabSearchIntroNotifV2 = () => {
+  return (
+    localStorageMgr.getItem(STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO_V2) === 'true'
   )
 }
 


### PR DESCRIPTION
Create a new Search for a Cause introduction button that appears in the user menu. Meanwhile, keep the original "beta" Search intro message.

* Show the text-heavy, "beta" intro message to all users who:
  * haven't already searched
  * haven't already clicked/dismissed the intro message
  * haven't already interacted with the intro in our previous experiment
  * have opened at least three tabs but fewer than 100 tabs
* Show the sparkly "Double your impact" search intro button to all users who:
  * aren't seeing the search intro message above
  * haven't already searched
  * haven't already clicked the intro button
  * have opened at least 150 tabs
