### PR TITLE
Don't log UnauthorizedQueryException errors

### DIFF
--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -8,7 +8,7 @@ import { permissionAuthorizers } from '../../utils/authorization-helpers'
 import config from '../../config'
 import { getTodayTabCount, getTodaySearchCount } from './user-utils'
 import {
-  DATABASE_ITEM_DOES_NOT_EXIST,
+  DatabaseItemDoesNotExistException,
   UserDoesNotExistException,
 } from '../../utils/exceptions'
 
@@ -393,7 +393,7 @@ class User extends BaseModel {
       const response = await super.get(...args)
       return response
     } catch (e) {
-      if (e.code === DATABASE_ITEM_DOES_NOT_EXIST) {
+      if (e.code === DatabaseItemDoesNotExistException.code) {
         throw new UserDoesNotExistException()
       } else {
         throw e

--- a/graphql/database/users/rewardReferringUser.js
+++ b/graphql/database/users/rewardReferringUser.js
@@ -8,7 +8,7 @@ import {
 } from '../../utils/permissions-overrides'
 import addVc from './addVc'
 import addUsersRecruited from './addUsersRecruited'
-import { DATABASE_ITEM_DOES_NOT_EXIST } from '../../utils/exceptions'
+import { DatabaseItemDoesNotExistException } from '../../utils/exceptions'
 
 const override = getPermissionsOverride(REWARD_REFERRER_OVERRIDE)
 
@@ -37,7 +37,7 @@ const rewardReferringUser = async (userContext, userId) => {
     }
   } catch (e) {
     // Referral data may not exist.
-    if (e.code === DATABASE_ITEM_DOES_NOT_EXIST) {
+    if (e.code === DatabaseItemDoesNotExistException.code) {
       return false
     }
     throw e

--- a/graphql/utils/error-logging.js
+++ b/graphql/utils/error-logging.js
@@ -1,6 +1,9 @@
 import { get } from 'lodash/object'
 import logger from './logger'
-import { USER_DOES_NOT_EXIST, UnauthorizedQueryException } from './exceptions'
+import {
+  UserDoesNotExistException,
+  UnauthorizedQueryException,
+} from './exceptions'
 
 /*
  * Wrap a function and log all exceptions, then re-throw the
@@ -39,7 +42,7 @@ export const formatError = graphQLError => ({
  */
 const shouldLogError = graphQLError => {
   const errorCodesToSkipLogging = [
-    USER_DOES_NOT_EXIST, // can happen during sign up
+    UserDoesNotExistException.code, // can happen during sign up
     UnauthorizedQueryException.code, // can happen during logout (when storage is cleared)
   ]
   const errCode = get(graphQLError, 'originalError.code')

--- a/graphql/utils/error-logging.js
+++ b/graphql/utils/error-logging.js
@@ -39,8 +39,8 @@ export const formatError = graphQLError => ({
  */
 const shouldLogError = graphQLError => {
   const errorCodesToSkipLogging = [
-    USER_DOES_NOT_EXIST,
-    UnauthorizedQueryException.code,
+    USER_DOES_NOT_EXIST, // can happen during sign up
+    UnauthorizedQueryException.code, // can happen during logout (when storage is cleared)
   ]
   const errCode = get(graphQLError, 'originalError.code')
   return errorCodesToSkipLogging.indexOf(errCode) === -1

--- a/graphql/utils/error-logging.js
+++ b/graphql/utils/error-logging.js
@@ -1,6 +1,6 @@
 import { get } from 'lodash/object'
 import logger from './logger'
-import { USER_DOES_NOT_EXIST } from './exceptions'
+import { USER_DOES_NOT_EXIST, UnauthorizedQueryException } from './exceptions'
 
 /*
  * Wrap a function and log all exceptions, then re-throw the
@@ -38,7 +38,10 @@ export const formatError = graphQLError => ({
  * @return {Boolean} Whether we should log the error.
  */
 const shouldLogError = graphQLError => {
-  const errorCodesToSkipLogging = [USER_DOES_NOT_EXIST]
+  const errorCodesToSkipLogging = [
+    USER_DOES_NOT_EXIST,
+    UnauthorizedQueryException.code,
+  ]
   const errCode = get(graphQLError, 'originalError.code')
   return errorCodesToSkipLogging.indexOf(errCode) === -1
 }

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -10,15 +10,19 @@ class ExtendableError extends Error {
   }
 }
 
-export const METHOD_NOT_IMPLEMENTED = 'METHOD_NOT_IMPLEMENTED'
+const METHOD_NOT_IMPLEMENTED = 'METHOD_NOT_IMPLEMENTED'
 class NotImplementedException extends ExtendableError {
   constructor() {
     super('Required method is not implemented.')
     this.code = METHOD_NOT_IMPLEMENTED
   }
+
+  static get code() {
+    return METHOD_NOT_IMPLEMENTED
+  }
 }
 
-export const UNAUTHORIZED_QUERY = 'UNAUTHORIZED_QUERY'
+const UNAUTHORIZED_QUERY = 'UNAUTHORIZED_QUERY'
 class UnauthorizedQueryException extends ExtendableError {
   constructor() {
     super('Query not authorized.')
@@ -30,7 +34,7 @@ class UnauthorizedQueryException extends ExtendableError {
   }
 }
 
-export const DATABASE_ITEM_DOES_NOT_EXIST = 'DATABASE_ITEM_DOES_NOT_EXIST'
+const DATABASE_ITEM_DOES_NOT_EXIST = 'DATABASE_ITEM_DOES_NOT_EXIST'
 class DatabaseItemDoesNotExistException extends ExtendableError {
   constructor() {
     super('The database does not contain an item with these keys.')
@@ -42,32 +46,44 @@ class DatabaseItemDoesNotExistException extends ExtendableError {
   }
 }
 
-export const USER_REACHED_MAX_LEVEL = 'USER_REACHED_MAX_LEVEL'
+const USER_REACHED_MAX_LEVEL = 'USER_REACHED_MAX_LEVEL'
 class UserReachedMaxLevelException extends ExtendableError {
   constructor() {
     super('There are no more levels. The user is at the max level.')
     this.code = USER_REACHED_MAX_LEVEL
   }
+
+  static get code() {
+    return USER_REACHED_MAX_LEVEL
+  }
 }
 
-export const USER_DOES_NOT_EXIST = 'USER_DOES_NOT_EXIST'
+const USER_DOES_NOT_EXIST = 'USER_DOES_NOT_EXIST'
 class UserDoesNotExistException extends ExtendableError {
   constructor() {
     super('No user exists with this ID.')
     this.code = USER_DOES_NOT_EXIST
+  }
+
+  static get code() {
+    return USER_DOES_NOT_EXIST
   }
 }
 
 // For tests.
 class MockDatabaseException extends ExtendableError {}
 
-export const OPERATION_STACK_IS_EMPTY = 'OPERATION_STACK_IS_EMPTY'
+const OPERATION_STACK_IS_EMPTY = 'OPERATION_STACK_IS_EMPTY'
 class EmptyOperationStackException extends MockDatabaseException {
   constructor() {
     super(
       'Operation stack is empty. Check if you set your expected data in the test.'
     )
     this.code = OPERATION_STACK_IS_EMPTY
+  }
+
+  static get code() {
+    return OPERATION_STACK_IS_EMPTY
   }
 }
 

--- a/graphql/utils/exceptions.js
+++ b/graphql/utils/exceptions.js
@@ -24,6 +24,10 @@ class UnauthorizedQueryException extends ExtendableError {
     super('Query not authorized.')
     this.code = UNAUTHORIZED_QUERY
   }
+
+  static get code() {
+    return UNAUTHORIZED_QUERY
+  }
 }
 
 export const DATABASE_ITEM_DOES_NOT_EXIST = 'DATABASE_ITEM_DOES_NOT_EXIST'
@@ -31,6 +35,10 @@ class DatabaseItemDoesNotExistException extends ExtendableError {
   constructor() {
     super('The database does not contain an item with these keys.')
     this.code = DATABASE_ITEM_DOES_NOT_EXIST
+  }
+
+  static get code() {
+    return DATABASE_ITEM_DOES_NOT_EXIST
   }
 }
 


### PR DESCRIPTION
The errors are expected when a user removes their credentials (e.g. they delete the Firebase item in IndexedDB) and aren't helpful.

We may eventually want to address the root issue, for example by not making requests when the user token is missing. There's a scenario where the logs are helpful; e.g., we introduce a bug in authorization and a spike in these exceptions would help us address it.