### PR TITLE
Support opting users into Tab v4 beta during sign-in

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -61,6 +61,7 @@ import logUserExperimentGroups from '../database/users/logUserExperimentGroups'
 import logUserExperimentActions from '../database/users/logUserExperimentActions'
 import constructExperimentActionsType from '../database/users/constructExperimentActionsType'
 import logReferralLinkClick from '../database/referrals/logReferralLinkClick'
+import setV4Enabled from '../database/users/setV4Enabled'
 
 import CharityModel from '../database/charities/CharityModel'
 import getCharities from '../database/charities/getCharities'
@@ -1683,6 +1684,26 @@ const logUserDataConsentMutation = mutationWithClientMutationId({
 })
 
 /**
+ * Enable or disable the Tab V4 beta app for this user.
+ */
+const setV4BetaMutation = mutationWithClientMutationId({
+  name: 'SetV4Beta',
+  inputFields: {
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    enabled: { type: new GraphQLNonNull(GraphQLBoolean) },
+  },
+  outputFields: {
+    user: {
+      type: userType,
+    },
+  },
+  mutateAndGetPayload: ({ userId, enabled }, context) => {
+    const userGlobalObj = fromGlobalId(userId)
+    return setV4Enabled(context.user, { userId: userGlobalObj.id, enabled })
+  },
+})
+
+/**
  * This is the type that will be the root of our query,
  * and the entry point into our schema.
  */
@@ -1737,6 +1758,7 @@ const mutationType = new GraphQLObjectType({
     setUsername: setUsernameMutation,
     updateUserExperimentGroups: updateUserExperimentGroupsMutation,
     logUserExperimentActions: logUserExperimentActionsMutation,
+    setV4Beta: setV4BetaMutation,
   }),
 })
 

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -461,6 +461,10 @@ const userType = new GraphQLObjectType({
       type: GraphQLInt,
       description: "User's vc",
     },
+    v4BetaEnabled: {
+      type: GraphQLBoolean,
+      description: 'If true, serve the new Tab V4 app.',
+    },
     // TODO: change to heartsForNextLevel to be able to get progress
     heartsUntilNextLevel: {
       type: GraphQLInt,

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -101,6 +101,10 @@ class User extends BaseModel {
         .integer()
         .forbidden() // only set in deserializer
         .description(`How many tabs the user has opened today (UTC day).`),
+      v4BetaEnabled: types
+        .boolean()
+        .default(self.fieldDefaults.v4BetaEnabled)
+        .description(`If true, serve the new Tab V4 app.`),
       validTabs: types
         .number()
         .integer()
@@ -365,6 +369,7 @@ class User extends BaseModel {
           numSearches: 0,
         },
       }),
+      v4BetaEnabled: false,
     }
   }
 

--- a/graphql/database/users/__tests__/UserModel.test.js
+++ b/graphql/database/users/__tests__/UserModel.test.js
@@ -263,6 +263,7 @@ describe('UserModel', () => {
         },
       },
       searchesToday: 0,
+      v4BetaEnabled: false,
     })
   })
 

--- a/graphql/database/users/__tests__/setV4Enabled.test.js
+++ b/graphql/database/users/__tests__/setV4Enabled.test.js
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+
+import moment from 'moment'
+import logger from '../../../utils/logger'
+import { getMockUserContext, mockDate } from '../../test-utils'
+
+jest.mock('../../databaseClient')
+jest.mock('../getUserByUsername')
+jest.mock('../../../utils/logger')
+
+const userContext = getMockUserContext()
+
+beforeAll(() => {
+  mockDate.on()
+})
+
+afterAll(() => {
+  mockDate.off()
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('setV4Enabled', () => {
+  it('sets the value when enabled === true', async () => {
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+    const setV4Enabled = require('../setV4Enabled').default
+    await setV4Enabled(userContext, { userId: userContext.id, enabled: true })
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      v4BetaEnabled: true,
+      updated: moment.utc().toISOString(),
+    })
+  })
+
+  it('sets the value when enabled === false', async () => {
+    const UserModel = require('../UserModel').default
+    const updateQuery = jest.spyOn(UserModel, 'update')
+    const setV4Enabled = require('../setV4Enabled').default
+    await setV4Enabled(userContext, { userId: userContext.id, enabled: false })
+    expect(updateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      v4BetaEnabled: false,
+      updated: moment.utc().toISOString(),
+    })
+  })
+
+  it('throws if calling the DB throws', async () => {
+    const UserModel = require('../UserModel').default
+    const mockErr = new Error('No good.')
+    jest.spyOn(UserModel, 'update').mockImplementationOnce(() => {
+      throw mockErr
+    })
+    const setV4Enabled = require('../setV4Enabled').default
+    await expect(
+      setV4Enabled(userContext, { userId: userContext.id, enabled: false })
+    ).rejects.toThrow(mockErr)
+  })
+
+  it('logs an error if calling the DB throws', async () => {
+    const UserModel = require('../UserModel').default
+    const mockErr = new Error('No good.')
+    jest.spyOn(UserModel, 'update').mockImplementationOnce(() => {
+      throw mockErr
+    })
+    const setV4Enabled = require('../setV4Enabled').default
+
+    try {
+      await setV4Enabled(userContext, {
+        userId: userContext.id,
+        enabled: false,
+      })
+    } catch (e) {} // eslint-disable-line no-empty
+    expect(logger.error).toHaveBeenCalledWith(mockErr)
+  })
+})

--- a/graphql/database/users/setV4Enabled.js
+++ b/graphql/database/users/setV4Enabled.js
@@ -1,0 +1,25 @@
+import UserModel from './UserModel'
+import logger from '../../utils/logger'
+
+/**
+ * Set whether the user should use the Tab V4 beta app.
+ * @param {Object} userContext - The user authorizer object.
+ * @param {String} userId - The user ID.
+ * @param {String} enabled - Whether the V4 beta is enabled.
+ * @return {Promise<Object>} response - A Promise that resolves into a
+ *   User object
+ */
+const setV4Enabled = async (userContext, { userId, enabled }) => {
+  try {
+    const user = await UserModel.update(userContext, {
+      id: userId,
+      v4BetaEnabled: enabled,
+    })
+    return user
+  } catch (e) {
+    logger.error(e)
+    throw e
+  }
+}
+
+export default setV4Enabled

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -606,6 +606,7 @@ type Mutation {
   setUsername(input: SetUsernameInput!): SetUsernamePayload
   updateUserExperimentGroups(input: UpdateUserExperimentGroupsInput!): UpdateUserExperimentGroupsPayload
   logUserExperimentActions(input: LogUserExperimentActionsInput!): LogUserExperimentActionsPayload
+  setV4Beta(input: SetV4BetaInput!): SetV4BetaPayload
 }
 
 """An object with an ID"""
@@ -727,6 +728,17 @@ input SetUsernameInput {
 type SetUsernamePayload {
   user: User
   errors: [CustomError]
+  clientMutationId: String
+}
+
+input SetV4BetaInput {
+  userId: String!
+  enabled: Boolean!
+  clientMutationId: String
+}
+
+type SetV4BetaPayload {
+  user: User
   clientMutationId: String
 }
 

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -828,6 +828,9 @@ type User implements Node {
   """User's vc"""
   level: Int
 
+  """If true, serve the new Tab V4 app."""
+  v4BetaEnabled: Boolean
+
   """Remaing hearts until next level."""
   heartsUntilNextLevel: Int
 

--- a/web/src/js/authentication/__tests__/user.test.js
+++ b/web/src/js/authentication/__tests__/user.test.js
@@ -294,7 +294,7 @@ describe('getUserToken tests', () => {
   })
 
   it('removes some localStorage items on logout', async () => {
-    expect.assertions(14)
+    expect.assertions(15)
     const localStorageMgr = require('js/utils/localstorage-mgr').default
     const logout = require('js/authentication/user').logout
     await logout()
@@ -335,7 +335,10 @@ describe('getUserToken tests', () => {
     expect(localStorageMgr.removeItem).toHaveBeenCalledWith(
       'tab.experiments.anonUser'
     )
-    expect(localStorageMgr.removeItem).toHaveBeenCalledTimes(13)
+    expect(localStorageMgr.removeItem).toHaveBeenCalledWith(
+      'tab.newUser.isTabV4Enabled'
+    )
+    expect(localStorageMgr.removeItem).toHaveBeenCalledTimes(14)
   })
 })
 

--- a/web/src/js/authentication/user.js
+++ b/web/src/js/authentication/user.js
@@ -15,6 +15,7 @@ import {
   STORAGE_EXTENSION_INSTALL_ID,
   STORAGE_APPROX_EXTENSION_INSTALL_TIME,
   STORAGE_EXPERIMENT_ANON_USER,
+  STORAGE_NEW_USER_IS_TAB_V4_BETA,
 } from 'js/constants'
 import { absoluteUrl, enterUsernameURL } from 'js/navigation/navigation'
 import logger from 'js/utils/logger'
@@ -206,6 +207,7 @@ const clearAuthLocalStorageItems = () => {
   localStorageMgr.removeItem(STORAGE_EXTENSION_INSTALL_ID)
   localStorageMgr.removeItem(STORAGE_APPROX_EXTENSION_INSTALL_TIME)
   localStorageMgr.removeItem(STORAGE_EXPERIMENT_ANON_USER)
+  localStorageMgr.removeItem(STORAGE_NEW_USER_IS_TAB_V4_BETA)
 }
 
 /**

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -265,7 +265,6 @@ class Authentication extends React.Component {
       // Don't display the message on the iframe auth message page, because
       // it will have its own message.
       location.pathname.indexOf(authMessageURL) === -1
-    const nextURL = this.getNextURLAfterSignIn()
 
     return (
       <MuiThemeProvider theme={defaultTheme}>

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -136,7 +136,7 @@ class Authentication extends React.Component {
       // If needed, opt the user into Tab v4. We need to
       // do this *after* all of the auth logic on this app
       // because v4 does not yet have a complete auth flow.
-      const enableTabV4 = get(user, 'isTabV4BetaUser') || isTabV4BetaUser()
+      const enableTabV4 = get(user, 'v4BetaEnabled') || isTabV4BetaUser()
       const destinationURL = this.getNextURLAfterSignIn()
       if (enableTabV4) {
         try {
@@ -425,6 +425,7 @@ Authentication.propTypes = {
   user: PropTypes.shape({
     id: PropTypes.string,
     username: PropTypes.string,
+    v4BetaEnabled: PropTypes.bool,
   }),
 }
 

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -36,6 +36,7 @@ import logger from 'js/utils/logger'
 import tabTheme from 'js/theme/defaultV1'
 import searchTheme from 'js/theme/searchTheme'
 import { SEARCH_APP, TAB_APP } from 'js/constants'
+import optIntoV4Beta from 'js/utils/v4-beta-opt-in'
 
 // Handle the authentication flow:
 //   check if current user is fully authenticated and redirect
@@ -161,7 +162,13 @@ class Authentication extends React.Component {
     // database, because this is when we add their email address
     // and email verification status to their profile.
     return createNewUser()
-      .then(createdOrFetchedUser => {
+      .then(async createdOrFetchedUser => {
+        // If needed, opt the user into Tab v4.
+        const isTabV4 = true // TODO
+        if (isTabV4) {
+          await optIntoV4Beta()
+        }
+
         // Check if the user has verified their email.
         // Note: later versions of firebaseui-web might support mandatory
         // email verification:

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -40,6 +40,7 @@ import searchTheme from 'js/theme/searchTheme'
 import { SEARCH_APP, TAB_APP } from 'js/constants'
 import optIntoV4Beta from 'js/utils/v4-beta-opt-in'
 import { isTabV4BetaUser } from 'js/utils/local-user-data-mgr'
+import SetV4BetaMutation from 'js/mutations/SetV4BetaMutation'
 
 // Handle the authentication flow:
 //   check if current user is fully authenticated and redirect
@@ -63,8 +64,8 @@ import { isTabV4BetaUser } from 'js/utils/local-user-data-mgr'
 //  * we're making the username mandatory but can't rely on a field
 //    from the authentication user token to store this info
 class Authentication extends React.Component {
-  componentDidMount() {
-    this.navigateToAuthStep()
+  async componentDidMount() {
+    await this.navigateToAuthStep()
   }
 
   componentWillReceiveProps(nextProps) {
@@ -145,6 +146,16 @@ class Authentication extends React.Component {
           // TODO: show error to user / handle error more gracefully
           logger.error(e)
         }
+
+        // If the local storage value is set to V4 but the user's
+        // profile is not, update the user's profile.
+        if (!get(user, 'v4BetaEnabled')) {
+          await SetV4BetaMutation({
+            userId: user.id,
+            enabled: true,
+          })
+        }
+
         externalRedirect(destinationURL)
       } else {
         replaceUrl(destinationURL)

--- a/web/src/js/components/Authentication/Authentication.js
+++ b/web/src/js/components/Authentication/Authentication.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
+import { get } from 'lodash/object'
 import Paper from '@material-ui/core/Paper'
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
@@ -37,6 +38,7 @@ import tabTheme from 'js/theme/defaultV1'
 import searchTheme from 'js/theme/searchTheme'
 import { SEARCH_APP, TAB_APP } from 'js/constants'
 import optIntoV4Beta from 'js/utils/v4-beta-opt-in'
+import { isTabV4BetaUser } from 'js/utils/local-user-data-mgr'
 
 // Handle the authentication flow:
 //   check if current user is fully authenticated and redirect
@@ -164,8 +166,10 @@ class Authentication extends React.Component {
     return createNewUser()
       .then(async createdOrFetchedUser => {
         // If needed, opt the user into Tab v4.
-        const isTabV4 = true // TODO
-        if (isTabV4) {
+        const enableTabV4 =
+          get(createdOrFetchedUser, 'createNewUser.isTabV4BetaUser') ||
+          isTabV4BetaUser()
+        if (enableTabV4) {
           await optIntoV4Beta()
         }
 

--- a/web/src/js/components/Authentication/AuthenticationContainer.js
+++ b/web/src/js/components/Authentication/AuthenticationContainer.js
@@ -3,6 +3,7 @@ import { createFragmentContainer } from 'react-relay'
 
 import Authentication from 'js/components/Authentication/Authentication'
 
+// TODO: fetch if the user is in the Tab v4 beta
 export default createFragmentContainer(Authentication, {
   user: graphql`
     fragment AuthenticationContainer_user on User {

--- a/web/src/js/components/Authentication/AuthenticationContainer.js
+++ b/web/src/js/components/Authentication/AuthenticationContainer.js
@@ -3,13 +3,13 @@ import { createFragmentContainer } from 'react-relay'
 
 import Authentication from 'js/components/Authentication/Authentication'
 
-// TODO: fetch if the user is in the Tab v4 beta
 export default createFragmentContainer(Authentication, {
   user: graphql`
     fragment AuthenticationContainer_user on User {
       id
       email
       username
+      v4BetaEnabled
       ...AssignExperimentGroupsContainer_user
     }
   `,

--- a/web/src/js/components/Authentication/EnterUsernameForm.js
+++ b/web/src/js/components/Authentication/EnterUsernameForm.js
@@ -85,6 +85,8 @@ class EnterUsernameForm extends React.Component {
     // and redirect to the app.
     setUsernameInLocalStorage(data.user.username)
 
+    // FIXME: need to set Tab V4 beta data here, too
+
     // Go to the app.
     goTo(nextURL)
   }

--- a/web/src/js/components/Authentication/EnterUsernameForm.js
+++ b/web/src/js/components/Authentication/EnterUsernameForm.js
@@ -7,7 +7,6 @@ import UsernameField from 'js/components/General/UsernameField'
 import SetUsernameMutation from 'js/mutations/SetUsernameMutation'
 import { setUsernameInLocalStorage } from 'js/authentication/user'
 import { checkIfEmailVerified } from 'js/authentication/helpers'
-import { goTo } from 'js/navigation/navigation'
 import logger from 'js/utils/logger'
 import { SEARCH_APP, TAB_APP } from 'js/constants'
 
@@ -57,7 +56,7 @@ class EnterUsernameForm extends React.Component {
   }
 
   onMutationCompleted(response) {
-    const { nextURL } = this.props
+    const { onCompleted } = this.props
     this.setState({
       savingUsernameInProgress: false,
     })
@@ -85,10 +84,8 @@ class EnterUsernameForm extends React.Component {
     // and redirect to the app.
     setUsernameInLocalStorage(data.user.username)
 
-    // FIXME: need to set Tab V4 beta data here, too
-
     // Go to the app.
-    goTo(nextURL)
+    onCompleted()
   }
 
   onMutationError(response) {
@@ -174,7 +171,7 @@ class EnterUsernameForm extends React.Component {
 
 EnterUsernameForm.propTypes = {
   app: PropTypes.oneOf([TAB_APP, SEARCH_APP]).isRequired,
-  nextURL: PropTypes.string.isRequired,
+  onCompleted: PropTypes.func.isRequired,
   user: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }),

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -24,6 +24,7 @@ import AssignExperimentGroups from 'js/components/Dashboard/AssignExperimentGrou
 import Logo from 'js/components/Logo/Logo'
 import tabTheme from 'js/theme/defaultV1'
 import searchTheme from 'js/theme/searchTheme'
+import optIntoV4Beta from 'js/utils/v4-beta-opt-in'
 
 jest.mock('react-router-dom')
 jest.mock('js/authentication/helpers')
@@ -34,6 +35,7 @@ jest.mock('js/utils/local-user-data-mgr')
 jest.mock('js/components/Dashboard/AssignExperimentGroupsContainer')
 jest.mock('js/components/Logo/Logo')
 jest.mock('js/components/Authentication/EnterUsernameForm')
+jest.mock('js/utils/v4-beta-opt-in')
 
 const mockFetchUser = jest.fn()
 
@@ -365,6 +367,50 @@ describe('Authentication.js tests', function() {
     expect(goTo).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
+  })
+
+  it('after sign-in, it opts the user into Tab v4 beta if the user is a v4 beta user', async () => {
+    expect.assertions(1)
+
+    // Args for onSignInSuccess
+    const mockFirebaseUserInstance = {
+      displayName: '',
+      email: 'foo@bar.com',
+      emailVerified: true,
+      isAnonymous: false,
+      metadata: {},
+      phoneNumber: null,
+      photoURL: null,
+      providerData: {},
+      providerId: 'some-id',
+      refreshToken: 'xyzxyz',
+      uid: 'abc123',
+    }
+    const mockFirebaseCredential = {}
+    const mockFirebaseDefaultRedirectURL = ''
+
+    createNewUser.mockResolvedValue({
+      id: 'abc123',
+      email: 'foo@bar.com',
+      username: null,
+    })
+
+    sendVerificationEmail.mockImplementation(() => Promise.resolve(true))
+
+    const Authentication = require('js/components/Authentication/Authentication')
+      .default
+    const mockProps = MockProps()
+    const wrapper = shallow(<Authentication {...mockProps} />)
+    const component = wrapper.instance()
+
+    // Mock a call from FirebaseUI after user signs in
+    await component.onSignInSuccess(
+      mockFirebaseUserInstance,
+      mockFirebaseCredential,
+      mockFirebaseDefaultRedirectURL
+    )
+
+    expect(optIntoV4Beta).toHaveBeenCalledTimes(1)
   })
 
   it('after sign-in, goes to missing email message screen if no email address', () => {

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -50,6 +50,7 @@ const MockProps = () => {
     user: {
       id: null,
       username: null,
+      v4BetaEnabled: false,
     },
     fetchUser: mockFetchUser,
   }
@@ -293,20 +294,62 @@ describe('Authentication.js tests', function() {
     // the Tab V4 beta.
     isTabV4BetaUser.mockReturnValue(true)
 
+    const defaultMockProps = MockProps()
+    const mockProps = {
+      ...defaultMockProps,
+      user: {
+        ...defaultMockProps,
+        v4BetaEnabled: false, // not enabled on user profile
+      },
+    }
+
     // User is fully authed.
     redirectToAuthIfNeeded.mockReturnValue(false)
 
     const Authentication = require('js/components/Authentication/Authentication')
       .default
-    const mockProps = MockProps()
-    mockProps.location.search = ''
     shallow(<Authentication {...mockProps} />)
 
     expect(optIntoV4Beta).toHaveBeenCalledTimes(1)
   })
 
-  it('does NOT opt in to Tab V4 (based on local storage flag) before redirecting to the app when the user is fully authenticated', () => {
+  it('does NOT opt in to Tab V4 (based on local storage and user profiel flags) before redirecting to the app when the user is fully authenticated', () => {
     expect.assertions(1)
+
+    // Set that the user's local storage is NOT flagged to use
+    // the Tab V4 beta.
+    isTabV4BetaUser.mockReturnValue(false)
+
+    const defaultMockProps = MockProps()
+    const mockProps = {
+      ...defaultMockProps,
+      user: {
+        ...defaultMockProps,
+        v4BetaEnabled: false, // not enabled on user profile
+      },
+    }
+
+    // User is fully authed.
+    redirectToAuthIfNeeded.mockReturnValue(false)
+
+    const Authentication = require('js/components/Authentication/Authentication')
+      .default
+    shallow(<Authentication {...mockProps} />)
+
+    expect(optIntoV4Beta).not.toHaveBeenCalled()
+  })
+
+  it('opts in to Tab V4 (based on user profile field) before redirecting to the app when the user is fully authenticated', () => {
+    expect.assertions(1)
+
+    const defaultMockProps = MockProps()
+    const mockProps = {
+      ...defaultMockProps,
+      user: {
+        ...defaultMockProps,
+        v4BetaEnabled: true, // not enabled on user profile
+      },
+    }
 
     // Set that the user's local storage is NOT flagged to use
     // the Tab V4 beta.
@@ -317,14 +360,12 @@ describe('Authentication.js tests', function() {
 
     const Authentication = require('js/components/Authentication/Authentication')
       .default
-    const mockProps = MockProps()
     mockProps.location.search = ''
     shallow(<Authentication {...mockProps} />)
 
-    expect(optIntoV4Beta).not.toHaveBeenCalled()
+    expect(optIntoV4Beta).toHaveBeenCalledTimes(1)
   })
 
-  // TODO: test v4 user profile flag
   // TODO: test setting the v4 user profile flag when it's not yet set
 
   it('redirects to Tab for a Cause if the user is fully authenticated and the "app" URL param is some invalid value', () => {

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -286,6 +286,47 @@ describe('Authentication.js tests', function() {
     expect(replaceUrl).toHaveBeenCalledWith(searchBaseURL)
   })
 
+  it('opts in to Tab V4 (based on local storage flag) before redirecting to the app when the user is fully authenticated', () => {
+    expect.assertions(1)
+
+    // Set that the user's local storage is flagged to use
+    // the Tab V4 beta.
+    isTabV4BetaUser.mockReturnValue(true)
+
+    // User is fully authed.
+    redirectToAuthIfNeeded.mockReturnValue(false)
+
+    const Authentication = require('js/components/Authentication/Authentication')
+      .default
+    const mockProps = MockProps()
+    mockProps.location.search = ''
+    shallow(<Authentication {...mockProps} />)
+
+    expect(optIntoV4Beta).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT opt in to Tab V4 (based on local storage flag) before redirecting to the app when the user is fully authenticated', () => {
+    expect.assertions(1)
+
+    // Set that the user's local storage is NOT flagged to use
+    // the Tab V4 beta.
+    isTabV4BetaUser.mockReturnValue(false)
+
+    // User is fully authed.
+    redirectToAuthIfNeeded.mockReturnValue(false)
+
+    const Authentication = require('js/components/Authentication/Authentication')
+      .default
+    const mockProps = MockProps()
+    mockProps.location.search = ''
+    shallow(<Authentication {...mockProps} />)
+
+    expect(optIntoV4Beta).not.toHaveBeenCalled()
+  })
+
+  // TODO: test v4 user profile flag
+  // TODO: test setting the v4 user profile flag when it's not yet set
+
   it('redirects to Tab for a Cause if the user is fully authenticated and the "app" URL param is some invalid value', () => {
     expect.assertions(1)
 
@@ -376,107 +417,6 @@ describe('Authentication.js tests', function() {
     expect(replaceUrl).not.toHaveBeenCalled()
     expect(replaceUrl).not.toHaveBeenCalled()
   })
-
-  it('after sign-in, it opts the user into Tab v4 beta if the user is a v4 beta user (based on local storage)', async () => {
-    expect.assertions(1)
-
-    // Set that the user's local storage is flagged to use
-    // the Tab V4 beta.
-    isTabV4BetaUser.mockReturnValue(true)
-
-    // Args for onSignInSuccess
-    const mockFirebaseUserInstance = {
-      displayName: '',
-      email: 'foo@bar.com',
-      emailVerified: true,
-      isAnonymous: false,
-      metadata: {},
-      phoneNumber: null,
-      photoURL: null,
-      providerData: {},
-      providerId: 'some-id',
-      refreshToken: 'xyzxyz',
-      uid: 'abc123',
-    }
-    const mockFirebaseCredential = {}
-    const mockFirebaseDefaultRedirectURL = ''
-
-    createNewUser.mockResolvedValue({
-      ...mockCreateNewUserResponse(),
-      id: 'abc123',
-      email: 'foo@bar.com',
-      username: null,
-    })
-
-    sendVerificationEmail.mockImplementation(() => Promise.resolve(true))
-
-    const Authentication = require('js/components/Authentication/Authentication')
-      .default
-    const mockProps = MockProps()
-    const wrapper = shallow(<Authentication {...mockProps} />)
-    const component = wrapper.instance()
-
-    // Mock a call from FirebaseUI after user signs in
-    await component.onSignInSuccess(
-      mockFirebaseUserInstance,
-      mockFirebaseCredential,
-      mockFirebaseDefaultRedirectURL
-    )
-
-    expect(optIntoV4Beta).toHaveBeenCalledTimes(1)
-  })
-
-  it('after sign-in, it does NOT opt the user into Tab v4 beta if the user is not a v4 beta user (based on local storage)', async () => {
-    expect.assertions(1)
-
-    // Set that the user's local storage is NOT flagged to use
-    // the Tab V4 beta.
-    isTabV4BetaUser.mockReturnValue(false)
-
-    // Args for onSignInSuccess
-    const mockFirebaseUserInstance = {
-      displayName: '',
-      email: 'foo@bar.com',
-      emailVerified: true,
-      isAnonymous: false,
-      metadata: {},
-      phoneNumber: null,
-      photoURL: null,
-      providerData: {},
-      providerId: 'some-id',
-      refreshToken: 'xyzxyz',
-      uid: 'abc123',
-    }
-    const mockFirebaseCredential = {}
-    const mockFirebaseDefaultRedirectURL = ''
-
-    createNewUser.mockResolvedValue({
-      ...mockCreateNewUserResponse(),
-      id: 'abc123',
-      email: 'foo@bar.com',
-      username: null,
-    })
-
-    sendVerificationEmail.mockImplementation(() => Promise.resolve(true))
-
-    const Authentication = require('js/components/Authentication/Authentication')
-      .default
-    const mockProps = MockProps()
-    const wrapper = shallow(<Authentication {...mockProps} />)
-    const component = wrapper.instance()
-
-    // Mock a call from FirebaseUI after user signs in
-    await component.onSignInSuccess(
-      mockFirebaseUserInstance,
-      mockFirebaseCredential,
-      mockFirebaseDefaultRedirectURL
-    )
-
-    expect(optIntoV4Beta).not.toHaveBeenCalled()
-  })
-
-  // TODO: test v4 user profile flag
-  // TODO: test setting the v4 user profile flag when it's not yet set
 
   it('after sign-in, goes to missing email message screen if no email address', () => {
     const Authentication = require('js/components/Authentication/Authentication')

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -1047,49 +1047,69 @@ describe('Authentication.js tests', function() {
     expect(shallow(<RenderedComponent />).prop('app')).toEqual('tab')
   })
 
-  it('passes the expected "nextURL" to the EnterUsernameForm when the "next" URL parameter is set', () => {
+  it('passes the onAuthProcessCompleted function as the "onCompleted" prop to the EnterUsernameForm, so it goes to the new tab page when invoked', () => {
     const Authentication = require('js/components/Authentication/Authentication')
       .default
     const mockProps = MockProps()
-    mockProps.location.search =
-      '?app=search&next=https%3A%2F%2Fexample.gladly.io%2Fnewtab%2Ffoo%2F'
     const wrapper = shallow(<Authentication {...mockProps} />)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
       .filterWhere(elem => elem.prop('path') === '/newtab/auth/username/')
     const RenderedComponent = routeElem.prop('render')
-    expect(shallow(<RenderedComponent />).prop('nextURL')).toEqual(
-      'https://example.gladly.io/newtab/foo/'
+    const onCompletedCallback = shallow(<RenderedComponent />).prop(
+      'onCompleted'
     )
+    onCompletedCallback()
+    expect(replaceUrl).toHaveBeenCalledWith('/newtab/')
   })
 
-  it('passes the expected "nextURL" to the EnterUsernameForm when the "next" URL parameter is NOT set and app === "tab"', () => {
+  it('passes the onAuthProcessCompleted function as the "onCompleted" prop to the EnterUsernameForm, so it calls to enable Tab v4 when invoked and the user has v4BetaEnabled === true', () => {
     const Authentication = require('js/components/Authentication/Authentication')
       .default
-    const mockProps = MockProps()
-    mockProps.location.search = '?app=tab'
+    const defaultMockProps = MockProps()
+    const mockProps = {
+      ...defaultMockProps,
+      user: {
+        ...defaultMockProps.user,
+        v4BetaEnabled: true,
+      },
+    }
     const wrapper = shallow(<Authentication {...mockProps} />)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
       .filterWhere(elem => elem.prop('path') === '/newtab/auth/username/')
     const RenderedComponent = routeElem.prop('render')
-    expect(shallow(<RenderedComponent />).prop('nextURL')).toEqual('/newtab/')
+    const onCompletedCallback = shallow(<RenderedComponent />).prop(
+      'onCompleted'
+    )
+    onCompletedCallback()
+    expect(optIntoV4Beta).toHaveBeenCalled()
   })
 
-  it('passes the expected "nextURL" to the EnterUsernameForm when the "next" URL parameter is NOT set and app === "search"', () => {
+  it('passes the onAuthProcessCompleted function as the "onCompleted" prop to the EnterUsernameForm, so it does not call to enable Tab v4 when the user has v4BetaEnabled === false', () => {
     const Authentication = require('js/components/Authentication/Authentication')
       .default
-    const mockProps = MockProps()
-    mockProps.location.search = '?app=search'
+    const defaultMockProps = MockProps()
+    const mockProps = {
+      ...defaultMockProps,
+      user: {
+        ...defaultMockProps.user,
+        v4BetaEnabled: false,
+      },
+    }
     const wrapper = shallow(<Authentication {...mockProps} />)
     const routeElem = wrapper
       .find(Switch)
       .find(Route)
       .filterWhere(elem => elem.prop('path') === '/newtab/auth/username/')
     const RenderedComponent = routeElem.prop('render')
-    expect(shallow(<RenderedComponent />).prop('nextURL')).toEqual('/search')
+    const onCompletedCallback = shallow(<RenderedComponent />).prop(
+      'onCompleted'
+    )
+    onCompletedCallback()
+    expect(optIntoV4Beta).not.toHaveBeenCalled()
   })
 
   it('passes "search" to the to the SignInIframeMessage "app" prop when the URL param value === "search"', () => {

--- a/web/src/js/components/Authentication/__tests__/Authentication.test.js
+++ b/web/src/js/components/Authentication/__tests__/Authentication.test.js
@@ -55,6 +55,13 @@ const MockProps = () => {
   }
 }
 
+const mockCreateNewUserResponse = () => ({
+  id: 'abc123',
+  email: 'foo@bar.com',
+  username: null,
+  justCreated: false,
+})
+
 const mockNow = '2017-05-19T13:59:58.000Z'
 
 beforeEach(() => {
@@ -395,6 +402,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -443,6 +451,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -526,6 +535,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -573,6 +583,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -621,6 +632,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -669,6 +681,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,
@@ -717,6 +730,7 @@ describe('Authentication.js tests', function() {
     const mockFirebaseDefaultRedirectURL = ''
 
     createNewUser.mockResolvedValue({
+      ...mockCreateNewUserResponse(),
       id: 'abc123',
       email: 'foo@bar.com',
       username: null,

--- a/web/src/js/components/Authentication/__tests__/EnterUsernameForm.test.js
+++ b/web/src/js/components/Authentication/__tests__/EnterUsernameForm.test.js
@@ -9,7 +9,6 @@ import UsernameField from 'js/components/General/UsernameField'
 import { checkIfEmailVerified } from 'js/authentication/helpers'
 import Button from '@material-ui/core/Button'
 import TextField from '@material-ui/core/TextField'
-import { goTo } from 'js/navigation/navigation'
 import { setUsernameInLocalStorage } from 'js/authentication/user'
 
 jest.mock('js/mutations/SetUsernameMutation')
@@ -20,7 +19,7 @@ jest.mock('js/authentication/user')
 
 const getMockProps = () => ({
   app: 'tab',
-  nextURL: 'https://tab.gladly.io/newtab/profile/donate/?foo=bar',
+  onCompleted: () => {},
   user: {
     id: 'abc-123',
   },
@@ -298,11 +297,13 @@ describe('EnterUsernameForm tests', () => {
     expect(setUsernameInLocalStorage).toHaveBeenCalledWith('AirplaneLover')
   })
 
-  it('redirects to the "nextURL" prop value after saving the username', () => {
+  it('calls the "onCompleted" prop value after saving the username', () => {
     const EnterUsernameForm = require('js/components/Authentication/EnterUsernameForm')
       .default
-    const mockProps = getMockProps()
-    mockProps.nextURL = 'https://tab.gladly.io/newtab/profile/donate/?foo=bar'
+    const mockProps = {
+      ...getMockProps(),
+      onCompleted: jest.fn(),
+    }
     const wrapper = mount(<EnterUsernameForm {...mockProps} />)
 
     // Enter a username
@@ -323,8 +324,6 @@ describe('EnterUsernameForm tests', () => {
       },
     })
 
-    expect(goTo).toHaveBeenCalledWith(
-      'https://tab.gladly.io/newtab/profile/donate/?foo=bar'
-    )
+    expect(mockProps.onCompleted).toHaveBeenCalled()
   })
 })

--- a/web/src/js/constants.js
+++ b/web/src/js/constants.js
@@ -73,6 +73,7 @@ export const STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO =
   'tab.newUser.clickedNewTabSearchIntro'
 export const STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO_V2 =
   'tab.newUser.clickedNewTabSearchIntroV2'
+export const STORAGE_NEW_USER_IS_TAB_V4_BETA = 'tab.newUser.isTabV4Enabled'
 
 // tab.experiments: values related to split-testing features
 // We may assign other values to localStorage with the tab.experiments.*

--- a/web/src/js/mutations/CreateNewUserMutation.js
+++ b/web/src/js/mutations/CreateNewUserMutation.js
@@ -1,7 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import { commitMutation } from 'react-relay'
 
-// TODO: fetch if the user is in the Tab v4 beta
 const mutation = graphql`
   mutation CreateNewUserMutation($input: CreateNewUserInput!) {
     createNewUser(input: $input) {

--- a/web/src/js/mutations/CreateNewUserMutation.js
+++ b/web/src/js/mutations/CreateNewUserMutation.js
@@ -1,6 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import { commitMutation } from 'react-relay'
 
+// TODO: fetch if the user is in the Tab v4 beta
 const mutation = graphql`
   mutation CreateNewUserMutation($input: CreateNewUserInput!) {
     createNewUser(input: $input) {

--- a/web/src/js/mutations/SetV4BetaMutation.js
+++ b/web/src/js/mutations/SetV4BetaMutation.js
@@ -1,0 +1,22 @@
+import graphql from 'babel-plugin-relay/macro'
+import commitMutation from 'relay-commit-mutation-promise'
+import environment from 'js/relay-env'
+
+const mutation = graphql`
+  mutation SetV4BetaMutation($input: SetV4BetaInput!) {
+    setV4Beta(input: $input) {
+      user {
+        v4BetaEnabled
+      }
+    }
+  }
+`
+
+export default input => {
+  return commitMutation(environment, {
+    mutation,
+    variables: {
+      input: input,
+    },
+  })
+}

--- a/web/src/js/mutations/__mocks__/SetV4BetaMutation.js
+++ b/web/src/js/mutations/__mocks__/SetV4BetaMutation.js
@@ -1,0 +1,2 @@
+/* eslint-env jest */
+module.exports = jest.fn(() => Promise.resolve({}))

--- a/web/src/js/mutations/__tests__/SetV4BetaMutation.test.js
+++ b/web/src/js/mutations/__tests__/SetV4BetaMutation.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+
+import environment from 'js/relay-env'
+import commitMutation from 'relay-commit-mutation-promise'
+
+jest.mock('js/relay-env')
+jest.mock('relay-commit-mutation-promise')
+
+const getMockInput = () => ({
+  userId: 'user-id-123',
+  enabled: true,
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('SetV4BetaMutation', () => {
+  it('calls commitMutation with expected values', async () => {
+    expect.assertions(1)
+    const SetV4BetaMutation = require('../SetV4BetaMutation').default
+    const args = getMockInput()
+    await SetV4BetaMutation(args)
+    expect(commitMutation).toHaveBeenCalledWith(environment, {
+      mutation: expect.any(Function),
+      variables: {
+        input: args,
+      },
+    })
+  })
+})

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -146,6 +146,9 @@ export const searchAccountURL = '/search/account/'
 export const searchExternalHelpURL =
   'https://gladly.zendesk.com/hc/en-us/categories/360001779552-Search-for-a-Cause'
 
+// Tab V4 API
+export const tabV4BetaOptInURL = '/v4/api/beta-opt-in'
+
 // Homepage
 
 export const homeURL = absoluteUrl('/')

--- a/web/src/js/utils/__mocks__/v4-beta-opt-in.js
+++ b/web/src/js/utils/__mocks__/v4-beta-opt-in.js
@@ -1,0 +1,2 @@
+/* eslint-env jest */
+module.exports = jest.fn(() => Promise.resolve())

--- a/web/src/js/utils/__tests__/local-user-data-mgr.test.js
+++ b/web/src/js/utils/__tests__/local-user-data-mgr.test.js
@@ -493,4 +493,16 @@ describe('local user data manager', () => {
     localStorageMgr.setItem('search.user.bingClientID', 'blah')
     expect(getBingClientID()).toBe('blah')
   })
+
+  // isTabV4BetaUser
+  it('returns whether the user is a Tab V4 beta user based on localStorage', () => {
+    localStorageMgr.setItem('tab.newUser.clickedNewTabSearchIntroV2', 'true')
+    const { isTabV4BetaUser } = require('js/utils/local-user-data-mgr')
+    localStorageMgr.setItem('tab.newUser.isTabV4Enabled', 'true')
+    expect(isTabV4BetaUser()).toBe(true)
+    localStorageMgr.setItem('tab.newUser.isTabV4Enabled', 'blah')
+    expect(isTabV4BetaUser()).toBe(false)
+    localStorageMgr.removeItem('tab.newUser.clickedNewTabSearchIntroV2')
+    expect(isTabV4BetaUser()).toBe(false)
+  })
 })

--- a/web/src/js/utils/__tests__/v4-beta-opt-in.test.js
+++ b/web/src/js/utils/__tests__/v4-beta-opt-in.test.js
@@ -1,0 +1,57 @@
+/* eslint-env jest */
+/* global fetch */
+import { mockFetchResponse } from 'js/utils/test-utils'
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve(mockFetchResponse()))
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('optIntoV4Beta', () => {
+  it('calls the expected endpoint', async () => {
+    expect.assertions(1)
+    const optIntoV4Beta = require('js/utils/v4-beta-opt-in').default
+    await optIntoV4Beta()
+    expect(fetch.mock.calls[0][0]).toEqual('/v4/api/beta-opt-in')
+  })
+
+  it('calls with the expected data', async () => {
+    expect.assertions(1)
+    const optIntoV4Beta = require('js/utils/v4-beta-opt-in').default
+    await optIntoV4Beta()
+    expect(fetch.mock.calls[0][1]).toEqual({
+      method: 'POST',
+      // eslint-disable-next-line no-undef
+      headers: new Headers({
+        'X-Gladly-Requested-By': 'tab-web-nextjs',
+        'Content-Type': 'application/json',
+      }),
+      credentials: 'include',
+      body: '{"optIn":true}',
+    })
+  })
+
+  it('calls the expected endpoint', async () => {
+    expect.assertions(1)
+    const optIntoV4Beta = require('js/utils/v4-beta-opt-in').default
+    await optIntoV4Beta()
+    expect(fetch.mock.calls[0][0]).toEqual('/v4/api/beta-opt-in')
+  })
+
+  it('throws if the response is not 200', async () => {
+    expect.assertions(1)
+
+    // Mock a bad response.
+    global.fetch.mockResolvedValue({
+      ...mockFetchResponse(),
+      ok: false,
+      statusText: 'The server messed up.',
+    })
+
+    const optIntoV4Beta = require('js/utils/v4-beta-opt-in').default
+    await expect(optIntoV4Beta()).rejects.toThrow('The server messed up.')
+  })
+})

--- a/web/src/js/utils/local-user-data-mgr.js
+++ b/web/src/js/utils/local-user-data-mgr.js
@@ -13,6 +13,7 @@ import {
   STORAGE_CAMPAIGN_DISMISS_TIME,
   STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO,
   STORAGE_CLICKED_NEW_TAB_SEARCH_INTRO_V2,
+  STORAGE_NEW_USER_IS_TAB_V4_BETA,
 } from 'js/constants'
 
 /**
@@ -331,3 +332,12 @@ export const setBingClientID = bingClientID => {
  */
 export const getBingClientID = () =>
   localStorageMgr.getItem(SEARCH_STORAGE_USER_BING_CLIENT_ID) || null
+
+/**
+ * Gets whether the user has dismissed the ad explanation.
+ * @returns {Boolean} Whether the user has dismissed the ad
+ *   explanation.
+ */
+export const isTabV4BetaUser = () => {
+  return localStorageMgr.getItem(STORAGE_NEW_USER_IS_TAB_V4_BETA) === 'true'
+}

--- a/web/src/js/utils/v4-beta-opt-in.js
+++ b/web/src/js/utils/v4-beta-opt-in.js
@@ -1,0 +1,9 @@
+/**
+ * Calls an endpoint to set a cookie that opts the user
+ * into Tab V4.
+ */
+const optIntoV4Beta = async () => {
+  // TODO
+}
+
+export default optIntoV4Beta

--- a/web/src/js/utils/v4-beta-opt-in.js
+++ b/web/src/js/utils/v4-beta-opt-in.js
@@ -1,9 +1,34 @@
+/* global fetch */
+
+import { tabV4BetaOptInURL } from 'js/navigation/navigation'
+
 /**
  * Calls an endpoint to set a cookie that opts the user
  * into Tab V4.
  */
 const optIntoV4Beta = async () => {
-  // TODO
+  let response
+  try {
+    response = await fetch(tabV4BetaOptInURL, {
+      method: 'POST',
+      // eslint-disable-next-line no-undef
+      headers: new Headers({
+        // This custom header provides modest CSRF protection. See:
+        // https://github.com/gladly-team/tab-web#authentication-approach
+        'X-Gladly-Requested-By': 'tab-web-nextjs',
+        'Content-Type': 'application/json',
+      }),
+      credentials: 'include',
+      body: JSON.stringify({ optIn: true }),
+    })
+    if (!response.ok) {
+      throw new Error(response.statusText)
+    }
+    await response.json()
+  } catch (e) {
+    throw e
+  }
+  return response
 }
 
 export default optIntoV4Beta


### PR DESCRIPTION
The goal is to be able to send users through this "legacy" app's sign-in flow, but upon sign-in completion, permanently direct them to the Tab v4 beta app. If the user clears storage and signs back in, they should still see the Tab v4 beta app.

* Add `v4BetaEnabled` field to the user profile
* On sign-in, if "tab.newUser.isTabV4Enabled" === "true" in local storage or the `v4BetaEnabled` field is set on the user's profile, call an endpoint to set a cookie that opts into the Tab V4 beta
* On sign-in, if "tab.newUser.isTabV4Enabled" === "true" but the the `v4BetaEnabled` field is **not** set on the user's profile, set it before signing in. This way, if the user clears storage or logs in elsewhere, they will continue to see the Tab v4 beta app.