### PR TITLE
Use a customized query renderer

### DIFF
--- a/web/src/js/components/Authentication/AuthenticationView.js
+++ b/web/src/js/components/Authentication/AuthenticationView.js
@@ -1,72 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import { get } from 'lodash/object'
-import environment from 'js/relay-env'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import AuthenticationContainer from 'js/components/Authentication/AuthenticationContainer'
-import { createNewUser } from 'js/authentication/helpers'
-import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
 import logger from 'js/utils/logger'
 import withUser from 'js/components/General/withUser'
-import { makePromiseCancelable } from 'js/utils/utils'
 
 // Fetch the user from our database if the user is
 // authenticated.
 class AuthenticationView extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      refetchCounter: 0,
-    }
-    this.mounted = false
-    this.createNewUserAttempts = 0
-    this.createNewUserPromise = null
-  }
-
-  componentDidMount() {
-    this.mounted = true
-  }
-
-  componentWillUnmount() {
-    if (this.createNewUserPromise && this.createNewUserPromise.cancel) {
-      this.createNewUserPromise.cancel()
-    }
-    this.mounted = false
-  }
-
-  // If we have an authed user with a user ID, fetch the
-  // user from our database.
-  // This will force Relay to refetch by modifying the
-  // variables object. We could also use the `retry`
-  // QueryRenderer function instead.
-  // Pass this to children to allow a forced refetch after
-  // we create a new user in our database.
-  async fetchUser() {
-    // This is an antipattern, and canceling our promises on unmount
-    // should handle the problem. However, in practice, the component
-    // sometimes unmounts between the userCreatePromise resolving and
-    // this point, causing an error when we try to update state on the
-    // unmounted component. It shouldn't cause a memory leak, as we've
-    // also canceled the promise.
-    // Note that this might be an error in our code, but it's not a
-    // priority to investigate.
-    if (!this.mounted) {
-      return
-    }
-    const { refetchCounter } = this.state
-    this.setState({
-      refetchCounter: refetchCounter + 1,
-    })
-  }
-
   render() {
     const { authUser } = this.props
-    const { refetchCounter } = this.state
     const userId = authUser && authUser.id ? authUser.id : null
     return (
-      <QueryRenderer
-        environment={environment}
+      <QueryRendererWithUser
         query={
           userId
             ? graphql`
@@ -82,40 +30,12 @@ class AuthenticationView extends React.Component {
           userId
             ? {
                 userId: userId,
-                refetchCounter: refetchCounter,
               }
             : {}
         }
-        render={({ error, props }) => {
+        render={({ error, props, retry }) => {
           if (error && get(error, 'source.errors')) {
-            // If any of the errors is because the user does not exist
-            // on the server side, create the user and re-query if
-            // possible.
-            const userDoesNotExistError = error.source.errors.some(
-              err => err.code === ERROR_USER_DOES_NOT_EXIST
-            )
-
-            // Limit the number of times we try to refetch a user after
-            // trying to create the user to prevent a loop in case of
-            // any bugs.
-            if (userDoesNotExistError && this.createNewUserAttempts < 3) {
-              this.createNewUserAttempts = this.createNewUserAttempts + 1
-
-              // Cancel new user creation on unmount.
-              this.createNewUserPromise = makePromiseCancelable(createNewUser())
-              this.createNewUserPromise.promise
-                .then(user => {
-                  this.fetchUser()
-                })
-                .catch(e => {
-                  if (e && e.isCanceled) {
-                    return
-                  }
-                  throw e
-                })
-            } else {
-              logger.error(error)
-            }
+            logger.error(error)
           }
 
           // Wait for the query to return to render content.
@@ -123,10 +43,11 @@ class AuthenticationView extends React.Component {
             return null
           }
           const user = props.user || null
+          const fetchUserFunc = retry || function() {}
           return (
             <AuthenticationContainer
               user={user}
-              fetchUser={this.fetchUser.bind(this)}
+              fetchUser={fetchUserFunc}
               {...this.props}
             />
           )

--- a/web/src/js/components/Authentication/__tests__/AuthenticationView.test.js
+++ b/web/src/js/components/Authentication/__tests__/AuthenticationView.test.js
@@ -2,16 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import AuthenticationView from 'js/components/Authentication/AuthenticationView'
-import { QueryRenderer } from 'react-relay'
 import AuthenticationContainer from 'js/components/Authentication/AuthenticationContainer'
-import { createNewUser } from 'js/authentication/helpers'
-import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
 import { __setMockAuthUser } from 'js/components/General/withUser'
 import { flushAllPromises } from 'js/utils/test-utils'
-import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/Authentication/AuthenticationContainer')
 jest.mock('js/authentication/helpers')
 jest.mock('js/components/General/withUser')
@@ -55,7 +52,7 @@ describe('AuthenticationView', () => {
     shallow(<AuthenticationView />).dive()
   })
 
-  it('QueryRenderer receives the "variables" prop', async () => {
+  it('QueryRendererWithUser receives the "variables" prop', async () => {
     expect.assertions(1)
 
     __setMockAuthUser({
@@ -65,15 +62,14 @@ describe('AuthenticationView', () => {
       isAnonymous: false,
       emailVerified: true,
     })
-    const wrapper = mount(<AuthenticationView />)
+    const wrapper = shallow(<AuthenticationView />).dive()
     wrapper.update()
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'abc123xyz456',
-      refetchCounter: 0,
     })
   })
 
-  it('QueryRenderer receives the "query" prop', async () => {
+  it('QueryRendererWithUser receives the "query" prop', async () => {
     expect.assertions(1)
 
     __setMockAuthUser({
@@ -83,27 +79,27 @@ describe('AuthenticationView', () => {
       isAnonymous: false,
       emailVerified: true,
     })
-    const wrapper = mount(<AuthenticationView />)
+    const wrapper = shallow(<AuthenticationView />).dive()
     wrapper.update()
-    expect(wrapper.find(QueryRenderer).prop('query')).toEqual(
+    expect(wrapper.find(QueryRendererWithUser).prop('query')).toEqual(
       expect.any(Function)
     )
   })
 
-  it('QueryRenderer receives empty "variables" and "query" props if there is no authed user', async () => {
+  it('QueryRendererWithUser receives empty "variables" and "query" props if there is no authed user', async () => {
     expect.assertions(2)
 
     __setMockAuthUser(null)
-    const wrapper = mount(<AuthenticationView />)
+    const wrapper = shallow(<AuthenticationView />).dive()
     wrapper.update()
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({})
-    expect(wrapper.find(QueryRenderer).prop('query')).toBeUndefined()
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({})
+    expect(wrapper.find(QueryRendererWithUser).prop('query')).toBeUndefined()
   })
 
   it('does not render AuthenticationContainer before receiving a query response', async () => {
     expect.assertions(1)
     __setMockAuthUser(null)
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -130,7 +126,7 @@ describe('AuthenticationView', () => {
         username: 'MyUsername',
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeProps,
       retry: jest.fn(),
@@ -144,211 +140,64 @@ describe('AuthenticationView', () => {
     expect(authContainer.prop('user')).toEqual(fakeProps.user)
   })
 
-  it('attempts to create a new user and refetch when there is a "user does not exist" error', async () => {
-    expect.assertions(2)
-
-    __setMockAuthUser({
-      id: 'acbdegfh2468',
-      email: 'foo@example.com',
-      username: 'example',
-      isAnonymous: false,
-      emailVerified: true,
-    })
-
-    // Have the server return an error on the first request.
-    const mockRetryFn = jest.fn()
-    QueryRenderer.__setQueryResponseOnce({
-      error: {
-        name: 'RelayNetwork',
-        type: 'mustfix',
-        framesToPop: 2,
-        source: {
-          errors: [
-            {
-              message: 'No user exists with this ID.',
-              locations: [
-                {
-                  line: 8,
-                  column: 3,
-                },
-              ],
-              path: ['user'],
-              code: ERROR_USER_DOES_NOT_EXIST,
-            },
-          ],
-          operation: { foo: 'bar' },
-          variables: { foo: 'baz' },
-        },
-      },
-      props: null,
-      retry: mockRetryFn,
-    })
-
-    // The server returns the user on the second request.
-    QueryRenderer.__setQueryResponse({
-      error: null,
-      props: {
-        user: {
-          id: 'acbdegfh2468',
-          email: 'foo@example.com',
-          username: null,
-        },
-      },
-      retry: jest.fn(),
-    })
-
-    createNewUser.mockResolvedValue({
-      id: 'acbdegfh2468',
-      username: null,
-      email: null,
-    })
-
-    const wrapper = mount(<AuthenticationView />)
-    await flushAllPromises()
-    wrapper.update()
-
-    expect(createNewUser).toHaveBeenCalledTimes(1)
-
-    // Incrementing the refetchCounter variable will cause a
-    // refetch of data.
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
-      userId: 'acbdegfh2468',
-      refetchCounter: 1,
-    })
-  })
-
-  it('only tries to refetch a user 3 times when there is a repeated "user does not exist" error', async () => {
-    expect.assertions(2)
-
+  it('passes the "retry" prop to the AuthenticationContainer as the "fetchUser" prop', async () => {
+    expect.assertions(1)
     __setMockAuthUser({
       id: 'abc123xyz456',
       email: 'foo@example.com',
-      username: 'example',
+      username: null,
       isAnonymous: false,
       emailVerified: true,
     })
-
-    // Have the server return an error every time. This would only
-    // happen if there's a server-side bug.
-    const mockRetryFn = jest.fn()
-    QueryRenderer.__setQueryResponse({
-      error: {
-        name: 'RelayNetwork',
-        type: 'mustfix',
-        framesToPop: 2,
-        source: {
-          errors: [
-            {
-              message: 'No user exists with this ID.',
-              locations: [
-                {
-                  line: 8,
-                  column: 3,
-                },
-              ],
-              path: ['user'],
-              code: ERROR_USER_DOES_NOT_EXIST,
-            },
-          ],
-          operation: { foo: 'bar' },
-          variables: { foo: 'baz' },
-        },
+    const fakeProps = {
+      user: {
+        id: 'abc123xyz456',
+        email: 'foo@example.com',
+        username: 'MyUsername',
       },
-      props: null,
+    }
+    const mockRetryFn = jest.fn()
+    QueryRendererWithUser.__setQueryResponse({
+      error: null,
+      props: fakeProps,
       retry: mockRetryFn,
-    })
-
-    createNewUser.mockResolvedValue({
-      id: 'acbdegfh2468',
-      username: null,
-      email: null,
     })
 
     const wrapper = mount(<AuthenticationView />)
     await flushAllPromises()
     wrapper.update()
 
-    expect(createNewUser).toHaveBeenCalledTimes(3)
-    expect(logger.error).toHaveBeenCalledTimes(1)
+    const authContainer = wrapper.find(AuthenticationContainer)
+    expect(authContainer.prop('fetchUser')).toEqual(mockRetryFn)
   })
 
-  // Note: Jest warnings will fail the test, because we include this
-  // in our setupTests.js file:
-  // https://github.com/facebook/jest/issues/6121#issuecomment-444269677
-  it('does not throw or log an error if the component unmounts during the async createNewUser call', async () => {
+  it('passes a function to the AuthenticationContainer as the "fetchUser" prop even when the "retry" function does not exist', async () => {
     expect.assertions(1)
-
     __setMockAuthUser({
-      id: 'acbdegfh2468',
+      id: 'abc123xyz456',
       email: 'foo@example.com',
-      username: 'example',
+      username: null,
       isAnonymous: false,
       emailVerified: true,
     })
-
-    // Have the server return an error on the first request.
-    const mockRetryFn = jest.fn()
-    QueryRenderer.__setQueryResponseOnce({
-      error: {
-        name: 'RelayNetwork',
-        type: 'mustfix',
-        framesToPop: 2,
-        source: {
-          errors: [
-            {
-              message: 'No user exists with this ID.',
-              locations: [
-                {
-                  line: 8,
-                  column: 3,
-                },
-              ],
-              path: ['user'],
-              code: ERROR_USER_DOES_NOT_EXIST,
-            },
-          ],
-          operation: { foo: 'bar' },
-          variables: { foo: 'baz' },
-        },
+    const fakeProps = {
+      user: {
+        id: 'abc123xyz456',
+        email: 'foo@example.com',
+        username: 'MyUsername',
       },
-      props: null,
-      retry: mockRetryFn,
-    })
-
-    // The server returns the user on the second request.
-    QueryRenderer.__setQueryResponse({
+    }
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
-      props: {
-        user: {
-          id: 'acbdegfh2468',
-          email: 'foo@example.com',
-          username: null,
-        },
-      },
-      retry: jest.fn(),
-    })
-
-    jest.useFakeTimers()
-    createNewUser.mockImplementation(() => {
-      return new Promise((resolve, reject) => {
-        setTimeout(() => {
-          resolve({
-            id: 'acbdegfh2468',
-            username: null,
-            email: 'foo@example.com',
-          })
-        }, 8e3)
-      })
+      props: fakeProps,
+      retry: undefined,
     })
 
     const wrapper = mount(<AuthenticationView />)
     await flushAllPromises()
+    wrapper.update()
 
-    // Unmount
-    wrapper.unmount()
-
-    jest.advanceTimersByTime(10e3)
-    await flushAllPromises()
-    expect(logger.error).not.toHaveBeenCalled()
+    const authContainer = wrapper.find(AuthenticationContainer)
+    expect(authContainer.prop('fetchUser')).toEqual(expect.any(Function))
   })
 })

--- a/web/src/js/components/Campaign/CampaignBaseView.js
+++ b/web/src/js/components/Campaign/CampaignBaseView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 import withUser from 'js/components/General/withUser'
 import CampaignBase from 'js/components/Campaign/CampaignBase'
 import logger from 'js/utils/logger'
@@ -17,8 +16,7 @@ class CampaignBaseView extends React.Component {
     const CHARITY_ID = 'b92989f8-2771-421a-b170-a39d4e765dab'
 
     return (
-      <QueryRenderer
-        environment={environment}
+      <QueryRendererWithUser
         // Hardcode campaign-specific data requirements here, and remove
         // after the campaign is no longer live.
         query={graphql`

--- a/web/src/js/components/Campaign/__tests__/CampaignBaseView.test.js
+++ b/web/src/js/components/Campaign/__tests__/CampaignBaseView.test.js
@@ -1,10 +1,10 @@
 /* eslint-env jest */
 
 import React from 'react'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import { shallow } from 'enzyme'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/local-user-data-mgr')
 
@@ -19,7 +19,7 @@ describe('Campaign base view', () => {
       .default
     const mockProps = getMockProps()
     const wrapper = shallow(<CampaignBaseView {...mockProps} />).dive()
-    expect(wrapper.find(QueryRenderer).length).toBe(1)
+    expect(wrapper.find(QueryRendererWithUser).length).toBe(1)
   })
 
   it("uses the authed user's user ID in the query", () => {
@@ -28,9 +28,8 @@ describe('Campaign base view', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<CampaignBaseView {...mockProps} />).dive()
     const mockUserId = 'abc123xyz456' // from mocked `withUser` function
-    expect(wrapper.find(QueryRenderer).prop('variables')).toHaveProperty(
-      'userId',
-      mockUserId
-    )
+    expect(
+      wrapper.find(QueryRendererWithUser).prop('variables')
+    ).toHaveProperty('userId', mockUserId)
   })
 })

--- a/web/src/js/components/Dashboard/DashboardView.js
+++ b/web/src/js/components/Dashboard/DashboardView.js
@@ -1,31 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import graphql from 'babel-plugin-relay/macro'
-import { QueryRenderer } from 'react-relay'
 import { get } from 'lodash/object'
-import environment from 'js/relay-env'
 
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import DashboardContainer from 'js/components/Dashboard/DashboardContainer'
-import { createNewUser } from 'js/authentication/helpers'
-import { goTo, loginURL } from 'js/navigation/navigation'
-import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
 import withUser from 'js/components/General/withUser'
-import logger from 'js/utils/logger'
-import { makePromiseCancelable } from 'js/utils/utils'
 
 class DashboardView extends React.Component {
-  constructor(props) {
-    super(props)
-    this.createNewUserPromise = null
-  }
-
-  componentWillUnmount() {
-    if (this.createNewUserPromise && this.createNewUserPromise.cancel) {
-      this.createNewUserPromise.cancel()
-    }
-  }
-
   render() {
     const { authUser } = this.props
     return (
@@ -35,8 +18,7 @@ class DashboardView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query DashboardViewQuery($userId: String!) {
               app {
@@ -52,34 +34,8 @@ class DashboardView extends React.Component {
           }}
           render={({ error, props, retry }) => {
             if (error && get(error, 'source.errors')) {
-              // If any of the errors is because the user does not exist
-              // on the server side, create the user and re-query if
-              // possible. If it's not possible to create a new user,
-              // redirect to the authentication page.
-              const userDoesNotExistError = error.source.errors.some(
-                err => err.code === ERROR_USER_DOES_NOT_EXIST
-              )
-
-              if (userDoesNotExistError) {
-                // Cancel new user creation on unmount.
-                this.createNewUserPromise = makePromiseCancelable(
-                  createNewUser()
-                )
-                this.createNewUserPromise.promise
-                  .then(user => {
-                    retry()
-                  })
-                  .catch(e => {
-                    if (e && e.isCanceled) {
-                      return
-                    }
-                    logger.error(e)
-                    goTo(loginURL)
-                  })
-              } else {
-                const errMsg = 'We had a problem loading your dashboard :('
-                return <ErrorMessage message={errMsg} />
-              }
+              const errMsg = 'We had a problem loading your dashboard :('
+              return <ErrorMessage message={errMsg} />
             }
             if (!props) {
               props = {}

--- a/web/src/js/components/General/QueryRendererWithUser.js
+++ b/web/src/js/components/General/QueryRendererWithUser.js
@@ -30,6 +30,7 @@ class QueryRendererWithUser extends React.Component {
       <QueryRenderer
         environment={environment}
         render={({ error, props, retry }) => {
+          var errToPassToChild = error
           if (error && get(error, 'source.errors')) {
             // If any of the errors is because the user does not exist
             // on the server side, create the user and re-query if
@@ -45,6 +46,10 @@ class QueryRendererWithUser extends React.Component {
               userDoesNotExistError &&
               this.createNewUserAttempts < MAX_CREATE_USER_ATTEMPTS
             ) {
+              // While we're trying to create the server-side user, don't
+              // pass an error to the child.
+              errToPassToChild = null
+
               this.createNewUserAttempts = this.createNewUserAttempts + 1
 
               // Cancel new user creation on unmount.
@@ -64,7 +69,7 @@ class QueryRendererWithUser extends React.Component {
             }
           }
 
-          return render({ error, props, retry })
+          return render({ error: errToPassToChild, props, retry })
         }}
         {...otherProps}
       />

--- a/web/src/js/components/General/QueryRendererWithUser.js
+++ b/web/src/js/components/General/QueryRendererWithUser.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { QueryRenderer } from 'react-relay'
+import { get } from 'lodash/object'
+import environment from 'js/relay-env'
+import { createNewUser } from 'js/authentication/helpers'
+import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
+import logger from 'js/utils/logger'
+import { makePromiseCancelable } from 'js/utils/utils'
+
+const MAX_CREATE_USER_ATTEMPTS = 5
+
+// Extend QueryRenderer to handle some common scenarios.
+class QueryRendererWithUser extends React.Component {
+  constructor(props) {
+    super(props)
+    this.createNewUserAttempts = 0
+    this.createNewUserPromise = null
+  }
+
+  componentWillUnmount() {
+    if (this.createNewUserPromise && this.createNewUserPromise.cancel) {
+      this.createNewUserPromise.cancel()
+    }
+  }
+
+  render() {
+    const { render, ...otherProps } = this.props
+    return (
+      <QueryRenderer
+        environment={environment}
+        render={({ error, props, retry }) => {
+          if (error && get(error, 'source.errors')) {
+            // If any of the errors is because the user does not exist
+            // on the server side, create the user and re-query if
+            // possible.
+            const userDoesNotExistError = error.source.errors.some(
+              err => err.code === ERROR_USER_DOES_NOT_EXIST
+            )
+
+            // Limit the number of times we try to refetch a user after
+            // trying to create the user to prevent a loop in case of
+            // any bugs.
+            if (
+              userDoesNotExistError &&
+              this.createNewUserAttempts < MAX_CREATE_USER_ATTEMPTS
+            ) {
+              this.createNewUserAttempts = this.createNewUserAttempts + 1
+
+              // Cancel new user creation on unmount.
+              this.createNewUserPromise = makePromiseCancelable(createNewUser())
+              this.createNewUserPromise.promise
+                .then(user => {
+                  retry()
+                })
+                .catch(e => {
+                  if (e && e.isCanceled) {
+                    return
+                  }
+                  logger.error(e)
+                })
+            } else {
+              logger.error(error)
+            }
+          }
+
+          return render({ error, props, retry })
+        }}
+        {...otherProps}
+      />
+    )
+  }
+}
+
+QueryRendererWithUser.propTypes = {
+  render: PropTypes.func.isRequired,
+}
+
+QueryRendererWithUser.defaultProps = {}
+
+export default QueryRendererWithUser

--- a/web/src/js/components/General/QueryRendererWithUser.js
+++ b/web/src/js/components/General/QueryRendererWithUser.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import { get } from 'lodash/object'
-import environment from 'js/relay-env'
 import { createNewUser } from 'js/authentication/helpers'
 import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
 import logger from 'js/utils/logger'
@@ -28,7 +27,6 @@ class QueryRendererWithUser extends React.Component {
     const { render, ...otherProps } = this.props
     return (
       <QueryRenderer
-        environment={environment}
         render={({ error, props, retry }) => {
           var errToPassToChild = error
           if (error && get(error, 'source.errors')) {

--- a/web/src/js/components/General/QueryRendererWithUser.js
+++ b/web/src/js/components/General/QueryRendererWithUser.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { QueryRenderer } from 'react-relay'
 import { get } from 'lodash/object'
+import environment from 'js/relay-env'
 import { createNewUser } from 'js/authentication/helpers'
 import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
 import logger from 'js/utils/logger'
@@ -27,6 +28,7 @@ class QueryRendererWithUser extends React.Component {
     const { render, ...otherProps } = this.props
     return (
       <QueryRenderer
+        environment={environment}
         render={({ error, props, retry }) => {
           var errToPassToChild = error
           if (error && get(error, 'source.errors')) {

--- a/web/src/js/components/General/__mocks__/QueryRendererWithUser.js
+++ b/web/src/js/components/General/__mocks__/QueryRendererWithUser.js
@@ -1,0 +1,7 @@
+/* eslint-env jest */
+
+// Use our react-relay QR mock for now.
+import { QueryRenderer } from 'react-relay'
+jest.mock('react-relay')
+
+export default QueryRenderer

--- a/web/src/js/components/General/__tests__/QueryRendererWithUser.test.js
+++ b/web/src/js/components/General/__tests__/QueryRendererWithUser.test.js
@@ -28,12 +28,20 @@ const getMockProps = () => ({
   },
 })
 
+beforeAll(() => {
+  jest.useFakeTimers()
+})
+
 beforeEach(() => {
   createNewUser.mockResolvedValue({
     id: 'abc-123',
     username: 'timmy',
     email: 'tturner@example.com',
   })
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
 })
 
 describe('QueryRendererWithUser', () => {
@@ -76,20 +84,31 @@ describe('QueryRendererWithUser', () => {
     expect(mockProps.render).toHaveBeenCalledWith(mockQueryResponse)
   })
 
-  // TODO
-  // it('passes render prop values to the child QueryRenderer\'s render function', async () => {
-  //   expect.assertions(1)
-  //   const mockProps = getMockProps()
-  //   const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
-  //   const mockQueryResponse = {
-  //     error: null,
-  //     props: null,
-  //     retry: jest.fn(),
-  //   }
-  //   const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
-  //   ourQueryRendererRenderFn(mockQueryResponse)
-  //   expect(mockProps.render).toHaveBeenCalledWith(mockQueryResponse)
-  // })
+  it("passes render prop values to the child QueryRenderer's render function", async () => {
+    expect.assertions(1)
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    const mockQueryResponse = {
+      error: null,
+      props: {
+        user: {
+          hi: 'there',
+        },
+      },
+      retry: jest.fn(),
+    }
+    const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+    ourQueryRendererRenderFn(mockQueryResponse)
+    expect(mockProps.render).toHaveBeenCalledWith({
+      props: {
+        user: {
+          hi: 'there',
+        },
+      },
+      error: null,
+      retry: expect.any(Function),
+    })
+  })
 
   it('attempts to create a new user and refetch when there is a "user does not exist" error', async () => {
     expect.assertions(2)
@@ -124,19 +143,6 @@ describe('QueryRendererWithUser', () => {
       retry: mockRetryFn,
     }
 
-    // Mock that the server returns the user on the second request.
-    // const mockQueryResponseNumberTwo = {
-    //   error: null,
-    //   props: {
-    //     user: {
-    //       id: 'acbdegfh2468',
-    //       email: 'foo@example.com',
-    //       username: null,
-    //     },
-    //   },
-    //   retry: jest.fn(),
-    // }
-
     const mockProps = getMockProps()
     const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
     const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
@@ -146,212 +152,138 @@ describe('QueryRendererWithUser', () => {
     expect(mockRetryFn).toHaveBeenCalledTimes(1)
   })
 
-  // TODO
-  //   it('attempts to create a new user and refetch when there is a "user does not exist" error', async () => {
-  //     expect.assertions(2)
-  //
-  //     __setMockAuthUser({
-  //       id: 'acbdegfh2468',
-  //       email: 'foo@example.com',
-  //       username: 'example',
-  //       isAnonymous: false,
-  //       emailVerified: true,
-  //     })
-  //
-  //     // Have the server return an error on the first request.
-  //     const mockRetryFn = jest.fn()
-  //     QueryRenderer.__setQueryResponseOnce({
-  //       error: {
-  //         name: 'RelayNetwork',
-  //         type: 'mustfix',
-  //         framesToPop: 2,
-  //         source: {
-  //           errors: [
-  //             {
-  //               message: 'No user exists with this ID.',
-  //               locations: [
-  //                 {
-  //                   line: 8,
-  //                   column: 3,
-  //                 },
-  //               ],
-  //               path: ['user'],
-  //               code: ERROR_USER_DOES_NOT_EXIST,
-  //             },
-  //           ],
-  //           operation: { foo: 'bar' },
-  //           variables: { foo: 'baz' },
-  //         },
-  //       },
-  //       props: null,
-  //       retry: mockRetryFn,
-  //     })
-  //
-  //     // The server returns the user on the second request.
-  //     QueryRenderer.__setQueryResponse({
-  //       error: null,
-  //       props: {
-  //         user: {
-  //           id: 'acbdegfh2468',
-  //           email: 'foo@example.com',
-  //           username: null,
-  //         },
-  //       },
-  //       retry: jest.fn(),
-  //     })
-  //
-  //     createNewUser.mockResolvedValue({
-  //       id: 'acbdegfh2468',
-  //       username: null,
-  //       email: null,
-  //     })
-  //
-  //     const wrapper = mount(<QueryRendererWithUser />)
-  //     await flushAllPromises()
-  //     wrapper.update()
-  //
-  //     expect(createNewUser).toHaveBeenCalledTimes(1)
-  //
-  //     // Incrementing the refetchCounter variable will cause a
-  //     // refetch of data.
-  //     expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
-  //       userId: 'acbdegfh2468',
-  //       refetchCounter: 1,
-  //     })
-  //   })
-  //
-  //   it('only tries to refetch a user 3 times when there is a repeated "user does not exist" error', async () => {
-  //     expect.assertions(2)
-  //
-  //     __setMockAuthUser({
-  //       id: 'abc123xyz456',
-  //       email: 'foo@example.com',
-  //       username: 'example',
-  //       isAnonymous: false,
-  //       emailVerified: true,
-  //     })
-  //
-  //     // Have the server return an error every time. This would only
-  //     // happen if there's a server-side bug.
-  //     const mockRetryFn = jest.fn()
-  //     QueryRenderer.__setQueryResponse({
-  //       error: {
-  //         name: 'RelayNetwork',
-  //         type: 'mustfix',
-  //         framesToPop: 2,
-  //         source: {
-  //           errors: [
-  //             {
-  //               message: 'No user exists with this ID.',
-  //               locations: [
-  //                 {
-  //                   line: 8,
-  //                   column: 3,
-  //                 },
-  //               ],
-  //               path: ['user'],
-  //               code: ERROR_USER_DOES_NOT_EXIST,
-  //             },
-  //           ],
-  //           operation: { foo: 'bar' },
-  //           variables: { foo: 'baz' },
-  //         },
-  //       },
-  //       props: null,
-  //       retry: mockRetryFn,
-  //     })
-  //
-  //     createNewUser.mockResolvedValue({
-  //       id: 'acbdegfh2468',
-  //       username: null,
-  //       email: null,
-  //     })
-  //
-  //     const wrapper = mount(<QueryRendererWithUser />)
-  //     await flushAllPromises()
-  //     wrapper.update()
-  //
-  //     expect(createNewUser).toHaveBeenCalledTimes(3)
-  //     expect(logger.error).toHaveBeenCalledTimes(1)
-  //   })
-  //
-  //   // Note: Jest warnings will fail the test, because we include this
-  //   // in our setupTests.js file:
-  //   // https://github.com/facebook/jest/issues/6121#issuecomment-444269677
-  //   it('does not throw or log an error if the component unmounts during the async createNewUser call', async () => {
-  //     expect.assertions(1)
-  //
-  //     __setMockAuthUser({
-  //       id: 'acbdegfh2468',
-  //       email: 'foo@example.com',
-  //       username: 'example',
-  //       isAnonymous: false,
-  //       emailVerified: true,
-  //     })
-  //
-  //     // Have the server return an error on the first request.
-  //     const mockRetryFn = jest.fn()
-  //     QueryRenderer.__setQueryResponseOnce({
-  //       error: {
-  //         name: 'RelayNetwork',
-  //         type: 'mustfix',
-  //         framesToPop: 2,
-  //         source: {
-  //           errors: [
-  //             {
-  //               message: 'No user exists with this ID.',
-  //               locations: [
-  //                 {
-  //                   line: 8,
-  //                   column: 3,
-  //                 },
-  //               ],
-  //               path: ['user'],
-  //               code: ERROR_USER_DOES_NOT_EXIST,
-  //             },
-  //           ],
-  //           operation: { foo: 'bar' },
-  //           variables: { foo: 'baz' },
-  //         },
-  //       },
-  //       props: null,
-  //       retry: mockRetryFn,
-  //     })
-  //
-  //     // The server returns the user on the second request.
-  //     QueryRenderer.__setQueryResponse({
-  //       error: null,
-  //       props: {
-  //         user: {
-  //           id: 'acbdegfh2468',
-  //           email: 'foo@example.com',
-  //           username: null,
-  //         },
-  //       },
-  //       retry: jest.fn(),
-  //     })
-  //
-  //     jest.useFakeTimers()
-  //     createNewUser.mockImplementation(() => {
-  //       return new Promise((resolve, reject) => {
-  //         setTimeout(() => {
-  //           resolve({
-  //             id: 'acbdegfh2468',
-  //             username: null,
-  //             email: 'foo@example.com',
-  //           })
-  //         }, 8e3)
-  //       })
-  //     })
-  //
-  //     const wrapper = mount(<QueryRendererWithUser />)
-  //     await flushAllPromises()
-  //
-  //     // Unmount
-  //     wrapper.unmount()
-  //
-  //     jest.advanceTimersByTime(10e3)
-  //     await flushAllPromises()
-  //     expect(logger.error).not.toHaveBeenCalled()
-  //   })
+  it('does not attempt to create a new user when the user already exists', async () => {
+    expect.assertions(2)
+
+    const mockRetryFn = jest.fn()
+
+    // Mock that the server returns the user.
+    const mockQueryResponse = {
+      error: null,
+      props: {
+        user: {
+          id: 'acbdegfh2468',
+          email: 'foo@example.com',
+          username: null,
+        },
+      },
+      retry: jest.fn(),
+    }
+
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+    ourQueryRendererRenderFn(mockQueryResponse)
+    await flushAllPromises()
+    expect(createNewUser).not.toHaveBeenCalled()
+    expect(mockRetryFn).not.toHaveBeenCalled()
+  })
+
+  it('only tries to refetch a user 5 times when there is a repeated "user does not exist" error', async () => {
+    expect.assertions(2)
+
+    const mockRetryFn = jest.fn()
+
+    // Mock an error that the user does not exist server-side.
+    const mockQueryResponse = {
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'No user exists with this ID.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: ERROR_USER_DOES_NOT_EXIST,
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: mockRetryFn,
+    }
+
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+
+    // Mock that the server continues to return the error.
+    for (let i = 0; i < 12; i++) {
+      ourQueryRendererRenderFn(mockQueryResponse)
+    }
+    expect(createNewUser).toHaveBeenCalledTimes(5)
+    expect(logger.error).toHaveBeenCalledTimes(7) // the remaining attempts are error logs
+  })
+
+  // Note: Jest warnings will fail the test, because we include this
+  // in our setupTests.js file:
+  it('does not throw or log an error if the component unmounts during the async createNewUser call', async () => {
+    expect.assertions(2)
+
+    jest.advanceTimersByTime(10e3)
+    await flushAllPromises()
+    expect(logger.error).not.toHaveBeenCalled()
+    const mockRetryFn = jest.fn()
+
+    // Mock an error that the user does not exist server-side.
+    const mockQueryResponse = {
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'No user exists with this ID.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: ERROR_USER_DOES_NOT_EXIST,
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: mockRetryFn,
+    }
+
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+
+    createNewUser.mockImplementation(() => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve({
+            id: 'acbdegfh2468',
+            username: null,
+            email: 'foo@example.com',
+          })
+        }, 8e3)
+      })
+    })
+    const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+    ourQueryRendererRenderFn(mockQueryResponse)
+
+    // Unmount
+    wrapper.unmount()
+
+    jest.advanceTimersByTime(10e3)
+    await flushAllPromises()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
 })

--- a/web/src/js/components/General/__tests__/QueryRendererWithUser.test.js
+++ b/web/src/js/components/General/__tests__/QueryRendererWithUser.test.js
@@ -1,0 +1,357 @@
+/* eslint-env jest */
+
+import React from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import { shallow } from 'enzyme'
+import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
+import { createNewUser } from 'js/authentication/helpers'
+import { ERROR_USER_DOES_NOT_EXIST } from 'js/constants'
+import { flushAllPromises } from 'js/utils/test-utils'
+import logger from 'js/utils/logger'
+
+jest.mock('react-relay')
+jest.mock('js/authentication/helpers')
+jest.mock('js/utils/logger')
+
+const getMockProps = () => ({
+  query: graphql`
+    query AuthenticationViewQuery($userId: String!) {
+      user(userId: $userId) {
+        ...AuthenticationContainer_user
+      }
+    }
+  `,
+  render: jest.fn(),
+  variables: {
+    userId: 'abc-123',
+  },
+})
+
+beforeEach(() => {
+  createNewUser.mockResolvedValue({
+    id: 'abc-123',
+    username: 'timmy',
+    email: 'tturner@example.com',
+  })
+})
+
+describe('QueryRendererWithUser', () => {
+  it('renders without error', () => {
+    const mockProps = getMockProps()
+    shallow(<QueryRendererWithUser {...mockProps} />)
+  })
+
+  it('the react-relay QueryRenderer receives the "variables" prop', async () => {
+    expect.assertions(1)
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    wrapper.update()
+    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+      userId: 'abc-123',
+    })
+  })
+
+  it('the react-relay QueryRenderer receives the "query" prop', async () => {
+    expect.assertions(1)
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    wrapper.update()
+    expect(wrapper.find(QueryRenderer).prop('query')).toEqual(
+      expect.any(Function)
+    )
+  })
+
+  it('calls render before receiving a query response', async () => {
+    expect.assertions(1)
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    const mockQueryResponse = {
+      error: null,
+      props: null,
+      retry: jest.fn(),
+    }
+    const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+    ourQueryRendererRenderFn(mockQueryResponse)
+    expect(mockProps.render).toHaveBeenCalledWith(mockQueryResponse)
+  })
+
+  // TODO
+  // it('passes render prop values to the child QueryRenderer\'s render function', async () => {
+  //   expect.assertions(1)
+  //   const mockProps = getMockProps()
+  //   const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+  //   const mockQueryResponse = {
+  //     error: null,
+  //     props: null,
+  //     retry: jest.fn(),
+  //   }
+  //   const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+  //   ourQueryRendererRenderFn(mockQueryResponse)
+  //   expect(mockProps.render).toHaveBeenCalledWith(mockQueryResponse)
+  // })
+
+  it('attempts to create a new user and refetch when there is a "user does not exist" error', async () => {
+    expect.assertions(2)
+
+    const mockRetryFn = jest.fn()
+
+    // Mock an error that the user does not exist server-side.
+    const mockQueryResponse = {
+      error: {
+        name: 'RelayNetwork',
+        type: 'mustfix',
+        framesToPop: 2,
+        source: {
+          errors: [
+            {
+              message: 'No user exists with this ID.',
+              locations: [
+                {
+                  line: 8,
+                  column: 3,
+                },
+              ],
+              path: ['user'],
+              code: ERROR_USER_DOES_NOT_EXIST,
+            },
+          ],
+          operation: { foo: 'bar' },
+          variables: { foo: 'baz' },
+        },
+      },
+      props: null,
+      retry: mockRetryFn,
+    }
+
+    // Mock that the server returns the user on the second request.
+    // const mockQueryResponseNumberTwo = {
+    //   error: null,
+    //   props: {
+    //     user: {
+    //       id: 'acbdegfh2468',
+    //       email: 'foo@example.com',
+    //       username: null,
+    //     },
+    //   },
+    //   retry: jest.fn(),
+    // }
+
+    const mockProps = getMockProps()
+    const wrapper = shallow(<QueryRendererWithUser {...mockProps} />)
+    const ourQueryRendererRenderFn = wrapper.find(QueryRenderer).prop('render')
+    ourQueryRendererRenderFn(mockQueryResponse)
+    await flushAllPromises()
+    expect(createNewUser).toHaveBeenCalledTimes(1)
+    expect(mockRetryFn).toHaveBeenCalledTimes(1)
+  })
+
+  // TODO
+  //   it('attempts to create a new user and refetch when there is a "user does not exist" error', async () => {
+  //     expect.assertions(2)
+  //
+  //     __setMockAuthUser({
+  //       id: 'acbdegfh2468',
+  //       email: 'foo@example.com',
+  //       username: 'example',
+  //       isAnonymous: false,
+  //       emailVerified: true,
+  //     })
+  //
+  //     // Have the server return an error on the first request.
+  //     const mockRetryFn = jest.fn()
+  //     QueryRenderer.__setQueryResponseOnce({
+  //       error: {
+  //         name: 'RelayNetwork',
+  //         type: 'mustfix',
+  //         framesToPop: 2,
+  //         source: {
+  //           errors: [
+  //             {
+  //               message: 'No user exists with this ID.',
+  //               locations: [
+  //                 {
+  //                   line: 8,
+  //                   column: 3,
+  //                 },
+  //               ],
+  //               path: ['user'],
+  //               code: ERROR_USER_DOES_NOT_EXIST,
+  //             },
+  //           ],
+  //           operation: { foo: 'bar' },
+  //           variables: { foo: 'baz' },
+  //         },
+  //       },
+  //       props: null,
+  //       retry: mockRetryFn,
+  //     })
+  //
+  //     // The server returns the user on the second request.
+  //     QueryRenderer.__setQueryResponse({
+  //       error: null,
+  //       props: {
+  //         user: {
+  //           id: 'acbdegfh2468',
+  //           email: 'foo@example.com',
+  //           username: null,
+  //         },
+  //       },
+  //       retry: jest.fn(),
+  //     })
+  //
+  //     createNewUser.mockResolvedValue({
+  //       id: 'acbdegfh2468',
+  //       username: null,
+  //       email: null,
+  //     })
+  //
+  //     const wrapper = mount(<QueryRendererWithUser />)
+  //     await flushAllPromises()
+  //     wrapper.update()
+  //
+  //     expect(createNewUser).toHaveBeenCalledTimes(1)
+  //
+  //     // Incrementing the refetchCounter variable will cause a
+  //     // refetch of data.
+  //     expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+  //       userId: 'acbdegfh2468',
+  //       refetchCounter: 1,
+  //     })
+  //   })
+  //
+  //   it('only tries to refetch a user 3 times when there is a repeated "user does not exist" error', async () => {
+  //     expect.assertions(2)
+  //
+  //     __setMockAuthUser({
+  //       id: 'abc123xyz456',
+  //       email: 'foo@example.com',
+  //       username: 'example',
+  //       isAnonymous: false,
+  //       emailVerified: true,
+  //     })
+  //
+  //     // Have the server return an error every time. This would only
+  //     // happen if there's a server-side bug.
+  //     const mockRetryFn = jest.fn()
+  //     QueryRenderer.__setQueryResponse({
+  //       error: {
+  //         name: 'RelayNetwork',
+  //         type: 'mustfix',
+  //         framesToPop: 2,
+  //         source: {
+  //           errors: [
+  //             {
+  //               message: 'No user exists with this ID.',
+  //               locations: [
+  //                 {
+  //                   line: 8,
+  //                   column: 3,
+  //                 },
+  //               ],
+  //               path: ['user'],
+  //               code: ERROR_USER_DOES_NOT_EXIST,
+  //             },
+  //           ],
+  //           operation: { foo: 'bar' },
+  //           variables: { foo: 'baz' },
+  //         },
+  //       },
+  //       props: null,
+  //       retry: mockRetryFn,
+  //     })
+  //
+  //     createNewUser.mockResolvedValue({
+  //       id: 'acbdegfh2468',
+  //       username: null,
+  //       email: null,
+  //     })
+  //
+  //     const wrapper = mount(<QueryRendererWithUser />)
+  //     await flushAllPromises()
+  //     wrapper.update()
+  //
+  //     expect(createNewUser).toHaveBeenCalledTimes(3)
+  //     expect(logger.error).toHaveBeenCalledTimes(1)
+  //   })
+  //
+  //   // Note: Jest warnings will fail the test, because we include this
+  //   // in our setupTests.js file:
+  //   // https://github.com/facebook/jest/issues/6121#issuecomment-444269677
+  //   it('does not throw or log an error if the component unmounts during the async createNewUser call', async () => {
+  //     expect.assertions(1)
+  //
+  //     __setMockAuthUser({
+  //       id: 'acbdegfh2468',
+  //       email: 'foo@example.com',
+  //       username: 'example',
+  //       isAnonymous: false,
+  //       emailVerified: true,
+  //     })
+  //
+  //     // Have the server return an error on the first request.
+  //     const mockRetryFn = jest.fn()
+  //     QueryRenderer.__setQueryResponseOnce({
+  //       error: {
+  //         name: 'RelayNetwork',
+  //         type: 'mustfix',
+  //         framesToPop: 2,
+  //         source: {
+  //           errors: [
+  //             {
+  //               message: 'No user exists with this ID.',
+  //               locations: [
+  //                 {
+  //                   line: 8,
+  //                   column: 3,
+  //                 },
+  //               ],
+  //               path: ['user'],
+  //               code: ERROR_USER_DOES_NOT_EXIST,
+  //             },
+  //           ],
+  //           operation: { foo: 'bar' },
+  //           variables: { foo: 'baz' },
+  //         },
+  //       },
+  //       props: null,
+  //       retry: mockRetryFn,
+  //     })
+  //
+  //     // The server returns the user on the second request.
+  //     QueryRenderer.__setQueryResponse({
+  //       error: null,
+  //       props: {
+  //         user: {
+  //           id: 'acbdegfh2468',
+  //           email: 'foo@example.com',
+  //           username: null,
+  //         },
+  //       },
+  //       retry: jest.fn(),
+  //     })
+  //
+  //     jest.useFakeTimers()
+  //     createNewUser.mockImplementation(() => {
+  //       return new Promise((resolve, reject) => {
+  //         setTimeout(() => {
+  //           resolve({
+  //             id: 'acbdegfh2468',
+  //             username: null,
+  //             email: 'foo@example.com',
+  //           })
+  //         }, 8e3)
+  //       })
+  //     })
+  //
+  //     const wrapper = mount(<QueryRendererWithUser />)
+  //     await flushAllPromises()
+  //
+  //     // Unmount
+  //     wrapper.unmount()
+  //
+  //     jest.advanceTimersByTime(10e3)
+  //     await flushAllPromises()
+  //     expect(logger.error).not.toHaveBeenCalled()
+  //   })
+})

--- a/web/src/js/components/Search/SearchMenuQuery.js
+++ b/web/src/js/components/Search/SearchMenuQuery.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 import SearchMenuContainer from 'js/components/Search/SearchMenuContainer'
 import withUser from 'js/components/General/withUser'
 import logger from 'js/utils/logger'
@@ -14,7 +13,7 @@ const SearchMenuQueryRenderer = props => {
   const { userId, ...queryRendererProps } = props
   if (userId) {
     return (
-      <QueryRenderer
+      <QueryRendererWithUser
         query={graphql`
           query SearchMenuQuery($userId: String!) {
             app {
@@ -33,7 +32,7 @@ const SearchMenuQueryRenderer = props => {
     )
   } else {
     return (
-      <QueryRenderer
+      <QueryRendererWithUser
         query={graphql`
           query SearchMenuQueryAnonymousQuery {
             app {
@@ -54,7 +53,6 @@ class SearchMenuQuery extends React.Component {
     return (
       <SearchMenuQueryRenderer
         userId={userId}
-        environment={environment}
         render={({ error, props }) => {
           if (error) {
             logger.error(error)

--- a/web/src/js/components/Search/Settings/SearchProfileInviteFriendView.js
+++ b/web/src/js/components/Search/Settings/SearchProfileInviteFriendView.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
-import environment from 'js/relay-env'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import SearchProfileInviteFriend from 'js/components/Search/Settings/SearchProfileInviteFriendComponent'
@@ -17,8 +16,7 @@ class ProfileInviteFriendView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={null}
           variables={{}}
           render={({ error, props }) => {

--- a/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendView.test.js
+++ b/web/src/js/components/Search/Settings/__tests__/SearchProfileInviteFriendView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import SearchProfileInviteFriendView from 'js/components/Search/Settings/SearchProfileInviteFriendView'
 import SearchProfileInviteFriend from 'js/components/Search/Settings/SearchProfileInviteFriendComponent'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -40,13 +40,13 @@ describe('SearchProfileInviteFriendView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<SearchProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<SearchProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({})
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({})
   })
 
   it('renders the child component without any data', () => {
@@ -57,7 +57,7 @@ describe('SearchProfileInviteFriendView', () => {
   })
 
   it('renders the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -68,7 +68,7 @@ describe('SearchProfileInviteFriendView', () => {
   })
 
   it('passes the expected props to the child component', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: {},
       retry: jest.fn(),
@@ -81,7 +81,7 @@ describe('SearchProfileInviteFriendView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
+++ b/web/src/js/components/Search/__tests__/SearchMenuQuery.test.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { mount, shallow } from 'enzyme'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/withUser')
 jest.mock('js/analytics/logEvent')
 jest.mock('js/components/Search/SearchMenuContainer')
@@ -53,8 +53,9 @@ describe('SearchMenuQuery', () => {
     const SearchMenuQuery = require('js/components/Search/SearchMenuQuery')
       .default
     const wrapper = mount(<SearchMenuQuery />)
-    const { QueryRenderer } = require('react-relay')
-    expect(wrapper.find(QueryRenderer).length).toBe(1)
+    const QueryRendererWithUser = require('js/components/General/QueryRendererWithUser')
+      .default
+    expect(wrapper.find(QueryRendererWithUser).length).toBe(1)
   })
 
   it('QueryRenderer has the "variables" prop when the user is authenticated', () => {
@@ -74,11 +75,11 @@ describe('SearchMenuQuery', () => {
     const SearchMenuQuery = require('js/components/Search/SearchMenuQuery')
       .default
     const wrapper = mount(<SearchMenuQuery />)
-    const { QueryRenderer } = require('react-relay')
-    expect(wrapper.find(QueryRenderer).prop('variables')).toHaveProperty(
-      'userId',
-      'abc123xyz456'
-    )
+    const QueryRendererWithUser = require('js/components/General/QueryRendererWithUser')
+      .default
+    expect(
+      wrapper.find(QueryRendererWithUser).prop('variables')
+    ).toHaveProperty('userId', 'abc123xyz456')
   })
 
   it('QueryRenderer does not have the "variables" prop when the user is not authenticated', () => {
@@ -90,8 +91,11 @@ describe('SearchMenuQuery', () => {
     const SearchMenuQuery = require('js/components/Search/SearchMenuQuery')
       .default
     const wrapper = mount(<SearchMenuQuery />)
-    const { QueryRenderer } = require('react-relay')
-    expect(wrapper.find(QueryRenderer).prop('variables')).not.toBeDefined()
+    const QueryRendererWithUser = require('js/components/General/QueryRendererWithUser')
+      .default
+    expect(
+      wrapper.find(QueryRendererWithUser).prop('variables')
+    ).not.toBeDefined()
   })
 
   it('passes "app", "user", "location" props to the child container when they exist', () => {
@@ -104,8 +108,9 @@ describe('SearchMenuQuery', () => {
         vc: 233,
       },
     }
-    const { QueryRenderer } = require('react-relay')
-    QueryRenderer.__setQueryResponse({
+    const QueryRendererWithUser = require('js/components/General/QueryRendererWithUser')
+      .default
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeProps,
       retry: jest.fn(),
@@ -134,8 +139,9 @@ describe('SearchMenuQuery', () => {
     const fakeProps = {
       app: null,
     }
-    const { QueryRenderer } = require('react-relay')
-    QueryRenderer.__setQueryResponse({
+    const QueryRendererWithUser = require('js/components/General/QueryRendererWithUser')
+      .default
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeProps,
       retry: jest.fn(),
@@ -165,8 +171,9 @@ describe('SearchMenuQuery', () => {
         vc: 233,
       },
     }
-    const { QueryRenderer } = require('react-relay')
-    QueryRenderer.__setQueryResponse({
+    const QueryRendererWithUser = require('js/components/General/QueryRendererWithUser')
+      .default
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeProps,
       retry: jest.fn(),

--- a/web/src/js/components/Settings/Account/AccountView.js
+++ b/web/src/js/components/Settings/Account/AccountView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import Account from 'js/components/Settings/Account/AccountContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
@@ -18,8 +17,7 @@ class AccountView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query AccountViewQuery($userId: String!) {
               user(userId: $userId) {

--- a/web/src/js/components/Settings/Account/__tests__/AccountView.test.js
+++ b/web/src/js/components/Settings/Account/__tests__/AccountView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import AccountView from 'js/components/Settings/Account/AccountView'
 import Account from 'js/components/Settings/Account/AccountContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -47,13 +47,13 @@ describe('AccountView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<AccountView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<AccountView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'example-user-id', // from the authUser prop
     })
   })
@@ -66,7 +66,7 @@ describe('AccountView', () => {
   })
 
   it('does not render the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -83,7 +83,7 @@ describe('AccountView', () => {
         vc: 233,
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeQueryRendererProps,
       retry: jest.fn(),
@@ -97,7 +97,7 @@ describe('AccountView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/components/Settings/Background/BackgroundSettingsView.js
+++ b/web/src/js/components/Settings/Background/BackgroundSettingsView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import BackgroundSettings from 'js/components/Settings/Background/BackgroundSettingsContainer'
@@ -19,8 +18,7 @@ class BackgroundSettingsView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query BackgroundSettingsViewQuery($userId: String!) {
               app {

--- a/web/src/js/components/Settings/Background/__tests__/BackgroundSettingsView.test.js
+++ b/web/src/js/components/Settings/Background/__tests__/BackgroundSettingsView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import BackgroundSettingsView from 'js/components/Settings/Background/BackgroundSettingsView'
 import BackgroundSettings from 'js/components/Settings/Background/BackgroundSettingsContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -47,13 +47,13 @@ describe('BackgroundSettingsView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<BackgroundSettingsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<BackgroundSettingsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'example-user-id', // from the authUser prop
     })
   })
@@ -66,7 +66,7 @@ describe('BackgroundSettingsView', () => {
   })
 
   it('does not render the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -86,7 +86,7 @@ describe('BackgroundSettingsView', () => {
         vc: 233,
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeQueryRendererProps,
       retry: jest.fn(),
@@ -101,7 +101,7 @@ describe('BackgroundSettingsView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileDonateHeartsView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsContainer'
@@ -19,8 +18,7 @@ class ProfileDonateHeartsView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query ProfileDonateHeartsViewQuery($userId: String!) {
               app {

--- a/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
+++ b/web/src/js/components/Settings/Profile/ProfileInviteFriendView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendContainer'
@@ -19,8 +18,7 @@ class ProfileInviteFriendView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query ProfileInviteFriendViewQuery($userId: String!) {
               app {

--- a/web/src/js/components/Settings/Profile/ProfileStatsView.js
+++ b/web/src/js/components/Settings/Profile/ProfileStatsView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import ProfileStats from 'js/components/Settings/Profile/ProfileStatsContainer'
@@ -19,8 +18,7 @@ class ProfileStatsView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query ProfileStatsViewQuery($userId: String!) {
               user(userId: $userId) {

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsView.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileDonateHeartsView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import ProfileDonateHeartsView from 'js/components/Settings/Profile/ProfileDonateHeartsView'
 import ProfileDonateHearts from 'js/components/Settings/Profile/ProfileDonateHeartsContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -47,13 +47,13 @@ describe('ProfileDonateHeartsView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<ProfileDonateHeartsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<ProfileDonateHeartsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'example-user-id', // from the authUser prop
     })
   })
@@ -66,7 +66,7 @@ describe('ProfileDonateHeartsView', () => {
   })
 
   it('does not render the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -86,7 +86,7 @@ describe('ProfileDonateHeartsView', () => {
         vc: 233,
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeQueryRendererProps,
       retry: jest.fn(),
@@ -101,7 +101,7 @@ describe('ProfileDonateHeartsView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendView.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileInviteFriendView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import ProfileInviteFriendView from 'js/components/Settings/Profile/ProfileInviteFriendView'
 import ProfileInviteFriend from 'js/components/Settings/Profile/ProfileInviteFriendContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -47,13 +47,13 @@ describe('ProfileInviteFriendView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<ProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<ProfileInviteFriendView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'example-user-id', // from the authUser prop
     })
   })
@@ -66,7 +66,7 @@ describe('ProfileInviteFriendView', () => {
   })
 
   it('does not render the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -86,7 +86,7 @@ describe('ProfileInviteFriendView', () => {
         vc: 233,
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeQueryRendererProps,
       retry: jest.fn(),
@@ -101,7 +101,7 @@ describe('ProfileInviteFriendView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/components/Settings/Profile/__tests__/ProfileStatsView.test.js
+++ b/web/src/js/components/Settings/Profile/__tests__/ProfileStatsView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import ProfileStatsView from 'js/components/Settings/Profile/ProfileStatsView'
 import ProfileStats from 'js/components/Settings/Profile/ProfileStatsContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -47,13 +47,13 @@ describe('ProfileStatsView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<ProfileStatsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<ProfileStatsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'example-user-id', // from the authUser prop
     })
   })
@@ -66,7 +66,7 @@ describe('ProfileStatsView', () => {
   })
 
   it('does not render the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -83,7 +83,7 @@ describe('ProfileStatsView', () => {
         vc: 233,
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeQueryRendererProps,
       retry: jest.fn(),
@@ -97,7 +97,7 @@ describe('ProfileStatsView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
+++ b/web/src/js/components/Settings/Widgets/WidgetsSettingsView.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import graphql from 'babel-plugin-relay/macro'
-import environment from 'js/relay-env'
 
 import SettingsChildWrapper from 'js/components/Settings/SettingsChildWrapperComponent'
 import WidgetsSettings from 'js/components/Settings/Widgets/WidgetsSettingsContainer'
@@ -19,8 +18,7 @@ class WidgetsSettingsView extends React.Component {
           width: '100%',
         }}
       >
-        <QueryRenderer
-          environment={environment}
+        <QueryRendererWithUser
           query={graphql`
             query WidgetsSettingsViewQuery($userId: String!) {
               app {

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsView.test.js
@@ -2,13 +2,13 @@
 
 import React from 'react'
 import { mount, shallow } from 'enzyme'
-import { QueryRenderer } from 'react-relay'
+import QueryRendererWithUser from 'js/components/General/QueryRendererWithUser'
 import WidgetsSettingsView from 'js/components/Settings/Widgets/WidgetsSettingsView'
 import WidgetsSettings from 'js/components/Settings/Widgets/WidgetsSettingsContainer'
 import ErrorMessage from 'js/components/General/ErrorMessage'
 import logger from 'js/utils/logger'
 
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('js/components/General/ErrorMessage')
 jest.mock('js/components/General/withUser')
 jest.mock('js/utils/logger')
@@ -47,13 +47,13 @@ describe('WidgetsSettingsView', () => {
   it('includes a QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = shallow(<WidgetsSettingsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).exists()).toBe(true)
+    expect(wrapper.find(QueryRendererWithUser).exists()).toBe(true)
   })
 
   it('passes the expected variables to the QueryRenderer', () => {
     const mockProps = getMockProps()
     const wrapper = mount(<WidgetsSettingsView {...mockProps} />)
-    expect(wrapper.find(QueryRenderer).prop('variables')).toEqual({
+    expect(wrapper.find(QueryRendererWithUser).prop('variables')).toEqual({
       userId: 'example-user-id', // from the authUser prop
     })
   })
@@ -66,7 +66,7 @@ describe('WidgetsSettingsView', () => {
   })
 
   it('does not render the child component when there is no data', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: null,
       retry: jest.fn(),
@@ -86,7 +86,7 @@ describe('WidgetsSettingsView', () => {
         vc: 233,
       },
     }
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: null,
       props: fakeQueryRendererProps,
       retry: jest.fn(),
@@ -101,7 +101,7 @@ describe('WidgetsSettingsView', () => {
   })
 
   it('logs an error and renders an ErrorMessage if unexpected QueryRenderer errors occur', () => {
-    QueryRenderer.__setQueryResponse({
+    QueryRendererWithUser.__setQueryResponse({
       error: {
         name: 'RelayNetwork',
         type: 'mustfix',

--- a/web/src/js/mutations/__tests__/DonateVcMutation.test.js
+++ b/web/src/js/mutations/__tests__/DonateVcMutation.test.js
@@ -7,7 +7,7 @@ import environment from 'js/relay-env'
 import commitMutation from 'relay-commit-mutation-promise'
 
 jest.mock('js/relay-env')
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('relay-commit-mutation-promise')
 
 const getMockInput = () => ({

--- a/web/src/js/mutations/__tests__/LogReferralLinkClickMutation.test.js
+++ b/web/src/js/mutations/__tests__/LogReferralLinkClickMutation.test.js
@@ -4,7 +4,7 @@ import environment from 'js/relay-env'
 import commitMutation from 'relay-commit-mutation-promise'
 
 jest.mock('js/relay-env')
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('relay-commit-mutation-promise')
 
 const getMockInput = () => ({

--- a/web/src/js/mutations/__tests__/LogSearchMutation.test.js
+++ b/web/src/js/mutations/__tests__/LogSearchMutation.test.js
@@ -4,7 +4,7 @@ import environment from 'js/relay-env'
 import commitMutation from 'relay-commit-mutation-promise'
 
 jest.mock('js/relay-env')
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('relay-commit-mutation-promise')
 
 const getMockInput = () => ({

--- a/web/src/js/mutations/__tests__/LogUserExperimentActionsMutation.test.js
+++ b/web/src/js/mutations/__tests__/LogUserExperimentActionsMutation.test.js
@@ -4,7 +4,7 @@ import environment from 'js/relay-env'
 import commitMutation from 'relay-commit-mutation-promise'
 
 jest.mock('js/relay-env')
-jest.mock('react-relay')
+jest.mock('js/components/General/QueryRendererWithUser')
 jest.mock('relay-commit-mutation-promise')
 
 const getMockInput = () => ({


### PR DESCRIPTION
Create a customized query renderer that handles server-side user creation, which simplifies query renderer logic elsewhere.