### PR TITLE
Open bookmarks in new tab with middle mouse button

### DIFF
--- a/web/src/js/components/General/ConditionalWrapper.js
+++ b/web/src/js/components/General/ConditionalWrapper.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types'
+
+const ConditionalWrapper = ({ condition, wrapper, children }) =>
+  condition ? wrapper(children) : children
+
+ConditionalWrapper.propTypes = {
+  condition: PropTypes.bool.isRequired,
+  wrapper: PropTypes.func.isRequired,
+  children: PropTypes.object.isRequired,
+}
+
+export default ConditionalWrapper

--- a/web/src/js/components/General/__tests__/ConditionalWrapper.test.js
+++ b/web/src/js/components/General/__tests__/ConditionalWrapper.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+const getMockProps = () => ({
+  condition: true,
+  wrapper: jest.fn(),
+  children: <p>test</p>,
+})
+
+describe('ConditionalWrapper', () => {
+  it('renders without error', () => {
+    const ConditionalWrapper = require('../ConditionalWrapper').default
+    shallow(<ConditionalWrapper {...getMockProps()} />)
+  })
+
+  it('calls wrapper(children) if condition is true', () => {
+    const ConditionalWrapper = require('../ConditionalWrapper').default
+    const mockProps = getMockProps()
+    shallow(<ConditionalWrapper {...mockProps} />)
+    expect(mockProps.wrapper).toHaveBeenCalledWith(mockProps.children)
+  })
+
+  it("doesn't call wrapper() if condition is false", () => {
+    const ConditionalWrapper = require('../ConditionalWrapper').default
+    const mockProps = getMockProps()
+    shallow(<ConditionalWrapper {...mockProps} condition={false} />)
+    expect(mockProps.wrapper).toHaveBeenCalledTimes(0)
+  })
+})

--- a/web/src/js/components/Widget/Widgets/Bookmarks/BookmarkChip.js
+++ b/web/src/js/components/Widget/Widgets/Bookmarks/BookmarkChip.js
@@ -10,6 +10,8 @@ import {
 } from 'js/theme/default'
 import hexToRgbA from 'hex-to-rgba'
 import logger from 'js/utils/logger'
+import ConditionalWrapper from 'js/components/General/ConditionalWrapper'
+import Link from 'js/components/General/Link'
 
 const EditBookmarkWidgetModal = lazy(() =>
   import('js/components/Widget/Widgets/Bookmarks/EditBookmarkWidgetModal')
@@ -45,22 +47,12 @@ class BookmarkChip extends React.Component {
     return url
   }
 
-  openLink(link) {
-    // The page might be iframed, so opening in _top is critical.
-    window.open(this.addProtocolToURLIfNeeded(link), '_top')
-    this.setState({
-      open: false,
-    })
-  }
-
   onClick(e) {
     if (this.props.editMode) {
       this.setState({
         isEditing: true,
         startingIndex: this.props.index,
       })
-    } else {
-      this.openLink(this.props.bookmark.link)
     }
   }
 
@@ -128,51 +120,60 @@ class BookmarkChip extends React.Component {
     }
     return (
       <span>
-        <Paper
-          zDepth={0}
-          style={{
-            position: 'relative',
-            display: 'flex',
-            justifyContent: 'center',
-            cursor: 'pointer',
-            alignItems: 'center',
-            margin: 5,
-            minWidth: 84,
-            maxWidth: 150,
-            height: 50,
-            fontSize: 14,
-            padding: 10,
-            backgroundColor: bookmarkColor,
-            color: '#FFF',
-            userSelect: 'none',
-          }}
-          onClick={this.onClick.bind(this)}
+        <ConditionalWrapper
+          condition={!this.props.editMode}
+          wrapper={children => (
+            <Link to={this.addProtocolToURLIfNeeded(this.props.bookmark.link)}>
+              {children}
+            </Link>
+          )}
         >
-          <EditIcon
-            color={widgetEditButtonInactive}
-            hoverColor={widgetEditButtonHover}
+          <Paper
+            zDepth={0}
             style={{
-              position: 'absolute',
-              zIndex: 5,
-              top: 2,
-              right: 2,
-              opacity: this.props.editMode ? 1 : 0,
-              transition: 'opacity 0.1s ease-in',
-              pointerEvents: this.props.editMode ? 'all' : 'none',
-            }}
-          />
-          <span
-            style={{
+              position: 'relative',
+              display: 'flex',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              alignItems: 'center',
+              margin: 5,
+              minWidth: 84,
+              maxWidth: 150,
+              height: 50,
+              fontSize: 14,
+              padding: 10,
+              backgroundColor: bookmarkColor,
               color: '#FFF',
-              pointerEvents: 'none',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
+              userSelect: 'none',
             }}
+            onClick={this.onClick.bind(this)}
           >
-            {bookmark.name}
-          </span>
-        </Paper>
+            <EditIcon
+              color={widgetEditButtonInactive}
+              hoverColor={widgetEditButtonHover}
+              style={{
+                position: 'absolute',
+                zIndex: 5,
+                top: 2,
+                right: 2,
+                opacity: this.props.editMode ? 1 : 0,
+                transition: 'opacity 0.1s ease-in',
+                pointerEvents: this.props.editMode ? 'all' : 'none',
+              }}
+            />
+            <span
+              style={{
+                color: '#FFF',
+                pointerEvents: 'none',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {bookmark.name}
+            </span>
+          </Paper>
+        </ConditionalWrapper>
         {this.state.isEditing ? (
           <Suspense fallback={null}>
             <EditBookmarkWidgetModal

--- a/web/src/js/components/Widget/Widgets/Bookmarks/BookmarkChip.js
+++ b/web/src/js/components/Widget/Widgets/Bookmarks/BookmarkChip.js
@@ -123,7 +123,10 @@ class BookmarkChip extends React.Component {
         <ConditionalWrapper
           condition={!this.props.editMode}
           wrapper={children => (
-            <Link to={this.addProtocolToURLIfNeeded(this.props.bookmark.link)}>
+            <Link
+              to={this.addProtocolToURLIfNeeded(this.props.bookmark.link)}
+              target="_top"
+            >
               {children}
             </Link>
           )}

--- a/web/src/js/components/Widget/Widgets/Bookmarks/__tests__/BookmarkChip.test.js
+++ b/web/src/js/components/Widget/Widgets/Bookmarks/__tests__/BookmarkChip.test.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import Link from 'js/components/General/Link'
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+
+const getMockPropsBookmarkChip = () => ({
+  bookmark: { name: 'example', link: 'example.com' },
+  index: 0,
+  editMode: false,
+  editBookmark: jest.fn(),
+  deleteBookmark: jest.fn(),
+  onReorderMoveUp: jest.fn(),
+  onReorderMoveDown: jest.fn(),
+})
+
+describe('BookmarkChip', () => {
+  it('renders without error', () => {
+    const BookmarkChip = require('../BookmarkChip').default
+    const mockProps = getMockPropsBookmarkChip()
+    shallow(<BookmarkChip {...mockProps} />)
+  })
+
+  it('mounts without error', () => {
+    const BookmarkChip = require('../BookmarkChip').default
+    const mockProps = getMockPropsBookmarkChip()
+    mount(
+      <MuiThemeProvider>
+        <BookmarkChip {...mockProps} />
+      </MuiThemeProvider>
+    )
+  })
+
+  it('renders a Link element when edit mode is false', () => {
+    const BookmarkChip = require('../BookmarkChip').default
+    const mockProps = getMockPropsBookmarkChip()
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <BookmarkChip {...mockProps} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.find(Link)).toHaveLength(1)
+  })
+
+  it('renders a Link element when edit mode is false with the "to" prop having full url with protocol', () => {
+    const BookmarkChip = require('../BookmarkChip').default
+    const mockProps = getMockPropsBookmarkChip()
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <BookmarkChip {...mockProps} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.find(Link).prop('to')).toBe('http://example.com')
+  })
+
+  it('does not render a Link element when edit mode is true', () => {
+    const BookmarkChip = require('../BookmarkChip').default
+    const mockProps = getMockPropsBookmarkChip()
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <BookmarkChip {...mockProps} editMode={true} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.find(Link)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Added tests.
Closes #622 

I couldn't just replace the span with an "a" or Link because it caused the page to change when user clicked on the bookmark to edit it. And I didn't want to conditionally render an "a" or Link and copy and paste all the children components with all the duplicate code, so I made a "ConditionalWrapper" that can be used to wrap the children with a Link when not editing.