### PR TITLE
Add ability to reopen the tree campaign after closing it

### DIFF
--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -311,6 +311,7 @@ class Dashboard extends React.Component {
                     userClickedSearchIntroV2: true,
                   })
                 }}
+                showCampaignReopenButton={hasUserDismissedCampaignRecently}
                 onClickCampaignReopen={() => {
                   this.setState({
                     hasUserDismissedCampaignRecently: false,

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -31,6 +31,7 @@ import {
   setUserClickedNewTabSearchIntroNotif,
   hasUserClickedNewTabSearchIntroNotifV2,
   setUserClickedNewTabSearchIntroNotifV2,
+  removeCampaignDismissTime,
 } from 'js/utils/local-user-data-mgr'
 import {
   CHROME_BROWSER,
@@ -309,6 +310,12 @@ class Dashboard extends React.Component {
                   this.setState({
                     userClickedSearchIntroV2: true,
                   })
+                }}
+                onClickCampaignReopen={() => {
+                  this.setState({
+                    hasUserDismissedCampaignRecently: false,
+                  })
+                  removeCampaignDismissTime()
                 }}
               />
               {this.state.showNotification ? (

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -239,6 +239,7 @@ class UserMenu extends React.Component {
               </div>
               <CircleIcon
                 style={{
+                  marginLeft: 10,
                   color: 'rgba(255, 255, 255, 0.8)',
                 }}
                 classes={{

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -33,12 +33,13 @@ import {
   UNSUPPORTED_BROWSER,
 } from 'js/constants'
 import ErrorBoundary from 'js/components/General/ErrorBoundary'
+import TreeIcon from 'mdi-material-ui/PineTree'
 
 const Sparkle = lazy(() => import('react-sparkle'))
 
 const defaultTheme = createMuiTheme(theme)
 
-const styles = {
+const styles = theme => ({
   circleIcon: {
     alignSelf: 'center',
     width: 5,
@@ -47,7 +48,19 @@ const styles = {
     marginLeft: 12,
     marginRight: 12,
   },
-}
+  treeText: {
+    transition: 'color 300ms ease-in',
+    fontWeight: 'normal',
+    userSelect: 'none',
+    cursor: 'pointer',
+  },
+  treeIcon: {
+    transition: 'color 300ms ease-in',
+    cursor: 'pointer',
+    paddingBottom: 0,
+    color: 'rgba(255, 255, 255, 0.8)',
+  },
+})
 
 const menuFontSize = 24
 
@@ -200,6 +213,24 @@ class UserMenu extends React.Component {
               </ErrorBoundary>
             </div>
           ) : null}
+          {/* Remove when tree campaign is no longer live */}
+          <div
+            data-test-id={'tree-campaign-reopen'}
+            style={{ marginRight: 0, display: 'flex', flexDirection: 'row' }}
+          >
+            <Typography variant={'h2'} className={classes.treeText}>
+              2
+            </Typography>
+            <TreeIcon className={classes.treeIcon} />
+          </div>
+          <CircleIcon
+            style={{
+              color: 'rgba(255, 255, 255, 0.8)',
+            }}
+            classes={{
+              root: classes.circleIcon,
+            }}
+          />
           <MoneyRaised
             app={app}
             dropdown={({ open, onClose, anchorElement }) => (

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -87,6 +87,7 @@ class UserMenu extends React.Component {
       onClickCampaignReopen,
       onClickSparklySearchIntroButton,
       showSparklySearchIntroButton,
+      showCampaignReopenButton,
     } = this.props
     const numUsersRecruitedForCampaign = get(
       user,
@@ -220,24 +221,32 @@ class UserMenu extends React.Component {
             </div>
           ) : null}
           {/* Remove when tree campaign is no longer live */}
-          <div
-            data-test-id={'tree-campaign-reopen'}
-            style={{ marginRight: 0, display: 'flex', flexDirection: 'row' }}
-            onClick={onClickCampaignReopen}
-          >
-            <Typography variant={'h2'} className={classes.treeText}>
-              {numUsersRecruitedForCampaign}
-            </Typography>
-            <TreeIcon className={classes.treeIcon} />
-          </div>
-          <CircleIcon
-            style={{
-              color: 'rgba(255, 255, 255, 0.8)',
-            }}
-            classes={{
-              root: classes.circleIcon,
-            }}
-          />
+          {showCampaignReopenButton ? (
+            <>
+              <div
+                data-test-id={'tree-campaign-reopen'}
+                style={{
+                  marginRight: 0,
+                  display: 'flex',
+                  flexDirection: 'row',
+                }}
+                onClick={onClickCampaignReopen}
+              >
+                <Typography variant={'h2'} className={classes.treeText}>
+                  {numUsersRecruitedForCampaign}
+                </Typography>
+                <TreeIcon className={classes.treeIcon} />
+              </div>
+              <CircleIcon
+                style={{
+                  color: 'rgba(255, 255, 255, 0.8)',
+                }}
+                classes={{
+                  root: classes.circleIcon,
+                }}
+              />
+            </>
+          ) : null}
           <MoneyRaised
             app={app}
             dropdown={({ open, onClose, anchorElement }) => (

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -87,6 +87,11 @@ class UserMenu extends React.Component {
       onClickSparklySearchIntroButton,
       showSparklySearchIntroButton,
     } = this.props
+    const numUsersRecruitedForCampaign = get(
+      user,
+      'recruits.recruitsWithAtLeastOneTab',
+      0
+    )
     return (
       <MuiThemeProvider
         theme={{
@@ -219,7 +224,7 @@ class UserMenu extends React.Component {
             style={{ marginRight: 0, display: 'flex', flexDirection: 'row' }}
           >
             <Typography variant={'h2'} className={classes.treeText}>
-              2
+              {numUsersRecruitedForCampaign}
             </Typography>
             <TreeIcon className={classes.treeIcon} />
           </div>
@@ -327,7 +332,11 @@ UserMenu.propTypes = {
   isUserAnonymous: PropTypes.bool,
   onClickSparklySearchIntroButton: PropTypes.func,
   showSparklySearchIntroButton: PropTypes.bool,
-  user: PropTypes.shape({}).isRequired,
+  user: PropTypes.shape({
+    recruits: PropTypes.shape({
+      recruitsWithAtLeastOneTab: PropTypes.number.isRequired,
+    }).isRequired,
+  }).isRequired,
 }
 
 UserMenu.defaultProps = {

--- a/web/src/js/components/Dashboard/UserMenuComponent.js
+++ b/web/src/js/components/Dashboard/UserMenuComponent.js
@@ -84,6 +84,7 @@ class UserMenu extends React.Component {
       classes,
       user,
       isUserAnonymous,
+      onClickCampaignReopen,
       onClickSparklySearchIntroButton,
       showSparklySearchIntroButton,
     } = this.props
@@ -222,6 +223,7 @@ class UserMenu extends React.Component {
           <div
             data-test-id={'tree-campaign-reopen'}
             style={{ marginRight: 0, display: 'flex', flexDirection: 'row' }}
+            onClick={onClickCampaignReopen}
           >
             <Typography variant={'h2'} className={classes.treeText}>
               {numUsersRecruitedForCampaign}
@@ -330,6 +332,7 @@ UserMenu.propTypes = {
   ]).isRequired,
   classes: PropTypes.object.isRequired,
   isUserAnonymous: PropTypes.bool,
+  onClickCampaignReopen: PropTypes.func,
   onClickSparklySearchIntroButton: PropTypes.func,
   showSparklySearchIntroButton: PropTypes.bool,
   user: PropTypes.shape({
@@ -341,6 +344,7 @@ UserMenu.propTypes = {
 
 UserMenu.defaultProps = {
   isUserAnonymous: false,
+  onClickCampaignReopen: () => {},
   onClickSparklySearchIntroButton: () => {},
   showSparklySearchIntroButton: false,
 }

--- a/web/src/js/components/Dashboard/UserMenuContainer.js
+++ b/web/src/js/components/Dashboard/UserMenuContainer.js
@@ -14,6 +14,14 @@ export default createFragmentContainer(UserMenu, {
     fragment UserMenuContainer_user on User {
       ...HeartsContainer_user
       ...HeartsDropdownContainer_user
+      # Remove this after the tree campaign ends.
+      recruits(
+        first: 5000
+        startTime: "2019-11-14T18:00:00.000Z"
+        endTime: "2020-01-10T24:00:00.000Z"
+      ) {
+        recruitsWithAtLeastOneTab
+      }
     }
   `,
 })

--- a/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/DashboardComponent.test.js
@@ -1298,6 +1298,16 @@ describe('Dashboard component: campaign reopen click', () => {
     hasUserDismissedCampaignRecently.mockReturnValueOnce(true)
   })
 
+  it('passes showCampaignReopenButton === true to the UserMenu when hasUserDismissedCampaignRecently is true', () => {
+    const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
+      .default
+    const wrapper = shallow(<DashboardComponent {...mockProps} />)
+    hasUserDismissedCampaignRecently.mockReturnValueOnce(true)
+    expect(wrapper.find(UserMenu).prop('showCampaignReopenButton')).toBe(true)
+    wrapper.setState({ hasUserDismissedCampaignRecently: false })
+    expect(wrapper.find(UserMenu).prop('showCampaignReopenButton')).toBe(false)
+  })
+
   it('reopens the campaign when the UserMenu calls the onClickCampaignReopen function', () => {
     const DashboardComponent = require('js/components/Dashboard/DashboardComponent')
       .default

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -19,6 +19,7 @@ import {
 } from 'js/navigation/navigation'
 import logger from 'js/utils/logger'
 import Link from 'js/components/General/Link'
+import TreeIcon from 'mdi-material-ui/PineTree'
 
 jest.mock('js/components/MoneyRaised/MoneyRaisedContainer')
 jest.mock('js/components/Dashboard/HeartsContainer')
@@ -31,7 +32,11 @@ jest.mock('js/utils/logger')
 const getMockProps = () => {
   return {
     browser: 'chrome',
-    user: {},
+    user: {
+      recruits: {
+        recruitsWithAtLeastOneTab: 2,
+      },
+    },
     app: {},
     isUserAnonymous: false,
     showSparklySearchIntroButton: false,
@@ -302,10 +307,14 @@ describe('User menu component: Hearts dropdown component', () => {
     const mockProps = getMockProps()
     mockProps.app = {
       hi: 'there',
+      campaign: {},
     }
     mockProps.user = {
       some: 'thing',
       abc: 123,
+      recruits: {
+        recruitsWithAtLeastOneTab: 1,
+      },
     }
     const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
       .default
@@ -569,5 +578,35 @@ describe('User menu component: campaign reopen button', () => {
     expect(wrapper.find('[data-test-id="tree-campaign-reopen"]').exists()).toBe(
       true
     )
+  })
+
+  it('displays the expected number of users recruited in the campaign reopen button text', () => {
+    const mockProps = getMockProps()
+    mockProps.user.recruits.recruitsWithAtLeastOneTab = 182
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="tree-campaign-reopen"]')
+        .find(Typography)
+        .first()
+        .render()
+        .text()
+    ).toEqual('182')
+  })
+
+  it('displays the tree icon the campaign reopen button text', () => {
+    const mockProps = getMockProps()
+    mockProps.user.recruits.recruitsWithAtLeastOneTab = 182
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(
+      wrapper
+        .find('[data-test-id="tree-campaign-reopen"]')
+        .find(TreeIcon)
+        .exists()
+    ).toBe(true)
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -40,6 +40,7 @@ const getMockProps = () => {
     app: {},
     isUserAnonymous: false,
     showSparklySearchIntroButton: false,
+    onClickCampaignReopen: jest.fn(),
     onClickSparklySearchIntroButton: jest.fn(),
   }
 }
@@ -608,5 +609,16 @@ describe('User menu component: campaign reopen button', () => {
         .find(TreeIcon)
         .exists()
     ).toBe(true)
+  })
+
+  it('calls the onClickCampaignReopen prop when clicked', () => {
+    const mockProps = getMockProps()
+    mockProps.user.recruits.recruitsWithAtLeastOneTab = 182
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(mockProps.onClickCampaignReopen).not.toHaveBeenCalled()
+    wrapper.find('[data-test-id="tree-campaign-reopen"]').simulate('click')
+    expect(mockProps.onClickCampaignReopen).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -39,6 +39,7 @@ const getMockProps = () => {
     },
     app: {},
     isUserAnonymous: false,
+    showCampaignReopenButton: false,
     showSparklySearchIntroButton: false,
     onClickCampaignReopen: jest.fn(),
     onClickSparklySearchIntroButton: jest.fn(),
@@ -571,8 +572,9 @@ describe('User menu component: sparkly search intro button', () => {
 })
 
 describe('User menu component: campaign reopen button', () => {
-  it('displays the campaign reopen button', () => {
+  it('displays the campaign reopen button when the showCampaignReopenButton prop is true', () => {
     const mockProps = getMockProps()
+    mockProps.showCampaignReopenButton = true
     const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
       .default
     const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
@@ -581,8 +583,20 @@ describe('User menu component: campaign reopen button', () => {
     )
   })
 
+  it('does not display the campaign reopen button when the showCampaignReopenButton prop is false', () => {
+    const mockProps = getMockProps()
+    mockProps.showCampaignReopenButton = false
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="tree-campaign-reopen"]').exists()).toBe(
+      false
+    )
+  })
+
   it('displays the expected number of users recruited in the campaign reopen button text', () => {
     const mockProps = getMockProps()
+    mockProps.showCampaignReopenButton = true
     mockProps.user.recruits.recruitsWithAtLeastOneTab = 182
     const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
       .default
@@ -599,6 +613,7 @@ describe('User menu component: campaign reopen button', () => {
 
   it('displays the tree icon the campaign reopen button text', () => {
     const mockProps = getMockProps()
+    mockProps.showCampaignReopenButton = true
     mockProps.user.recruits.recruitsWithAtLeastOneTab = 182
     const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
       .default
@@ -613,6 +628,7 @@ describe('User menu component: campaign reopen button', () => {
 
   it('calls the onClickCampaignReopen prop when clicked', () => {
     const mockProps = getMockProps()
+    mockProps.showCampaignReopenButton = true
     mockProps.user.recruits.recruitsWithAtLeastOneTab = 182
     const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
       .default

--- a/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
+++ b/web/src/js/components/Dashboard/__tests__/UserMenuComponent.test.js
@@ -559,3 +559,15 @@ describe('User menu component: sparkly search intro button', () => {
     expect(mockProps.onClickSparklySearchIntroButton).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('User menu component: campaign reopen button', () => {
+  it('displays the campaign reopen button', () => {
+    const mockProps = getMockProps()
+    const UserMenuComponent = require('js/components/Dashboard/UserMenuComponent')
+      .default
+    const wrapper = shallow(<UserMenuComponent {...mockProps} />).dive()
+    expect(wrapper.find('[data-test-id="tree-campaign-reopen"]').exists()).toBe(
+      true
+    )
+  })
+})

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -299,7 +299,8 @@ describe('local user data manager', () => {
   })
 
   it('returns false if the user has not dismissed a notification recently', () => {
-    const now = moment('2018-04-01T12:50:42.000') // ~12 days ago
+    // const now = moment('2018-04-01T12:50:42.000') // ~12 days ago
+    const now = moment('2018-02-01T12:50:42.000') // ~2 months ago
     localStorageMgr.setItem(
       'tab.user.notifications.dismissTime',
       now.utc().toISOString()

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -392,6 +392,17 @@ describe('local user data manager', () => {
     )
   })
 
+  // removeCampaignDismissTime method
+  it('sets the notification dismiss time timestamp in localStorage', () => {
+    const {
+      removeCampaignDismissTime,
+    } = require('js/utils/local-user-data-mgr')
+    removeCampaignDismissTime()
+    expect(localStorageMgr.removeItem).toHaveBeenCalledWith(
+      'tab.user.campaign.dismissTime'
+    )
+  })
+
   // hasUserDismissedCampaignRecently method
   it('returns true if the user dismissed a notification recently', () => {
     const now = moment('2018-04-11T12:50:42.000') // ~1 day ago

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -210,7 +210,8 @@ export const hasUserDismissedNotificationRecently = () => {
   return (
     moment()
       .utc()
-      .diff(dismissTime, 'days') < 10
+      // TODO: revert this to 10 days after we end the tree planting campaign.
+      .diff(dismissTime, 'days') < 60
   )
 }
 

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -268,6 +268,14 @@ export const setCampaignDismissTime = () => {
 }
 
 /**
+ * Deletes the time the user dismissed a campaign.
+ * @returns {undefined}
+ */
+export const removeCampaignDismissTime = () => {
+  localStorageMgr.removeItem(STORAGE_CAMPAIGN_DISMISS_TIME)
+}
+
+/**
  * Returns whether the user has dismissed a campaign
  * in the last few days.
  * @returns {Boolean}


### PR DESCRIPTION
This adds an icon to the user menu when the user closes the "tree planting" campaign. We should remove or generalize this code when the campaign is over.