### PR TITLE
Upgrade tab-cmp

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -70,7 +70,7 @@
     "relay-commit-mutation-promise": "^1.0.1",
     "sanitize-html": "^1.20.1",
     "tab-ads": "^1.0.0-beta.9",
-    "tab-cmp": "^0.11.1",
+    "tab-cmp": "0.12.0-beta.0",
     "tti-polyfill": "^0.2.2",
     "uuid": "^3.3.2"
   },

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -14766,10 +14766,10 @@ tab-ads@^1.0.0-beta.9:
   dependencies:
     lodash "^4.17.15"
 
-tab-cmp@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/tab-cmp/-/tab-cmp-0.11.1.tgz#1708e858edc6e0d004bde05125b9abed885e9c0f"
-  integrity sha512-mawMTIDVDpjEQRQ3/B0LI6GjkRMuK0NshL0mao5tRMyxnDGfxzPtiqCW1TYu5c/KSgUnD+PmnZ/BsF27SA52mQ==
+tab-cmp@0.12.0-beta.0:
+  version "0.12.0-beta.0"
+  resolved "https://registry.yarnpkg.com/tab-cmp/-/tab-cmp-0.12.0-beta.0.tgz#eaa8b11c561b3933f1671e4a2f95d6c20b82a2c0"
+  integrity sha512-8mYklftVJ6als5u0GFFcIdPBB6LsH65eCYZHH+6G/0mhCsKab7EMxRW9ZY4dlVjwZv/LqkvILNaYBEezKdPHrg==
 
 table@^5.2.3:
   version "5.3.3"


### PR DESCRIPTION
## Test Checklist

### US/CCPA
**Basic CMP functionality**
* A new user has the expected default privacy string. Clear the CMP data, then run:
  ```js
  __uspapi("getUSPData", 1, (uspData, success) => { console.log('cmp responded:', uspData, success)})
  ```
  The `uspString` property value should be `1YNN`.
  
  Works on:
  - [x] top frame
  - [x] iframed new tab
  
* GDPR should not apply. Run:
   ```js
   __tcfapi('getTCData', 2, (tcData, success) => { console.log('cmp responded:', tcData, success)})
   ```
   The `gdprApplies` property value should be `false`.
   
  Works on:
  - [x] top frame
  - [x] iframed new tab
 
**CMP Consent Dialog**
* The user's account page should show a "Do Not Show My Info" link that opens the CCPA dialog.

  Works on:
  - [x] top frame
  - [x] iframed new tab

* The user's choice should persist. Open the dialog, opt out of data sale, and save. Refresh the app, open the dialog, and confirm you are still opted out.

  Works on:
  - [x] top frame
  - [x] iframed new tab

* After opting out of data sale, the USP string changes. Run:
  ```js
  __uspapi("getUSPData", 1, (uspData, success) => { console.log('cmp responded:', uspData, success)})
  ```
  The `uspString` property value should be `1YYN`.
  
    Works on:
  - [x] top frame
  - [x] iframed new tab

**Ad Partner Behavior**
* The request to Google Ad Manager includes the expected privacy options. For the request to `securepubads.g.doubleclick.net/gampad/`: the `us_privacy` query string value is `1YNN` and the `gdpr` value is `0`.

  Works on:
  - [x] top frame
  - [x] iframed new tab

* The request to Amazon has expected privacy options. For the request to `https://c.amazon-adsystem.com/e/dtb/bid`: the `pj` query string value is `{"us_privacy":"1YNN"}`, the `gdpre` value is `0`, and the `gdprl.status` value is `tcfv2-success`.

  Works on:
  - [x] top frame
  - [x] iframed new tab
  
* A Prebid partner uses expected privacy options. E.g., for the Sonobi request to `apex.go.sonobi.com/trinity.json`: the `us_privacy` query string value is `1YNN` and the `gdpr` value is `false`.

  Works on:
  - [x] top frame
  - [x] iframed new tab
  
* Index Exchange uses expected privacy options. For the request to `htlb.casalemedia.com/cygnus`: the `r` query string value includes the `regs` property equal to `{"ext":{"gdpr":0,"us_privacy":"1YNN"}}`.

  Works on:
  - [x] top frame
  - [x] iframed new tab

* The request to fetch ads is not substantially slower than prior to making CMP changes. Compare the request time of `securepubads.g.doubleclick.net/gampad/` to a prior deployment.

  Confirmed on:
  - [x] top frame
  
  *It's challenging to accurately test timing in the iframe, so no need to.*


### EU/GDPR
**Basic CMP functionality**
Start  by clearing the CMP data, then consenting to data usage.

* The CMP responds with expected data. Run:
  ```js
  __tcfapi('getTCData', 2, (tcData, success) => { console.log('cmp responded:', tcData, success)})
  ```
  The `gdprApplies` property value should be `true`, and the `tcString` and `addtlConsent` properties should be set.
  
  Works on:
  - [x] top frame
  - [x] iframed new tab
  
* CCPA should not apply. Run:
   ```js
   __uspapi("getUSPData", 1, (uspData, success) => { console.log('cmp responded:', uspData, success)})
   ```
   The `uspString` property value should be `1---`.
   
  Works on:
  - [x] top frame
  - [x] iframed new tab
 
**CMP Consent Dialog**
* The consent dialog appears on first use.
  * Clear the CMP data, then refresh the page.
  * Ensure the dialog appears.
  * Choose some custom data use consents and save.
  * Refresh the page and ensure the dialog does *not* reappear.
  ####
  
  Works on:
  - [x] top frame
  - [x] iframed new tab

* The user's account page should show a "Privacy Options" button that opens the GDPR dialog. Opening it should show the options you previously selected.

  Works on:
  - [x] top frame
  - [x] iframed new tab

* The user's choices should persist. Open the dialog, change your options, and save. Refresh the app, open the dialog, and confirm your changes are still there.

  Works on:
  - [x] top frame
  - [x] iframed new tab

**Ad Partner Behavior**
* The request to Google Ad Manager includes the expected privacy options. For the request to `securepubads.g.doubleclick.net/gampad/`: the `us_privacy` query string value is `1---`, the `gdpr` value is `1`, the `gdpr_consent` value is the consent string (matching the `euconsent-v2` cookie value), and `addtl_consent` is a string of numbers.

  Works on:
  - [x] top frame
  - [x] iframed new tab

* The request to Amazon has expected privacy options. For the request to `https://c.amazon-adsystem.com/e/dtb/bid`: the `pj` query string value is `{"us_privacy":"1---"}`, the `gdpre` value is `1`, the `gdprc` value is the consent string, and the `gdprl.status` value is `tcfv2-success`.

  Works on:
  - [x] top frame
  - [x] iframed new tab
  
* A Prebid partner uses expected privacy options. E.g., for the Sonobi request to `apex.go.sonobi.com/trinity.json`: the `us_privacy` query string value is `1---`, the `gdpr` value is `true`, and the `consent_string` value is the consent string.

  Works on:
  - [x] top frame
  - [x] iframed new tab
  
* Index Exchange uses expected privacy options. For the request to `htlb.casalemedia.com/cygnus`: the `r` query string value includes the `regs` property equal to `{"ext":{"gdpr":1,"us_privacy":"1---"}}` and an `ext` property with a `consent` value equal to the consent string.

  Works on:
  - [x] top frame
  - [x] iframed new tab
