### PR TITLE
Create a server-side Campaign object

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -682,8 +682,12 @@ const campaignType = new GraphQLObjectType({
       description: 'the ID of the campaign',
     },
     isLive: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
       description: 'whether or not the campaign should currently show to users',
+    },
+    numNewUsers: {
+      type: GraphQLInt,
+      description: 'the number of new users who joined during this campaign',
     },
   }),
 })

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -82,6 +82,7 @@ import {
   getDollarsPerDayRate,
   isGlobalCampaignLive,
 } from '../database/globals/globals'
+import getCampaign from '../database/globals/getCampaign'
 
 class App {
   constructor(id) {
@@ -672,6 +673,21 @@ const charityType = new GraphQLObjectType({
   interfaces: [nodeInterface],
 })
 
+const campaignType = new GraphQLObjectType({
+  name: 'Campaign',
+  description: 'Campaigns (or "charity spotlights") shown to users.',
+  fields: () => ({
+    campaignId: {
+      type: GraphQLString,
+      description: 'the ID of the campaign',
+    },
+    isLive: {
+      type: GraphQLBoolean,
+      description: 'whether or not the campaign should currently show to users',
+    },
+  }),
+})
+
 const appType = new GraphQLObjectType({
   name: 'App',
   description: 'Global app fields',
@@ -738,9 +754,15 @@ const appType = new GraphQLObjectType({
           args
         ),
     },
+    // Deprecated. Use the campaign object.
     isGlobalCampaignLive: {
       type: GraphQLBoolean,
       resolve: () => isGlobalCampaignLive(),
+    },
+    campaign: {
+      type: campaignType,
+      description: 'Campaigns (or "charity spotlights") shown to users.',
+      resolve: () => getCampaign(),
     },
   }),
   interfaces: [nodeInterface],

--- a/graphql/database/globals/__tests__/getCampaign.test.js
+++ b/graphql/database/globals/__tests__/getCampaign.test.js
@@ -6,7 +6,7 @@ jest.mock('../getCampaignData')
 
 beforeEach(() => {
   getCurrentCampaign.mockReturnValue({
-    id: 'someCampaign',
+    campaignId: 'someCampaign',
     isLive: true,
   })
 })
@@ -15,11 +15,11 @@ describe('getCampaign', () => {
   it('returns an object with the correct campaign ID', async () => {
     expect.assertions(1)
     getCurrentCampaign.mockReturnValue({
-      id: 'someCampaignIdHere',
+      campaignId: 'someCampaignIdHere',
       isLive: true,
     })
     expect(await getCampaign()).toMatchObject({
-      id: 'someCampaignIdHere',
+      campaignId: 'someCampaignIdHere',
     })
   })
 
@@ -33,7 +33,7 @@ describe('getCampaign', () => {
   it('returns an object with the isLive property === false when the campaign is not live', async () => {
     expect.assertions(1)
     getCurrentCampaign.mockReturnValue({
-      id: 'someCampaignIdHere',
+      campaignId: 'someCampaignIdHere',
       isLive: false,
     })
     expect(await getCampaign()).toMatchObject({
@@ -41,10 +41,10 @@ describe('getCampaign', () => {
     })
   })
 
-  it('does not include the id property when the campaign is not live', async () => {
+  it('does not include the campaignId property when the campaign is not live', async () => {
     expect.assertions(1)
     getCurrentCampaign.mockReturnValue({
-      id: 'someCampaignIdHere',
+      campaignId: 'someCampaignIdHere',
       isLive: false,
     })
     expect((await getCampaign()).id).toBeUndefined()

--- a/graphql/database/globals/__tests__/getCampaign.test.js
+++ b/graphql/database/globals/__tests__/getCampaign.test.js
@@ -1,0 +1,52 @@
+/* eslint-env jest */
+import getCampaign from '../getCampaign'
+import { getCurrentCampaign } from '../getCampaignData'
+
+jest.mock('../getCampaignData')
+
+beforeEach(() => {
+  getCurrentCampaign.mockReturnValue({
+    id: 'someCampaign',
+    isLive: true,
+  })
+})
+
+describe('getCampaign', () => {
+  it('returns an object with the correct campaign ID', async () => {
+    expect.assertions(1)
+    getCurrentCampaign.mockReturnValue({
+      id: 'someCampaignIdHere',
+      isLive: true,
+    })
+    expect(await getCampaign()).toMatchObject({
+      id: 'someCampaignIdHere',
+    })
+  })
+
+  it('returns an object with the isLive property === true when the campaign is live', async () => {
+    expect.assertions(1)
+    expect(await getCampaign()).toMatchObject({
+      isLive: true,
+    })
+  })
+
+  it('returns an object with the isLive property === false when the campaign is not live', async () => {
+    expect.assertions(1)
+    getCurrentCampaign.mockReturnValue({
+      id: 'someCampaignIdHere',
+      isLive: false,
+    })
+    expect(await getCampaign()).toMatchObject({
+      isLive: false,
+    })
+  })
+
+  it('does not include the id property when the campaign is not live', async () => {
+    expect.assertions(1)
+    getCurrentCampaign.mockReturnValue({
+      id: 'someCampaignIdHere',
+      isLive: false,
+    })
+    expect((await getCampaign()).id).toBeUndefined()
+  })
+})

--- a/graphql/database/globals/__tests__/getCampaign.test.js
+++ b/graphql/database/globals/__tests__/getCampaign.test.js
@@ -1,23 +1,35 @@
 /* eslint-env jest */
 import getCampaign from '../getCampaign'
 import { getCurrentCampaign } from '../getCampaignData'
+import callRedis from '../../../utils/redis'
 
 jest.mock('../getCampaignData')
+jest.mock('../../../utils/redis')
+
+const getMockCurrentCampaign = ({
+  campaignId = 'someCampaign',
+  ...otherProps
+} = {}) => ({
+  campaignId,
+  isLive: true,
+  getNewUsersRedisKey: jest.fn(() => `campaign:${campaignId}:newUsers`),
+  ...otherProps,
+})
 
 beforeEach(() => {
-  getCurrentCampaign.mockReturnValue({
-    campaignId: 'someCampaign',
-    isLive: true,
-  })
+  getCurrentCampaign.mockReturnValue(getMockCurrentCampaign())
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
 })
 
 describe('getCampaign', () => {
   it('returns an object with the correct campaign ID', async () => {
     expect.assertions(1)
-    getCurrentCampaign.mockReturnValue({
-      campaignId: 'someCampaignIdHere',
-      isLive: true,
-    })
+    getCurrentCampaign.mockReturnValue(
+      getMockCurrentCampaign({ campaignId: 'someCampaignIdHere' })
+    )
     expect(await getCampaign()).toMatchObject({
       campaignId: 'someCampaignIdHere',
     })
@@ -32,10 +44,12 @@ describe('getCampaign', () => {
 
   it('returns an object with the isLive property === false when the campaign is not live', async () => {
     expect.assertions(1)
-    getCurrentCampaign.mockReturnValue({
-      campaignId: 'someCampaignIdHere',
-      isLive: false,
-    })
+    getCurrentCampaign.mockReturnValue(
+      getMockCurrentCampaign({
+        campaignId: 'someCampaignIdHere',
+        isLive: false,
+      })
+    )
     expect(await getCampaign()).toMatchObject({
       isLive: false,
     })
@@ -43,10 +57,33 @@ describe('getCampaign', () => {
 
   it('does not include the campaignId property when the campaign is not live', async () => {
     expect.assertions(1)
-    getCurrentCampaign.mockReturnValue({
-      campaignId: 'someCampaignIdHere',
-      isLive: false,
-    })
+    getCurrentCampaign.mockReturnValue(
+      getMockCurrentCampaign({
+        campaignId: 'someCampaignIdHere',
+        isLive: false,
+      })
+    )
     expect((await getCampaign()).id).toBeUndefined()
+  })
+
+  it('calls Redis to get the "numNewUsers" value when the campaign is live', async () => {
+    expect.assertions(1)
+    getCurrentCampaign.mockReturnValue(
+      getMockCurrentCampaign({ campaignId: 'foobar', isLive: true })
+    )
+    await getCampaign()
+    expect(callRedis).toHaveBeenCalledWith({
+      operation: 'GET',
+      key: 'campaign:foobar:newUsers',
+    })
+  })
+
+  it('does not call Redis when the campaign is not live', async () => {
+    expect.assertions(1)
+    getCurrentCampaign.mockReturnValue(
+      getMockCurrentCampaign({ isLive: false })
+    )
+    await getCampaign()
+    expect(callRedis).not.toHaveBeenCalled()
   })
 })

--- a/graphql/database/globals/__tests__/getCampaignData.test.js
+++ b/graphql/database/globals/__tests__/getCampaignData.test.js
@@ -6,10 +6,10 @@ beforeEach(() => {
 })
 
 describe('getCurrentCampaign', () => {
-  it('returns an object with campaign.id and campaign.isLive properties', () => {
+  it('returns an object with campaign.campaignId and campaign.isLive properties', () => {
     expect.assertions(1)
     expect(getCurrentCampaign()).toMatchObject({
-      id: expect.any(String),
+      campaignId: expect.any(String),
       isLive: expect.any(Boolean),
     })
   })

--- a/graphql/database/globals/__tests__/getCampaignData.test.js
+++ b/graphql/database/globals/__tests__/getCampaignData.test.js
@@ -6,11 +6,12 @@ beforeEach(() => {
 })
 
 describe('getCurrentCampaign', () => {
-  it('returns an object with campaign.campaignId and campaign.isLive properties', () => {
+  it('returns an object with the expected properties', () => {
     expect.assertions(1)
     expect(getCurrentCampaign()).toMatchObject({
       campaignId: expect.any(String),
       isLive: expect.any(Boolean),
+      getNewUsersRedisKey: expect.any(Function),
     })
   })
 
@@ -28,5 +29,13 @@ describe('getCurrentCampaign', () => {
     expect(getCurrentCampaign()).toMatchObject({
       isLive: false,
     })
+  })
+
+  it('creates the expected string when calling getNewUsersRedisKey', () => {
+    expect.assertions(1)
+    const campaign = getCurrentCampaign()
+    expect(getCurrentCampaign().getNewUsersRedisKey()).toEqual(
+      `campaign:${campaign.campaignId}:newUsers`
+    )
   })
 })

--- a/graphql/database/globals/__tests__/getCampaignData.test.js
+++ b/graphql/database/globals/__tests__/getCampaignData.test.js
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+import { getCurrentCampaign } from '../getCampaignData'
+
+beforeEach(() => {
+  process.env.IS_GLOBAL_CAMPAIGN_LIVE = false
+})
+
+describe('getCurrentCampaign', () => {
+  it('returns an object with campaign.id and campaign.isLive properties', () => {
+    expect.assertions(1)
+    expect(getCurrentCampaign()).toMatchObject({
+      id: expect.any(String),
+      isLive: expect.any(Boolean),
+    })
+  })
+
+  it('returns campaign.isLive === true when process.env.IS_GLOBAL_CAMPAIGN_LIVE is "true"', () => {
+    expect.assertions(1)
+    process.env.IS_GLOBAL_CAMPAIGN_LIVE = true
+    expect(getCurrentCampaign()).toMatchObject({
+      isLive: true,
+    })
+  })
+
+  it('returns campaign.isLive === false when process.env.IS_GLOBAL_CAMPAIGN_LIVE is "false"', () => {
+    expect.assertions(1)
+    process.env.IS_GLOBAL_CAMPAIGN_LIVE = false
+    expect(getCurrentCampaign()).toMatchObject({
+      isLive: false,
+    })
+  })
+})

--- a/graphql/database/globals/getCampaign.js
+++ b/graphql/database/globals/getCampaign.js
@@ -1,0 +1,27 @@
+import { getCurrentCampaign } from './getCampaignData'
+
+/**
+ * Return data about any currently-live campaign.
+ * @return {Promise<Object>} campaign - a Promise that resolves into a
+ *   Campaign object.
+ * @return {Boolean} campaign.isLive - whether we should show the campaign
+ *   on the new tab page.
+ * @return {String|undefined} campaign.id - the unique ID of the campaign.
+ *   This may be undefined if the campaign is not live.
+ */
+const getCampaign = async () => {
+  const campaign = getCurrentCampaign()
+  if (!campaign || !campaign.isLive) {
+    return {
+      isLive: false,
+    }
+  }
+  return {
+    isLive: campaign.isLive,
+    ...(campaign.isLive && {
+      id: campaign.id,
+    }),
+  }
+}
+
+export default getCampaign

--- a/graphql/database/globals/getCampaign.js
+++ b/graphql/database/globals/getCampaign.js
@@ -1,4 +1,6 @@
 import { getCurrentCampaign } from './getCampaignData'
+import callRedis from '../../utils/redis'
+import logger from '../../utils/logger'
 
 /**
  * Return data about any currently-live campaign.
@@ -16,10 +18,23 @@ const getCampaign = async () => {
       isLive: false,
     }
   }
+
+  // Try to get the number of new users from this campaign.
+  let numNewUsers = null
+  try {
+    numNewUsers = await callRedis({
+      operation: 'GET',
+      key: campaign.getNewUsersRedisKey(),
+    })
+  } catch (e) {
+    logger.error(e)
+  }
+
   return {
     isLive: campaign.isLive,
     ...(campaign.isLive && {
       campaignId: campaign.campaignId,
+      numNewUsers,
     }),
   }
 }

--- a/graphql/database/globals/getCampaign.js
+++ b/graphql/database/globals/getCampaign.js
@@ -6,10 +6,10 @@ import logger from '../../utils/logger'
  * Return data about any currently-live campaign.
  * @return {Promise<Object>} campaign - a Promise that resolves into a
  *   Campaign object.
+ * @return {String|undefined} campaign.campaignId - the unique ID of the campaign.
+ *   This may be undefined if the campaign is not live.
  * @return {Boolean} campaign.isLive - whether we should show the campaign
  *   on the new tab page.
- * @return {String|undefined} campaign.id - the unique ID of the campaign.
- *   This may be undefined if the campaign is not live.
  */
 const getCampaign = async () => {
   const campaign = getCurrentCampaign()

--- a/graphql/database/globals/getCampaign.js
+++ b/graphql/database/globals/getCampaign.js
@@ -19,7 +19,7 @@ const getCampaign = async () => {
   return {
     isLive: campaign.isLive,
     ...(campaign.isLive && {
-      id: campaign.id,
+      campaignId: campaign.campaignId,
     }),
   }
 }

--- a/graphql/database/globals/getCampaignData.js
+++ b/graphql/database/globals/getCampaignData.js
@@ -1,0 +1,17 @@
+const campaigns = {
+  testNov2019: {
+    id: 'testNov2019',
+  },
+}
+
+// Hardcode the currently-active campaign here.
+const CURRENT_CAMPAIGN = campaigns.testNov2019
+
+// eslint-disable-next-line import/prefer-default-export
+export const getCurrentCampaign = () => {
+  const isLive = process.env.IS_GLOBAL_CAMPAIGN_LIVE === 'true' || false
+  return {
+    ...CURRENT_CAMPAIGN,
+    isLive,
+  }
+}

--- a/graphql/database/globals/getCampaignData.js
+++ b/graphql/database/globals/getCampaignData.js
@@ -1,7 +1,12 @@
-const campaigns = {
-  testNov2019: {
-    campaignId: 'testNov2019',
+const createCampaign = data => ({
+  campaignId: data.campaignId,
+  getNewUsersRedisKey() {
+    return `campaign:${this.campaignId}:newUsers`
   },
+})
+
+const campaigns = {
+  testNov2019: createCampaign({ campaignId: 'testNov2019' }),
 }
 
 // Hardcode the currently-active campaign here.

--- a/graphql/database/globals/getCampaignData.js
+++ b/graphql/database/globals/getCampaignData.js
@@ -12,6 +12,17 @@ const campaigns = {
 // Hardcode the currently-active campaign here.
 const CURRENT_CAMPAIGN = campaigns.testNov2019
 
+/**
+ * Return the hardcoded campaign info for the current campaign.
+ * @return {Promise<Object>} campaign
+ * @return {String|undefined} campaign.campaignId - the unique ID of the
+ *   campaign.
+ * @return {Boolean} campaign.isLive - whether we should show the campaign
+ *   on the new tab page.
+ * @return {Function} campaign.getNewUsersRedisKey - a function that returns
+ *   a string of the Redis key value. The Redis item stores the number of new
+ *   users who joined during this campaign.
+ */
 // eslint-disable-next-line import/prefer-default-export
 export const getCurrentCampaign = () => {
   const isLive = process.env.IS_GLOBAL_CAMPAIGN_LIVE === 'true' || false

--- a/graphql/database/globals/getCampaignData.js
+++ b/graphql/database/globals/getCampaignData.js
@@ -1,6 +1,6 @@
 const campaigns = {
   testNov2019: {
-    id: 'testNov2019',
+    campaignId: 'testNov2019',
   },
 }
 

--- a/graphql/database/globals/globals.js
+++ b/graphql/database/globals/globals.js
@@ -13,6 +13,7 @@ class Globals {
   }
 }
 
+// Deprecated. Use the Campaign schema object.
 function isGlobalCampaignLive() {
   return process.env.IS_GLOBAL_CAMPAIGN_LIVE === 'true' || false
 }

--- a/graphql/utils/redis.js
+++ b/graphql/utils/redis.js
@@ -5,9 +5,8 @@ import logger from './logger'
 
 const redisAccessEndpoint = `${process.env.REDIS_SERVICE_ENDPOINT}/redis`
 
-export const redisKeys = {
-  // foo: 'foo',
-}
+// Key namespaces:
+// - "campaign:*" used for campaign data
 
 /**
  * Call the Redis service.

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -18,6 +18,9 @@ type App implements Node {
   """All the background Images"""
   backgroundImages(after: String, first: Int, before: String, last: Int): BackgroundImageConnection
   isGlobalCampaignLive: Boolean
+
+  """Campaigns (or "charity spotlights") shown to users."""
+  campaign: Campaign
 }
 
 """A background image"""
@@ -60,6 +63,15 @@ type BackgroundImageEdge {
 
   """A cursor for use in pagination"""
   cursor: String!
+}
+
+"""Campaigns (or "charity spotlights") shown to users."""
+type Campaign {
+  """the ID of the campaign"""
+  campaignId: String
+
+  """whether or not the campaign should currently show to users"""
+  isLive: Boolean
 }
 
 """Fields on which to filter the list of charities."""

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -71,7 +71,10 @@ type Campaign {
   campaignId: String
 
   """whether or not the campaign should currently show to users"""
-  isLive: Boolean
+  isLive: Boolean!
+
+  """the number of new users who joined during this campaign"""
+  numNewUsers: Int
 }
 
 """Fields on which to filter the list of charities."""

--- a/web/src/js/components/Campaign/CampaignBaseView.js
+++ b/web/src/js/components/Campaign/CampaignBaseView.js
@@ -29,6 +29,11 @@ class CampaignBaseView extends React.Component {
             app {
               ...HeartDonationCampaignContainer_app
                 @arguments(startTime: $startTime, endTime: $endTime)
+              campaign {
+                campaignId
+                isLive
+                numNewUsers
+              }
             }
             user(userId: $userId) {
               ...HeartDonationCampaignContainer_user

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -162,9 +162,9 @@ class Dashboard extends React.Component {
     } = this.state
 
     // Whether or not a campaign should show on the dashboard
+    const isCampaignLive = !!(app && app.campaign && app.campaign.isLive)
     const showCampaign = !!(
-      app &&
-      app.isGlobalCampaignLive &&
+      isCampaignLive &&
       !hasUserDismissedCampaignRecently &&
       user.tabs > 1
     )
@@ -619,14 +619,12 @@ Dashboard.propTypes = {
     tabs: PropTypes.number.isRequired,
   }),
   app: PropTypes.shape({
-    isGlobalCampaignLive: PropTypes.bool,
+    campaign: PropTypes.shape({
+      isLive: PropTypes.bool.isRequired,
+    }).isRequired,
   }),
 }
 
-Dashboard.defaultProps = {
-  app: {
-    isGlobalCampaignLive: false,
-  },
-}
+Dashboard.defaultProps = {}
 
 export default Dashboard

--- a/web/src/js/components/Dashboard/DashboardContainer.js
+++ b/web/src/js/components/Dashboard/DashboardContainer.js
@@ -6,7 +6,9 @@ import Dashboard from 'js/components/Dashboard/DashboardComponent'
 export default createFragmentContainer(Dashboard, {
   app: graphql`
     fragment DashboardContainer_app on App {
-      isGlobalCampaignLive
+      campaign {
+        isLive
+      }
       ...UserMenuContainer_app
     }
   `,

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -104,7 +104,9 @@ const mockProps = {
     experimentActions: {},
   },
   app: {
-    isGlobalCampaignLive: false,
+    campaign: {
+      isLive: false,
+    },
   },
 }
 


### PR DESCRIPTION
We'll use the Campaign object to fetch the new users who join during a campaign. Gradually, we can move more campaign logic to the server-side to reduce dependence on pushing new client code to launch campaigns.