### PR TITLE
Handle database ConditionalCheckFailed errors

### DIFF
--- a/graphql/database/base/BaseModel.js
+++ b/graphql/database/base/BaseModel.js
@@ -454,6 +454,9 @@ class BaseModel {
       const updatedItem = await this.dynogelsModel.updateAsync(item, options)
       return this.deserialize(updatedItem)
     } catch (e) {
+      if (e.code === AWSConditionalCheckFailedErrorCode) {
+        throw new DatabaseConditionalCheckFailedException()
+      }
       throw e
     }
   }

--- a/graphql/database/base/BaseModel.js
+++ b/graphql/database/base/BaseModel.js
@@ -236,7 +236,7 @@ class BaseModel {
     }
     // logger.debug(`Getting obj with hashKey ${hashKey} from table ${this.tableName}.`)
     if (!this.isQueryAuthorized(userContext, 'get', hashKey, rangeKey)) {
-      return Promise.reject(new UnauthorizedQueryException())
+      throw new UnauthorizedQueryException()
     }
     return this.dynogelsModel
       .getAsync(...keys)
@@ -271,7 +271,7 @@ class BaseModel {
       }
     })
     if (authorizationError) {
-      return Promise.reject(new UnauthorizedQueryException())
+      throw new UnauthorizedQueryException()
     }
     return this.dynogelsModel
       .getItemsAsync(keys)
@@ -285,7 +285,7 @@ class BaseModel {
     // logger.debug(`Getting all objs in table ${this.tableName}.`)
     const self = this
     if (!this.isQueryAuthorized(userContext, 'getAll')) {
-      return Promise.reject(new UnauthorizedQueryException())
+      throw new UnauthorizedQueryException()
     }
     // https://github.com/clarkie/dynogels#scan
     return this.dynogelsModel
@@ -328,7 +328,7 @@ class BaseModel {
         indexName
       )
     ) {
-      return Promise.reject(new UnauthorizedQueryException())
+      throw new UnauthorizedQueryException()
     }
 
     return queryObj
@@ -365,7 +365,7 @@ class BaseModel {
     }
 
     if (!this.isQueryAuthorized(userContext, 'create', hashKey, null, item)) {
-      return Promise.reject(new UnauthorizedQueryException())
+      throw new UnauthorizedQueryException()
     }
     return this.dynogelsModel
       .createAsync(item, { overwrite })
@@ -443,7 +443,7 @@ class BaseModel {
         item
       )
     ) {
-      return Promise.reject(new UnauthorizedQueryException())
+      throw new UnauthorizedQueryException()
     }
 
     // TODO: fix rule violation

--- a/graphql/database/base/__tests__/BaseModel-queries.test.js
+++ b/graphql/database/base/__tests__/BaseModel-queries.test.js
@@ -119,13 +119,11 @@ describe('BaseModel queries', () => {
 
     // Set mock response from DB client.
     const itemToGet = Object.assign({}, fixturesA[0])
-    const dbQueryMock = databaseClient.get.mockImplementation(
-      (params, callback) => {
-        callback(null, {
-          Item: null,
-        })
-      }
-    )
+    databaseClient.get.mockImplementation((params, callback) => {
+      callback(null, {
+        Item: null,
+      })
+    })
 
     return expect(ExampleModel.get(user, itemToGet.id)).rejects.toEqual(
       new DatabaseItemDoesNotExistException()

--- a/graphql/database/base/__tests__/BaseModel-queries.test.js
+++ b/graphql/database/base/__tests__/BaseModel-queries.test.js
@@ -8,7 +8,7 @@ import ExampleModelRangeKey, {
 } from '../test-utils/ExampleModelRangeKey'
 import {
   addTimestampFieldsToItem,
-  ConditionalCheckFailedException,
+  MockAWSConditionalCheckFailedError,
   getMockUserContext,
   mockDate,
   setModelPermissions,
@@ -726,7 +726,7 @@ describe('BaseModel queries', () => {
 
     // Mock that the item already exists.
     databaseClient.put.mockImplementation((params, callback) => {
-      callback(ConditionalCheckFailedException(), null) // error
+      callback(MockAWSConditionalCheckFailedError(), null) // error
     })
 
     const dbGetQueryMock = databaseClient.get.mockImplementation(
@@ -770,7 +770,7 @@ describe('BaseModel queries', () => {
 
     // Mock that the item already exists.
     databaseClient.put.mockImplementation((params, callback) => {
-      callback(ConditionalCheckFailedException(), null) // error
+      callback(MockAWSConditionalCheckFailedError(), null) // error
     })
     return expect(
       ExampleModel.getOrCreate(user, itemToGetOrCreate)

--- a/graphql/database/base/__tests__/BaseModel-queries.test.js
+++ b/graphql/database/base/__tests__/BaseModel-queries.test.js
@@ -8,6 +8,7 @@ import ExampleModelRangeKey, {
 } from '../test-utils/ExampleModelRangeKey'
 import {
   addTimestampFieldsToItem,
+  ConditionalCheckFailedException,
   DatabaseOperation,
   getMockUserContext,
   mockDate,
@@ -664,7 +665,7 @@ describe('BaseModel queries', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
     const dbGetQueryMock = setMockDBResponse(DatabaseOperation.GET, {
       Item: itemToGetOrCreate,
@@ -705,7 +706,7 @@ describe('BaseModel queries', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
     return expect(
       ExampleModel.getOrCreate(user, itemToGetOrCreate)

--- a/graphql/database/donations/__tests__/donateVc.test.js
+++ b/graphql/database/donations/__tests__/donateVc.test.js
@@ -7,7 +7,7 @@ import donateVc from '../donateVc'
 import UserModel from '../../users/UserModel'
 import addVcDonatedAllTime from '../../users/addVcDonatedAllTime'
 import {
-  ConditionalCheckFailedException,
+  MockAWSConditionalCheckFailedError,
   DatabaseOperation,
   getMockUserContext,
   getMockUserInstance,
@@ -111,7 +111,7 @@ describe('donateVc', () => {
     setMockDBResponse(
       DatabaseOperation.UPDATE,
       null,
-      new ConditionalCheckFailedException() // simple mock error
+      new MockAWSConditionalCheckFailedError() // simple mock error
     )
     const returnedVal = await donateVc(
       userContext,
@@ -176,7 +176,7 @@ describe('donateVc', () => {
     jest
       .spyOn(VCDonationByCharityModel, 'update')
       .mockImplementation(() =>
-        Promise.reject(new ConditionalCheckFailedException())
+        Promise.reject(new MockAWSConditionalCheckFailedError())
       )
 
     const vcByHourCreateMethod = jest
@@ -221,7 +221,7 @@ describe('donateVc', () => {
     jest
       .spyOn(VCDonationByCharityModel, 'update')
       .mockImplementation(() =>
-        Promise.reject(new ConditionalCheckFailedException())
+        Promise.reject(new MockAWSConditionalCheckFailedError())
       )
 
     jest

--- a/graphql/database/donations/__tests__/donateVc.test.js
+++ b/graphql/database/donations/__tests__/donateVc.test.js
@@ -6,6 +6,7 @@ import VCDonationByCharityModel from '../VCDonationByCharityModel'
 import donateVc from '../donateVc'
 import UserModel from '../../users/UserModel'
 import addVcDonatedAllTime from '../../users/addVcDonatedAllTime'
+import { DatabaseConditionalCheckFailedException } from '../../../utils/exceptions'
 import {
   MockAWSConditionalCheckFailedError,
   DatabaseOperation,
@@ -176,7 +177,7 @@ describe('donateVc', () => {
     jest
       .spyOn(VCDonationByCharityModel, 'update')
       .mockImplementation(() =>
-        Promise.reject(new MockAWSConditionalCheckFailedError())
+        Promise.reject(new DatabaseConditionalCheckFailedException())
       )
 
     const vcByHourCreateMethod = jest
@@ -221,7 +222,7 @@ describe('donateVc', () => {
     jest
       .spyOn(VCDonationByCharityModel, 'update')
       .mockImplementation(() =>
-        Promise.reject(new MockAWSConditionalCheckFailedError())
+        Promise.reject(new DatabaseConditionalCheckFailedException())
       )
 
     jest

--- a/graphql/database/donations/donateVc.js
+++ b/graphql/database/donations/donateVc.js
@@ -84,7 +84,7 @@ export default async (userContext, userId, charityId, vc) => {
       })
     } catch (e) {
       // The item does not exist, so create it.
-      if (e.code === 'ConditionalCheckFailedException') {
+      if (e.code === DatabaseConditionalCheckFailedException.code) {
         try {
           await VCDonationByCharityModel.create(addVCDonatedByCharityOverride, {
             charityId,

--- a/graphql/database/donations/donateVc.js
+++ b/graphql/database/donations/donateVc.js
@@ -3,6 +3,7 @@ import VCDonationModel from './VCDonationModel'
 import VCDonationByCharityModel from './VCDonationByCharityModel'
 import UserModel from '../users/UserModel'
 import addVcDonatedAllTime from '../users/addVcDonatedAllTime'
+import { DatabaseConditionalCheckFailedException } from '../../utils/exceptions'
 import {
   getPermissionsOverride,
   ADD_VC_DONATED_BY_CHARITY,
@@ -43,7 +44,7 @@ export default async (userContext, userId, charityId, vc) => {
       )
     } catch (e) {
       // The user did not have sufficient VC.
-      if (e.code === 'ConditionalCheckFailedException') {
+      if (e.code === DatabaseConditionalCheckFailedException.code) {
         return {
           user: null,
           errors: [

--- a/graphql/database/test-utils.js
+++ b/graphql/database/test-utils.js
@@ -31,6 +31,7 @@ const availableOperations = [
   'query',
 ]
 
+// Deprecated: use more explicit mocks (see BaseModel-queries.testjs for examples).
 /**
  * Set a mock return function for a call to the database client.
  * @param {string} operation - The database operation to override
@@ -55,6 +56,7 @@ export const setMockDBResponse = (
   )
 }
 
+// Deprecated: use more explicit mocks (see BaseModel-queries.testjs for examples).
 /**
  * Clear all mock implementations for database operations.
  * @return {undefined}

--- a/graphql/database/test-utils.js
+++ b/graphql/database/test-utils.js
@@ -184,9 +184,9 @@ export const addTimestampFieldsToItem = item => {
 /**
  * Mock a ConditionalCheckFailedException error from DynamoDB.
  * @return {Object} An Error object with
- *.  code == 'ConditionalCheckFailedException'
+ *   code == 'ConditionalCheckFailedException'
  */
-export const ConditionalCheckFailedException = () => {
+export const MockAWSConditionalCheckFailedError = () => {
   const err = new Error('Conditional check failed.')
   err.code = 'ConditionalCheckFailedException'
   return err

--- a/graphql/database/userRevenue/__tests__/logRevenue.test.js
+++ b/graphql/database/userRevenue/__tests__/logRevenue.test.js
@@ -5,7 +5,7 @@ import { random } from 'lodash/number'
 import UserRevenueModel from '../UserRevenueModel'
 import logRevenue from '../logRevenue'
 import {
-  ConditionalCheckFailedException,
+  MockAWSConditionalCheckFailedError,
   DatabaseOperation,
   setMockDBResponse,
   addTimestampFieldsToItem,
@@ -425,7 +425,7 @@ describe('logRevenue', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Control the random millisecond selection.
@@ -461,12 +461,12 @@ describe('logRevenue', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     await expect(

--- a/graphql/database/userRevenue/__tests__/logRevenue.test.js
+++ b/graphql/database/userRevenue/__tests__/logRevenue.test.js
@@ -5,6 +5,7 @@ import { random } from 'lodash/number'
 import UserRevenueModel from '../UserRevenueModel'
 import logRevenue from '../logRevenue'
 import {
+  ConditionalCheckFailedException,
   DatabaseOperation,
   setMockDBResponse,
   addTimestampFieldsToItem,
@@ -421,9 +422,11 @@ describe('logRevenue', () => {
     const userRevenueCreate = jest.spyOn(UserRevenueModel, 'create')
 
     // Mock that the item already exists.
-    setMockDBResponse(DatabaseOperation.CREATE, null, {
-      code: 'ConditionalCheckFailedException',
-    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      ConditionalCheckFailedException()
+    )
 
     // Control the random millisecond selection.
     random.mockReturnValueOnce(7)
@@ -458,16 +461,12 @@ describe('logRevenue', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      new Error({
-        code: 'ConditionalCheckFailedException',
-      })
+      ConditionalCheckFailedException()
     )
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      new Error({
-        code: 'ConditionalCheckFailedException',
-      })
+      ConditionalCheckFailedException()
     )
 
     await expect(
@@ -480,9 +479,13 @@ describe('logRevenue', () => {
 
     // Mock that the item already exists for the original and the
     // retried "create" operations.
-    setMockDBResponse(DatabaseOperation.CREATE, null, {
-      code: 'BadExampleError',
-    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      new Error({
+        code: 'BadExampleError',
+      })
+    )
 
     await expect(
       logRevenue(userContext, userContext.id, 0.0172, '2468')

--- a/graphql/database/userRevenue/__tests__/logRevenue.test.js
+++ b/graphql/database/userRevenue/__tests__/logRevenue.test.js
@@ -429,7 +429,7 @@ describe('logRevenue', () => {
     )
 
     // Control the random millisecond selection.
-    random.mockReturnValueOnce(7)
+    random.mockReturnValueOnce(12).mockReturnValueOnce(18)
 
     await logRevenue(userContext, userContext.id, 0.0172, '2468')
     expect(userRevenueCreate).toHaveBeenCalledTimes(2)
@@ -437,7 +437,7 @@ describe('logRevenue', () => {
       userContext,
       addTimestampFieldsToItem({
         userId: userContext.id,
-        timestamp: '2017-06-22T01:13:28.000Z',
+        timestamp: '2017-06-22T01:13:28.012Z',
         revenue: 0.0172,
         dfpAdvertiserId: '2468',
       })
@@ -446,18 +446,59 @@ describe('logRevenue', () => {
       userContext,
       addTimestampFieldsToItem({
         userId: userContext.id,
-        timestamp: '2017-06-22T01:13:28.007Z', // Different time
+        timestamp: '2017-06-22T01:13:28.018Z', // Different time
         revenue: 0.0172,
         dfpAdvertiserId: '2468',
       })
     )
   })
 
-  test('throws an error when a DB item already exists twice in a row', async () => {
+  test('retries three times when a DB item already exists', async () => {
+    expect.assertions(1)
+
+    const userRevenueCreate = jest.spyOn(UserRevenueModel, 'create')
+
+    // Mock that the item already exists for the original and the
+    // retried "create" operations.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+
+    // Control the random millisecond selection.
+    random
+      .mockReturnValueOnce(12)
+      .mockReturnValueOnce(18)
+      .mockReturnValueOnce(3)
+
+    await logRevenue(userContext, userContext.id, 0.0172, '2468')
+    expect(userRevenueCreate).toHaveBeenLastCalledWith(
+      userContext,
+      addTimestampFieldsToItem({
+        userId: userContext.id,
+        timestamp: '2017-06-22T01:13:28.003Z', // Different time
+        revenue: 0.0172,
+        dfpAdvertiserId: '2468',
+      })
+    )
+  })
+
+  test('throws after 3 tries to log when a DB item already exists', async () => {
     expect.assertions(1)
 
     // Mock that the item already exists for the original and the
     // retried "create" operations.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,

--- a/graphql/database/userRevenue/logRevenue.js
+++ b/graphql/database/userRevenue/logRevenue.js
@@ -1,6 +1,7 @@
 import moment from 'moment'
 import { isNil } from 'lodash/lang'
 import { random } from 'lodash/number'
+import { DatabaseConditionalCheckFailedException } from '../../utils/exceptions'
 import UserRevenueModel from './UserRevenueModel'
 import decodeAmazonCPM from './decodeAmazonCPM'
 
@@ -172,13 +173,14 @@ const logRevenue = async (
   try {
     await createRevenueLogItem(ISOTimestamp)
   } catch (e) {
-    // TODO: make this more robust and rely on our custom exception.
+    // TODO: make this more robust
+
     // An item already exists with these keys.
     // This happens when a user logs two revenue items at the exact
     // same millisecond. We had assumed user ID (hash key) and timestamp
     // (sort key) would be sufficiently unique, but that's not always true.
     // https://github.com/gladly-team/tab/issues/330
-    if (e.code === 'ConditionalCheckFailedException') {
+    if (e.code === DatabaseConditionalCheckFailedException.code) {
       try {
         // A messy but sufficient fix: modify the timestamp slightly.
         const newISOTimestamp = addMillisecondsToISODatetime(ISOTimestamp)

--- a/graphql/database/userRevenue/logRevenue.js
+++ b/graphql/database/userRevenue/logRevenue.js
@@ -172,6 +172,7 @@ const logRevenue = async (
   try {
     await createRevenueLogItem(ISOTimestamp)
   } catch (e) {
+    // TODO: make this more robust and rely on our custom exception.
     // An item already exists with these keys.
     // This happens when a user logs two revenue items at the exact
     // same millisecond. We had assumed user ID (hash key) and timestamp

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -11,6 +11,7 @@ import setUpWidgetsForNewUser from '../../widgets/setUpWidgetsForNewUser'
 import logUserExperimentGroups from '../logUserExperimentGroups'
 import {
   addTimestampFieldsToItem,
+  ConditionalCheckFailedException,
   DatabaseOperation,
   getMockUserContext,
   getMockUserInfo,
@@ -555,7 +556,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
 
     // Mock database responses.
@@ -581,7 +582,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
     const userInfo = getMockUserInfo()
     const referralData = {
@@ -615,7 +616,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
 
     // Mock database responses.
@@ -654,7 +655,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
 
     // Mock database responses.
@@ -685,7 +686,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
 
     // Mock database responses.
@@ -733,7 +734,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
 
     // Mock database responses.
@@ -773,7 +774,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      { code: 'ConditionalCheckFailedException' } // simple mock error
+      ConditionalCheckFailedException()
     )
 
     // Mock database responses.

--- a/graphql/database/users/__tests__/createUser.test.js
+++ b/graphql/database/users/__tests__/createUser.test.js
@@ -11,7 +11,7 @@ import setUpWidgetsForNewUser from '../../widgets/setUpWidgetsForNewUser'
 import logUserExperimentGroups from '../logUserExperimentGroups'
 import {
   addTimestampFieldsToItem,
-  ConditionalCheckFailedException,
+  MockAWSConditionalCheckFailedError,
   DatabaseOperation,
   getMockUserContext,
   getMockUserInfo,
@@ -556,7 +556,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Mock database responses.
@@ -582,7 +582,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
     const userInfo = getMockUserInfo()
     const referralData = {
@@ -616,7 +616,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Mock database responses.
@@ -655,7 +655,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Mock database responses.
@@ -686,7 +686,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Mock database responses.
@@ -734,7 +734,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Mock database responses.
@@ -774,7 +774,7 @@ describe('createUser when user already exists (should be idempotent)', () => {
     setMockDBResponse(
       DatabaseOperation.CREATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Mock database responses.

--- a/graphql/database/users/__tests__/logTab.test.js
+++ b/graphql/database/users/__tests__/logTab.test.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import moment from 'moment'
-import { random } from 'lodash/number'
 import uuid from 'uuid/v4'
 import UserModel from '../UserModel'
 import UserTabsLogModel from '../UserTabsLogModel'
@@ -232,7 +231,7 @@ describe('logTab', () => {
       Item: mockUser,
     })
     jest.spyOn(UserModel, 'update').mockImplementationOnce(() => mockUser)
-    const userTabsLogCreate = jest.spyOn(UserTabsLogModel, 'create')
+    jest.spyOn(UserTabsLogModel, 'create')
 
     // Mock that the tab log already exists.
     setMockDBResponse(

--- a/graphql/database/users/__tests__/logTab.test.js
+++ b/graphql/database/users/__tests__/logTab.test.js
@@ -1,12 +1,14 @@
 /* eslint-env jest */
 
 import moment from 'moment'
+import { random } from 'lodash/number'
 import uuid from 'uuid/v4'
 import UserModel from '../UserModel'
 import UserTabsLogModel from '../UserTabsLogModel'
 import logTab from '../logTab'
 import addVc from '../addVc'
 import {
+  MockAWSConditionalCheckFailedError,
   DatabaseOperation,
   addTimestampFieldsToItem,
   getMockUserContext,
@@ -17,6 +19,7 @@ import {
 import { getCampaignObject } from '../../globals/getCampaign'
 import callRedis from '../../../utils/redis'
 
+jest.mock('lodash/number')
 jest.mock('../../databaseClient')
 jest.mock('../addVc')
 jest.mock('../../globals/getCampaign')
@@ -147,6 +150,108 @@ describe('logTab', () => {
         timestamp: moment.utc().toISOString(),
       })
     )
+  })
+
+  test('it retries logging the tab if there is a key conflict with the timestamp', async () => {
+    const userId = userContext.id
+
+    // Mock fetching the user.
+    const mockUser = getMockUserInstance({
+      lastTabTimestamp: '2017-06-22T01:13:25.000Z',
+    })
+    setMockDBResponse(DatabaseOperation.GET, {
+      Item: mockUser,
+    })
+    jest.spyOn(UserModel, 'update').mockImplementationOnce(() => mockUser)
+    const userTabsLogCreate = jest.spyOn(UserTabsLogModel, 'create')
+
+    // Mock that the tab log already exists.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+
+    await logTab(userContext, userId)
+
+    // It should create an item in UserTabsLog.
+    expect(userTabsLogCreate).toHaveBeenLastCalledWith(
+      userContext,
+      addTimestampFieldsToItem({
+        userId,
+        timestamp: moment.utc().toISOString(),
+      })
+    )
+  })
+
+  test('it retries logging the tab three times if there is a key conflict with the timestamp', async () => {
+    const userId = userContext.id
+
+    // Mock fetching the user.
+    const mockUser = getMockUserInstance({
+      lastTabTimestamp: '2017-06-22T01:13:25.000Z',
+    })
+    setMockDBResponse(DatabaseOperation.GET, {
+      Item: mockUser,
+    })
+    jest.spyOn(UserModel, 'update').mockImplementationOnce(() => mockUser)
+    const userTabsLogCreate = jest.spyOn(UserTabsLogModel, 'create')
+
+    // Mock that the tab log already exists.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+
+    await logTab(userContext, userId)
+
+    // It should create an item in UserTabsLog.
+    expect(userTabsLogCreate).toHaveBeenLastCalledWith(
+      userContext,
+      addTimestampFieldsToItem({
+        userId,
+        timestamp: moment.utc().toISOString(),
+      })
+    )
+  })
+
+  test('it throws after 3 tries to log when a DB item already exists', async () => {
+    const userId = userContext.id
+
+    // Mock fetching the user.
+    const mockUser = getMockUserInstance({
+      lastTabTimestamp: '2017-06-22T01:13:25.000Z',
+    })
+    setMockDBResponse(DatabaseOperation.GET, {
+      Item: mockUser,
+    })
+    jest.spyOn(UserModel, 'update').mockImplementationOnce(() => mockUser)
+    const userTabsLogCreate = jest.spyOn(UserTabsLogModel, 'create')
+
+    // Mock that the tab log already exists.
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
+
+    await expect(logTab(userContext, userId)).rejects.toThrow()
   })
 
   test('it logs the tab ID when given', async () => {

--- a/graphql/database/users/logTab.js
+++ b/graphql/database/users/logTab.js
@@ -95,6 +95,7 @@ const logTab = async (userContext, userId, tabId = null) => {
       maxTabsDay: maxTabsDayVal,
     })
 
+    // TODO: handle duplicate timestamps
     // Log the tab for analytics whether a valid tab or not.
     await UserTabsLogModel.create(userContext, {
       userId,

--- a/graphql/database/widgets/userWidget/__tests__/updateUserWidgetConfig.test.js
+++ b/graphql/database/widgets/userWidget/__tests__/updateUserWidgetConfig.test.js
@@ -4,6 +4,7 @@ import moment from 'moment'
 import updateUserWidgetConfig from '../updateUserWidgetConfig'
 import UserWidgetModel from '../UserWidgetModel'
 import {
+  ConditionalCheckFailedException,
   DatabaseOperation,
   getMockUserContext,
   getMockUserInfo,
@@ -71,9 +72,11 @@ describe('updateUserWidgetConfig', () => {
     const userWidgetCreate = jest.spyOn(UserWidgetModel, 'create')
 
     // Set that the item doesn't exist when updating.
-    setMockDBResponse(DatabaseOperation.UPDATE, null, {
-      code: 'ConditionalCheckFailedException',
-    })
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      ConditionalCheckFailedException()
+    )
 
     // Set the return for the created object.
     const userWidget = new UserWidgetModel({
@@ -114,9 +117,11 @@ describe('updateUserWidgetConfig', () => {
     const userInfo = getMockUserInfo()
 
     // Set that the item doesn't exist when updating.
-    setMockDBResponse(DatabaseOperation.UPDATE, null, {
-      code: 'ConditionalCheckFailedException',
-    })
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      ConditionalCheckFailedException()
+    )
 
     // Set the return for the created object.
     const userWidget = new UserWidgetModel({
@@ -176,9 +181,7 @@ describe('updateUserWidgetConfig', () => {
     setMockDBResponse(
       DatabaseOperation.UPDATE,
       null,
-      new Error({
-        code: 'ConditionalCheckFailedException',
-      })
+      ConditionalCheckFailedException()
     )
 
     // Set some error during creation.

--- a/graphql/database/widgets/userWidget/__tests__/updateUserWidgetConfig.test.js
+++ b/graphql/database/widgets/userWidget/__tests__/updateUserWidgetConfig.test.js
@@ -4,7 +4,7 @@ import moment from 'moment'
 import updateUserWidgetConfig from '../updateUserWidgetConfig'
 import UserWidgetModel from '../UserWidgetModel'
 import {
-  ConditionalCheckFailedException,
+  MockAWSConditionalCheckFailedError,
   DatabaseOperation,
   getMockUserContext,
   getMockUserInfo,
@@ -75,7 +75,7 @@ describe('updateUserWidgetConfig', () => {
     setMockDBResponse(
       DatabaseOperation.UPDATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Set the return for the created object.
@@ -120,7 +120,7 @@ describe('updateUserWidgetConfig', () => {
     setMockDBResponse(
       DatabaseOperation.UPDATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Set the return for the created object.
@@ -181,7 +181,7 @@ describe('updateUserWidgetConfig', () => {
     setMockDBResponse(
       DatabaseOperation.UPDATE,
       null,
-      ConditionalCheckFailedException()
+      MockAWSConditionalCheckFailedError()
     )
 
     // Set some error during creation.

--- a/graphql/database/widgets/userWidget/__tests__/updateUserWidgetEnabled.test.js
+++ b/graphql/database/widgets/userWidget/__tests__/updateUserWidgetEnabled.test.js
@@ -4,6 +4,7 @@ import moment from 'moment'
 import updateUserWidgetEnabled from '../updateUserWidgetEnabled'
 import UserWidgetModel from '../UserWidgetModel'
 import {
+  MockAWSConditionalCheckFailedError,
   DatabaseOperation,
   getMockUserContext,
   getMockUserInfo,
@@ -65,9 +66,11 @@ describe('updateUserWidgetEnabled', () => {
     const userWidgetCreate = jest.spyOn(UserWidgetModel, 'create')
 
     // Set that the item doesn't exist when updating.
-    setMockDBResponse(DatabaseOperation.UPDATE, null, {
-      code: 'ConditionalCheckFailedException',
-    })
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
 
     // Set the return for the created object.
     const userWidget = new UserWidgetModel({
@@ -105,9 +108,11 @@ describe('updateUserWidgetEnabled', () => {
     const userInfo = getMockUserInfo()
 
     // Set that the item doesn't exist when updating.
-    setMockDBResponse(DatabaseOperation.UPDATE, null, {
-      code: 'ConditionalCheckFailedException',
-    })
+    setMockDBResponse(
+      DatabaseOperation.UPDATE,
+      null,
+      MockAWSConditionalCheckFailedError()
+    )
 
     // Set the return for the created object.
     const userWidget = new UserWidgetModel({
@@ -162,15 +167,17 @@ describe('updateUserWidgetEnabled', () => {
     setMockDBResponse(
       DatabaseOperation.UPDATE,
       null,
-      new Error({
-        code: 'ConditionalCheckFailedException',
-      })
+      MockAWSConditionalCheckFailedError()
     )
 
     // Set some error during creation.
-    setMockDBResponse(DatabaseOperation.CREATE, null, {
-      code: 'SomethingWentWrong',
-    })
+    setMockDBResponse(
+      DatabaseOperation.CREATE,
+      null,
+      new Error({
+        code: 'SomethingWentWrong',
+      })
+    )
 
     return expect(
       updateUserWidgetEnabled(userContext, userInfo.id, widgetId, true)

--- a/graphql/database/widgets/userWidget/updateUserWidgetConfig.js
+++ b/graphql/database/widgets/userWidget/updateUserWidgetConfig.js
@@ -1,4 +1,5 @@
 import UserWidgetModel from './UserWidgetModel'
+import { DatabaseConditionalCheckFailedException } from '../../../utils/exceptions'
 
 /**
  * Update widget data.
@@ -21,7 +22,7 @@ export default async (userContext, userId, widgetId, config) => {
     // The item likely does not exist. This might happen when a
     // user modifies the config of a widget they've never used.
     // Try to create the widget.
-    if (e.code === 'ConditionalCheckFailedException') {
+    if (e.code === DatabaseConditionalCheckFailedException.code) {
       try {
         userWidget = await UserWidgetModel.create(userContext, {
           userId,

--- a/graphql/database/widgets/userWidget/updateUserWidgetEnabled.js
+++ b/graphql/database/widgets/userWidget/updateUserWidgetEnabled.js
@@ -1,4 +1,5 @@
 import UserWidgetModel from './UserWidgetModel'
+import { DatabaseConditionalCheckFailedException } from '../../../utils/exceptions'
 
 /**
  * Update widget data.
@@ -21,7 +22,7 @@ export default async (userContext, userId, widgetId, enabled) => {
     // The item likely does not exist. This might happen when a
     // user enables a widget they've never used.
     // Try to create the widget.
-    if (e.code === 'ConditionalCheckFailedException') {
+    if (e.code === DatabaseConditionalCheckFailedException.code) {
       try {
         userWidget = await UserWidgetModel.create(userContext, {
           userId,

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -27,12 +27,15 @@ class UnauthorizedQueryException extends ExtendableError {
 }
 
 // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes
-export const DATABASE_CONDITIONAL_CHECK_FAILED =
-  'DATABASE_CONDITIONAL_CHECK_FAILED'
+const DATABASE_CONDITIONAL_CHECK_FAILED = 'DATABASE_CONDITIONAL_CHECK_FAILED'
 class DatabaseConditionalCheckFailedException extends ExtendableError {
   constructor() {
     super('The conditional check failed when trying to modify a database item.')
     this.code = DATABASE_CONDITIONAL_CHECK_FAILED
+  }
+
+  static get code() {
+    return DATABASE_CONDITIONAL_CHECK_FAILED
   }
 }
 

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -26,6 +26,16 @@ class UnauthorizedQueryException extends ExtendableError {
   }
 }
 
+// https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes
+export const DATABASE_CONDITIONAL_CHECK_FAILED =
+  'DATABASE_CONDITIONAL_CHECK_FAILED'
+class DatabaseConditionalCheckFailedException extends ExtendableError {
+  constructor() {
+    super('The conditional check failed when trying to modify a database item.')
+    this.code = DATABASE_CONDITIONAL_CHECK_FAILED
+  }
+}
+
 export const DATABASE_ITEM_DOES_NOT_EXIST = 'DATABASE_ITEM_DOES_NOT_EXIST'
 class DatabaseItemDoesNotExistException extends ExtendableError {
   constructor() {
@@ -66,6 +76,7 @@ class EmptyOperationStackException extends MockDatabaseException {
 export {
   NotImplementedException,
   UnauthorizedQueryException,
+  DatabaseConditionalCheckFailedException,
   DatabaseItemDoesNotExistException,
   UserReachedMaxLevelException,
   UserDoesNotExistException,


### PR DESCRIPTION
* Create a custom error, `DatabaseConditionalCheckFailedException`, to throw when AWS DynamoDB returns a "ConditionalCheckFailedException" during item create/update
* Try logging revenue 3 times instead of 2 when it fails with key conflicts
* Try logging tabs 3 times when it fails with key conflicts (currently failing immediately)
* Use await/async in BaseModel
* Clean up BaseModel tests to explicitly set database operation mocks and deprecate the `setMockDBResponse` helper function, which just complicates tests
* Use a helper function to create mock AWS "ConditionalCheckFailedException" errors in tests 