### PR TITLE
add a category to referral emails for tracking

### DIFF
--- a/graphql/database/invitedUsers/__tests__/utils.test.js
+++ b/graphql/database/invitedUsers/__tests__/utils.test.js
@@ -61,6 +61,7 @@ describe('verifyAndSendInvite', () => {
     expect(sgMail.send).toHaveBeenCalledWith({
       dynamicTemplateData: { name: 'alec', username: 'test1' },
       from: 'foo@bar.com',
+      category: 'referral',
       templateId: 'd-69707bd6c49a444fa68a99505930f801',
       to: 'test123',
       asm: { group_id: 3861, groups_to_display: [3861] },

--- a/graphql/database/invitedUsers/utils.js
+++ b/graphql/database/invitedUsers/utils.js
@@ -49,6 +49,7 @@ export const verifyAndSendInvite = async (
       username: encodeURIComponent(invitingUser.username),
       personalMessage: inviterMessage,
     },
+    category: 'referral',
     asm: {
       group_id: 3861,
       groups_to_display: [3861],


### PR DESCRIPTION
this allows us to get advanced sendgrid stats/analytics on our referral emails so that we don't have to calculate them