### PR TITLE
fix updating impact from referrer

### DIFF
--- a/graphql/database/users/__tests__/rewardReferringUser.test.js
+++ b/graphql/database/users/__tests__/rewardReferringUser.test.js
@@ -15,7 +15,12 @@ import {
 } from '../../test-utils'
 import { DatabaseItemDoesNotExistException } from '../../../utils/exceptions'
 import UserImpactModel from '../../userImpact/UserImpactModel'
+import {
+  getPermissionsOverride,
+  REWARD_REFERRER_OVERRIDE,
+} from '../../../utils/permissions-overrides'
 
+const override = getPermissionsOverride(REWARD_REFERRER_OVERRIDE)
 jest.mock('../../databaseClient')
 jest.mock('../addVc')
 jest.mock('../addUsersRecruited')
@@ -642,7 +647,7 @@ describe('rewardReferringUser', () => {
     })
     const updateMethod = jest.spyOn(UserImpactModel, 'update')
     await rewardReferringUser(userContext, userId)
-    expect(updateMethod).toHaveBeenLastCalledWith(userContext, {
+    expect(updateMethod).toHaveBeenLastCalledWith(override, {
       ...getMockUserImpact(),
       pendingUserReferralCount: 2,
       pendingUserReferralImpact: 20,

--- a/graphql/database/users/rewardReferringUser.js
+++ b/graphql/database/users/rewardReferringUser.js
@@ -92,7 +92,7 @@ const rewardReferringUser = async (userContext, userId) => {
       pendingUserReferralImpact,
       pendingUserReferralCount,
     } = userImpactRecord
-    await UserImpactModel.update(userContext, {
+    await UserImpactModel.update(override, {
       ...userImpactRecord,
       pendingUserReferralImpact:
         pendingUserReferralImpact + USER_IMPACT_REFERRAL_BONUS,


### PR DESCRIPTION
I actually think we don't want to use getOrCreate here.  If we do, a user might refer another user on tab legacy and we'd end up creating and giving them referral bonuses on our v4 UserImpact document.  If a user does refer someone to Tab for Cats, then their UserImpact record must already be created so I don't think it's an issue