### PR TITLE
Send all /newtab/auth* traffic to the legacy Tab app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -241,7 +241,7 @@ before_install:
   # Gulp (used in Prebid.js build)
   - yarn global add gulp
   # AWS CLI
-  - pip install --user awscli
+  - pip3 install --user awscli
   - export PATH=$PATH:$HOME/.local/bin
 install: yarn run all:install
 # We want to fail fast if any script step fails, but TravisCI does not

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: node_js
 node_js:
-- '14'
+- '10'
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ env:
   - TEST_DEPLOYMENT_SEARCH_APP_S3_BUCKET_NAME=test-search.gladly.io
   - TEST_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - TEST_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
-  - TEST_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1104 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - TEST_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1112 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - TEST_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=139 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - TEST_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=test-tab2017-media.gladly.io
   - TEST_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=test-tab2017-media.gladly.io
@@ -145,7 +145,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_NAME=dev-search.gladly.io
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
-  - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=977 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=981 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=133 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 # Node 6 has a bug that affects some of our unit tests:
 # https://github.com/facebook/jest/issues/3152#issuecomment-287496730
 node_js:
-- '10'
+- '14'
 env:
   global:
   - CI=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 dist: trusty
 sudo: false
 language: node_js
-# Node 6 has a bug that affects some of our unit tests:
-# https://github.com/facebook/jest/issues/3152#issuecomment-287496730
 node_js:
 - '14'
+addons:
+  apt:
+    packages:
+      - "python3"
+      - "python3-pip"
 env:
   global:
   - CI=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ env:
   - TEST_DEPLOYMENT_SEARCH_APP_S3_BUCKET_NAME=test-search.gladly.io
   - TEST_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - TEST_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
-  - TEST_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1112 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - TEST_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1118 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - TEST_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=139 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - TEST_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=test-tab2017-media.gladly.io
   - TEST_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=test-tab2017-media.gladly.io
@@ -148,7 +148,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_NAME=dev-search.gladly.io
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
-  - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=981 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=985 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=133 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io

--- a/lambda/src/newtab-app-lambda-edge/__tests__/newtab-lambda-edge.test.js
+++ b/lambda/src/newtab-app-lambda-edge/__tests__/newtab-lambda-edge.test.js
@@ -16,6 +16,7 @@ afterEach(() => {
   jest.resetModules()
 })
 
+// The `referer` should be an absolute URL.
 const addRefererHeaderToEvent = (event, referer) => {
   const { headers } = event.Records[0].cf.request
   headers.referer = [
@@ -273,7 +274,7 @@ describe('newtab app Lambda@Edge function: auth page routing', () => {
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.uri = '/newtab/static/some-file.js'
-    addRefererHeaderToEvent(event, '/newtab/auth/')
+    addRefererHeaderToEvent(event, 'https://example.com/newtab/auth/')
     event.Records[0].cf.request.headers.cookie = [
       { key: 'Cookie', value: 'tabV4OptIn=enabled' },
     ]
@@ -289,7 +290,10 @@ describe('newtab app Lambda@Edge function: auth page routing', () => {
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.uri = '/newtab/static/img/my-thing.png'
-    addRefererHeaderToEvent(event, '/newtab/auth/something/here/')
+    addRefererHeaderToEvent(
+      event,
+      'https://example.com/newtab/auth/something/here/'
+    )
     event.Records[0].cf.request.headers.cookie = [
       { key: 'Cookie', value: 'tabV4OptIn=enabled' },
     ]
@@ -305,7 +309,7 @@ describe('newtab app Lambda@Edge function: auth page routing', () => {
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.uri = '/newtab/static/img/my-thing.png'
-    addRefererHeaderToEvent(event, '/newtab/another-page/')
+    addRefererHeaderToEvent(event, 'https://example.com/newtab/another-page/')
     event.Records[0].cf.request.headers.cookie = [
       { key: 'Cookie', value: 'tabV4OptIn=enabled' },
     ]

--- a/lambda/src/newtab-app-lambda-edge/__tests__/newtab-lambda-edge.test.js
+++ b/lambda/src/newtab-app-lambda-edge/__tests__/newtab-lambda-edge.test.js
@@ -113,7 +113,7 @@ describe('newtab app Lambda@Edge function on origin-request', () => {
     expect(request.origin).toMatchObject(originalOrigin)
   })
 
-  it('changes the origin to ZEIT Now when the v4 beta opt-in cookie is passed in request.headers.cookie', () => {
+  it('changes the origin to Vercel when the v4 beta opt-in cookie is passed in request.headers.cookie', () => {
     process.env.LAMBDA_TAB_V4_HOST = 'my.example.com'
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
@@ -152,7 +152,7 @@ describe('newtab app Lambda@Edge function on origin-request', () => {
     expect(request.origin).toMatchObject(originalOrigin)
   })
 
-  it('changes the request host header to the ZEIT Now origin when the v4 beta opt-in cookie is passed in request.headers.cookie', () => {
+  it('changes the request host header to the Vercel origin when the v4 beta opt-in cookie is passed in request.headers.cookie', () => {
     process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
@@ -167,7 +167,7 @@ describe('newtab app Lambda@Edge function on origin-request', () => {
     ])
   })
 
-  it('does not change the request host header to the ZEIT Now origin when the v4 beta opt-in cookie is not passed in request.headers.cookie', () => {
+  it('does not change the request host header to the Vercel origin when the v4 beta opt-in cookie is not passed in request.headers.cookie', () => {
     process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
@@ -182,7 +182,7 @@ describe('newtab app Lambda@Edge function on origin-request', () => {
     ])
   })
 
-  it('does not modify the request path when using the custom ZEIT Now origin', () => {
+  it('does not modify the request path when using the custom Vercel origin', () => {
     const { handler } = require('../newtab-app-lambda-edge')
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.headers.cookie = [
@@ -194,5 +194,65 @@ describe('newtab app Lambda@Edge function on origin-request', () => {
     handler(event, context, callback)
     const request = callback.mock.calls[0][1]
     expect(request.uri).toEqual('/newtab/')
+  })
+
+  it('uses the legacy origin when calling /newtab/auth, even when the v4 beta cookie is set', () => {
+    process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
+    const { handler } = require('../newtab-app-lambda-edge')
+    const event = getMockCloudFrontEventObject()
+    event.Records[0].cf.request.uri = '/newtab/auth'
+    event.Records[0].cf.request.headers.cookie = [
+      { key: 'Cookie', value: 'tabV4OptIn=enabled' },
+    ]
+    const originalOrigin = event.Records[0].cf.request.origin
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const request = callback.mock.calls[0][1]
+    expect(request.origin).toMatchObject(originalOrigin)
+  })
+
+  it('uses the legacy origin when calling /newtab/auth/, even when the v4 beta cookie is set', () => {
+    process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
+    const { handler } = require('../newtab-app-lambda-edge')
+    const event = getMockCloudFrontEventObject()
+    event.Records[0].cf.request.uri = '/newtab/auth/'
+    event.Records[0].cf.request.headers.cookie = [
+      { key: 'Cookie', value: 'tabV4OptIn=enabled' },
+    ]
+    const originalOrigin = event.Records[0].cf.request.origin
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const request = callback.mock.calls[0][1]
+    expect(request.origin).toMatchObject(originalOrigin)
+  })
+
+  it('uses the legacy origin when calling /newtab/auth/username/, even when the v4 beta cookie is set', () => {
+    process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
+    const { handler } = require('../newtab-app-lambda-edge')
+    const event = getMockCloudFrontEventObject()
+    event.Records[0].cf.request.uri = '/newtab/auth/username/'
+    event.Records[0].cf.request.headers.cookie = [
+      { key: 'Cookie', value: 'tabV4OptIn=enabled' },
+    ]
+    const originalOrigin = event.Records[0].cf.request.origin
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const request = callback.mock.calls[0][1]
+    expect(request.origin).toMatchObject(originalOrigin)
+  })
+
+  it('uses the legacy origin when calling /newtab/auth/blah/example/, even when the v4 beta cookie is set', () => {
+    process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
+    const { handler } = require('../newtab-app-lambda-edge')
+    const event = getMockCloudFrontEventObject()
+    event.Records[0].cf.request.uri = '/newtab/auth/blah/example/'
+    event.Records[0].cf.request.headers.cookie = [
+      { key: 'Cookie', value: 'tabV4OptIn=enabled' },
+    ]
+    const originalOrigin = event.Records[0].cf.request.origin
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const request = callback.mock.calls[0][1]
+    expect(request.origin).toMatchObject(originalOrigin)
   })
 })

--- a/lambda/src/newtab-app-lambda-edge/__tests__/newtab-lambda-edge.test.js
+++ b/lambda/src/newtab-app-lambda-edge/__tests__/newtab-lambda-edge.test.js
@@ -16,7 +16,6 @@ afterEach(() => {
   jest.resetModules()
 })
 
-// The `referer` should be an absolute URL.
 const addRefererHeaderToEvent = (event, referer) => {
   const { headers } = event.Records[0].cf.request
   headers.referer = [
@@ -275,6 +274,22 @@ describe('newtab app Lambda@Edge function: auth page routing', () => {
     const event = getMockCloudFrontEventObject()
     event.Records[0].cf.request.uri = '/newtab/static/some-file.js'
     addRefererHeaderToEvent(event, 'https://example.com/newtab/auth/')
+    event.Records[0].cf.request.headers.cookie = [
+      { key: 'Cookie', value: 'tabV4OptIn=enabled' },
+    ]
+    const originalOrigin = event.Records[0].cf.request.origin
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const request = callback.mock.calls[0][1]
+    expect(request.origin).toMatchObject(originalOrigin)
+  })
+
+  it('uses the legacy origin when calling a static file with a relative referrer URI of /newtab/auth/, even when the v4 beta cookie is set', () => {
+    process.env.LAMBDA_TAB_V4_HOST = 'foo.example.com'
+    const { handler } = require('../newtab-app-lambda-edge')
+    const event = getMockCloudFrontEventObject()
+    event.Records[0].cf.request.uri = '/newtab/static/some-file.js'
+    addRefererHeaderToEvent(event, '/newtab/auth/')
     event.Records[0].cf.request.headers.cookie = [
       { key: 'Cookie', value: 'tabV4OptIn=enabled' },
     ]

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -27,11 +27,17 @@ exports.handler = (event, context, callback) => {
     }
   }
 
-  // If visiting an auth page, always use the legacy Tab app
+  // If this is an auth page resource, always use the legacy Tab app
   // until the auth functionality is complete.
-  const isAuthPage = request.uri.startsWith('/newtab/auth')
+  const authPagePrefix = '/newtab/auth'
+  const referrers = headers.referer || []
+  const isAuthPageReferrer = referrers
+    .map(({ value }) => value.startsWith(authPagePrefix))
+    .some(elem => !!elem)
+  const isAuthPage = request.uri.startsWith(authPagePrefix)
+  const showLegacyAuthPage = isAuthPage || isAuthPageReferrer
 
-  if (isTabV4OptIn && !isAuthPage) {
+  if (isTabV4OptIn && !showLegacyAuthPage) {
     const tabV4Host = process.env.LAMBDA_TAB_V4_HOST
     if (!tabV4Host) {
       throw new Error('The LAMBDA_TAB_V4_HOST env variable must be set.')

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -1,5 +1,6 @@
 /* eslint prefer-destructuring: 0 */
 
+const url = require('url')
 const path = require('path')
 
 // This function rewrites all CloudFront HTML requests
@@ -32,7 +33,13 @@ exports.handler = (event, context, callback) => {
   const authPagePrefix = '/newtab/auth'
   const referrers = headers.referer || []
   const isAuthPageReferrer = referrers
-    .map(({ value }) => value.startsWith(authPagePrefix))
+    .map(({ value: referrerURI }) => {
+      if (!referrerURI) {
+        return false
+      }
+      const referrerPath = url.parse(referrerURI).pathname
+      return referrerPath.startsWith(authPagePrefix)
+    })
     .some(elem => !!elem)
   const isAuthPage = request.uri.startsWith(authPagePrefix)
   const showLegacyAuthPage = isAuthPage || isAuthPageReferrer

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -44,6 +44,17 @@ exports.handler = (event, context, callback) => {
   const isAuthPage = request.uri.startsWith(authPagePrefix)
   const showLegacyAuthPage = isAuthPage || isAuthPageReferrer
 
+  // TODO: remove after debugging.
+  // eslint-disable-next-line no-console
+  console.log(
+    'URI:',
+    request.uri,
+    'Referer:',
+    headers.referer,
+    'showLegacyAuthPage?',
+    showLegacyAuthPage
+  )
+
   if (isTabV4OptIn && !showLegacyAuthPage) {
     const tabV4Host = process.env.LAMBDA_TAB_V4_HOST
     if (!tabV4Host) {

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -28,32 +28,33 @@ exports.handler = (event, context, callback) => {
     }
   }
 
-  // If this is an auth page resource, always use the legacy Tab app
-  // until the auth functionality is complete.
-  const authPagePrefix = '/newtab/auth'
-  const referrers = headers.referer || []
-  const isAuthPageReferrer = referrers
-    .map(({ value: referrerURI }) => {
-      if (!referrerURI) {
-        return false
-      }
-      const referrerPath = url.parse(referrerURI).pathname
-      return referrerPath.startsWith(authPagePrefix)
-    })
-    .some(elem => !!elem)
-  const isAuthPage = request.uri.startsWith(authPagePrefix)
-  const showLegacyAuthPage = isAuthPage || isAuthPageReferrer
+  // If this is an auth page, or an auth page resource with a referrer
+  // from an auth page, always use the legacy Tab app until the auth
+  // functionality in Tab v4 is complete.
+  const USE_LEGACY_APP_FOR_AUTH = true
 
-  // TODO: remove after debugging.
-  // eslint-disable-next-line no-console
-  console.log(
-    'URI:',
-    request.uri,
-    'Referer:',
-    headers.referer,
-    'showLegacyAuthPage?',
-    showLegacyAuthPage
-  )
+  let showLegacyAuthPage = false
+  if (USE_LEGACY_APP_FOR_AUTH) {
+    const authPagePrefix = '/newtab/auth'
+    const referrers = headers.referer || []
+    const hasAuthPageReferrer = referrers
+      .map(({ value: referrerURI }) => {
+        if (!referrerURI) {
+          return false
+        }
+        const referrerPath = url.parse(referrerURI).pathname
+        return referrerPath.startsWith(authPagePrefix)
+      })
+      .some(elem => !!elem)
+
+    // Only consider referrers for non-page resources. E.g.: we don't
+    // want to consider the referrer of the newtab page after a redirect
+    // from the auth page.
+    const isNonPageResource = !!path.extname(request.uri)
+    const isAuthPage = request.uri.startsWith(authPagePrefix)
+    showLegacyAuthPage =
+      isAuthPage || (isNonPageResource && hasAuthPageReferrer)
+  }
 
   if (isTabV4OptIn && !showLegacyAuthPage) {
     const tabV4Host = process.env.LAMBDA_TAB_V4_HOST

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -10,7 +10,7 @@ const path = require('path')
 // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-cloudfront
 exports.handler = (event, context, callback) => {
   // If the cookie "tabV4OptIn" is set, change the origin to
-  // the Tab V4 origin hosted on ZEIT Now.
+  // the Tab V4 origin hosted on Vercel.
   // https://aws.amazon.com/blogs/networking-and-content-delivery/dynamically-route-viewer-requests-to-any-origin-using-lambdaedge/
   // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-examples.html#lambda-examples-content-based-custom-origin-request-trigger
   let isTabV4OptIn = false
@@ -21,33 +21,36 @@ exports.handler = (event, context, callback) => {
     const enabledVal = 'enabled'
     for (let i = 0; i < headers.cookie.length; i += 1) {
       if (headers.cookie[i].value.indexOf(`${cookieName}=${enabledVal}`) >= 0) {
-        const tabV4Host = process.env.LAMBDA_TAB_V4_HOST
-        if (!tabV4Host) {
-          throw new Error('The LAMBDA_TAB_V4_HOST env variable must be set.')
-        }
-        request.origin = {
-          custom: {
-            domainName: tabV4Host,
-            port: 443,
-            protocol: 'https',
-            path: '',
-            sslProtocols: ['TLSv1', 'TLSv1.1'],
-            readTimeout: 10,
-            keepaliveTimeout: 10,
-            customHeaders: {},
-          },
-        }
-        request.headers.host = [{ key: 'host', value: tabV4Host }]
         isTabV4OptIn = true
         break
       }
     }
   }
 
-  if (!isTabV4OptIn) {
-    if (!path.extname(request.uri)) {
-      request.uri = '/newtab/index.html'
+  // If visiting an auth page, always use the legacy Tab app
+  // until the auth functionality is complete.
+  const isAuthPage = request.uri.startsWith('/newtab/auth')
+
+  if (isTabV4OptIn && !isAuthPage) {
+    const tabV4Host = process.env.LAMBDA_TAB_V4_HOST
+    if (!tabV4Host) {
+      throw new Error('The LAMBDA_TAB_V4_HOST env variable must be set.')
     }
+    request.origin = {
+      custom: {
+        domainName: tabV4Host,
+        port: 443,
+        protocol: 'https',
+        path: '',
+        sslProtocols: ['TLSv1', 'TLSv1.1'],
+        readTimeout: 10,
+        keepaliveTimeout: 10,
+        customHeaders: {},
+      },
+    }
+    request.headers.host = [{ key: 'host', value: tabV4Host }]
+  } else if (!path.extname(request.uri)) {
+    request.uri = '/newtab/index.html'
   }
   callback(null, request)
 }

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -234,10 +234,10 @@ resources:
                     - TabAuth.AuthUserTokens.sig
                     - tabV4OptIn
                     - tabV4OptIn.sig
-                  Headers:
-                    # The referer header is necessary for conditional auth page
-                    # routing (via Lambda@Edge) between Tab v4 and Tab legacy.
-                    - Referer
+                Headers:
+                  # The referer header is necessary for conditional auth page
+                  # routing (via Lambda@Edge) between Tab v4 and Tab legacy.
+                  - Referer
               Compress: true
               ViewerProtocolPolicy: redirect-to-https
               # When CloudFront calls our origin, this function rewrites all

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -205,7 +205,26 @@ resources:
                 Cookies:
                   Forward: none
               ViewerProtocolPolicy: redirect-to-https
-            # New tab app
+            # New tab app (Tab Legacy)
+            # Until Tab v4 has a complete auth flow, we want to *always* show
+            # the Tab Legacy app for auth.
+            - PathPattern: 'newtab/auth*'
+              MinTTL: 0
+              DefaultTTL: 86400
+              # Allow the origin to set long-lived caching on files.
+              MaxTTL: 63115200 # two years
+              AllowedMethods:
+                - HEAD
+                - GET
+                - OPTIONS
+              TargetOriginId: ${self:custom.webAppName}
+              ForwardedValues:
+                QueryString: false
+                Cookies:
+                  Forward: none
+              Compress: true
+              ViewerProtocolPolicy: redirect-to-https
+            # New tab app 
             - PathPattern: 'newtab*'
               MinTTL: 0
               DefaultTTL: 86400

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -205,26 +205,7 @@ resources:
                 Cookies:
                   Forward: none
               ViewerProtocolPolicy: redirect-to-https
-            # New tab app (Tab Legacy)
-            # Until Tab v4 has a complete auth flow, we want to *always* show
-            # the Tab Legacy app for auth.
-            - PathPattern: 'newtab/auth*'
-              MinTTL: 0
-              DefaultTTL: 86400
-              # Allow the origin to set long-lived caching on files.
-              MaxTTL: 63115200 # two years
-              AllowedMethods:
-                - HEAD
-                - GET
-                - OPTIONS
-              TargetOriginId: ${self:custom.webAppName}
-              ForwardedValues:
-                QueryString: false
-                Cookies:
-                  Forward: none
-              Compress: true
-              ViewerProtocolPolicy: redirect-to-https
-            # New tab app 
+            # New tab app
             - PathPattern: 'newtab*'
               MinTTL: 0
               DefaultTTL: 86400

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -234,6 +234,10 @@ resources:
                     - TabAuth.AuthUserTokens.sig
                     - tabV4OptIn
                     - tabV4OptIn.sig
+                  Headers:
+                    # The referer header is necessary for conditional auth page
+                    # routing (via Lambda@Edge) between Tab v4 and Tab legacy.
+                    - Referer
               Compress: true
               ViewerProtocolPolicy: redirect-to-https
               # When CloudFront calls our origin, this function rewrites all


### PR DESCRIPTION
This PR adds CloudFront Lambda@Edge logic to route all auth-related requests to the legacy Tab app. It will route:
* any page (no file type suffix) with a path beginning with `/newtab/auth`
* any non-page resource (**must** have a file type suffix) and `Referer` with a path beginning with `/newtab/auth`

This is a workaround until Tab v4 has a fully-implemented auth flow.

Outstanding: we should make sure Tab v4 refreshes upon logout rather than navigating within the app router so that we'll show the Tab legacy auth page.