### PR TITLE
Update SSL certificate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - CXX=g++-5
   - SLS_DEBUG=true
   - LOG_TEST_COVERAGE=true
-  - SSL_CERTIFICATE_ARN=arn:aws:acm:us-east-1:167811431063:certificate/fb405a2a-68c1-4fa3-a1d6-d10f3dd19e59
+  - SSL_CERTIFICATE_ARN=arn:aws:acm:us-east-1:167811431063:certificate/99bbcea3-7913-4282-b391-435cbe285834
   ########## Test stage ##########
   # Note: Material UI creates different DOM between development
   # and production Node environments, which breaks Jest snapshot tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - CXX=g++-5
   - SLS_DEBUG=true
   - LOG_TEST_COVERAGE=true
-  - SSL_CERTIFICATE_ARN=arn:aws:acm:us-east-1:167811431063:certificate/8a660efb-4edc-45ca-b82b-bae1987156fc
+  - SSL_CERTIFICATE_ARN=arn:aws:acm:us-east-1:167811431063:certificate/5e058db8-5c79-4bae-9209-cde666eda29e
   ########## Test stage ##########
   # Note: Material UI creates different DOM between development
   # and production Node environments, which breaks Jest snapshot tests.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - CXX=g++-5
   - SLS_DEBUG=true
   - LOG_TEST_COVERAGE=true
-  - SSL_CERTIFICATE_ARN=arn:aws:acm:us-east-1:167811431063:certificate/99bbcea3-7913-4282-b391-435cbe285834
+  - SSL_CERTIFICATE_ARN=arn:aws:acm:us-east-1:167811431063:certificate/8a660efb-4edc-45ca-b82b-bae1987156fc
   ########## Test stage ##########
   # Note: Material UI creates different DOM between development
   # and production Node environments, which breaks Jest snapshot tests.

--- a/s3/serverless.yml
+++ b/s3/serverless.yml
@@ -10,6 +10,11 @@ provider:
   # Let's be conservative and prevent any unexpected changes
   # to the stack. See:
   # https://github.com/gladly-team/tab/issues/582
+  # Example to update policy:
+  #   aws cloudformation set-stack-policy --stack-name tab-media-dev --region us-west-2 --stack-policy-body \
+  #   '{"Statement":[
+  #     {"Effect":"Allow","Principal":"*","Action":"Update:Modify","Resource":"LogicalResourceId/WebAppCloudFrontDistribution"}
+  #   ]}'
   stackPolicy:
     - Effect: Deny
       Principal: "*"

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -33,7 +33,6 @@ custom:
   webAppName: Tab2017
   searchAppName: SearchForACause
   graphQLAppName: TabGraphQL
-  # We assume the domain is *not* prefixed by "www".
   cloudfrontDomainAlias: ${env:DEPLOYMENT_WEB_APP_CLOUDFRONT_DOMAIN_ALIAS}
   SSLCertificateARN: ${env:SSL_CERTIFICATE_ARN}
   websiteOrigin: ${env:DEPLOYMENT_LANDING_PAGE_DOMAIN}
@@ -169,7 +168,6 @@ resources:
           # DefaultRootObject: index.html
           Aliases:
             - ${self:custom.cloudfrontDomainAlias}
-            - www.${self:custom.cloudfrontDomainAlias} # for a www redirect
           # Show the homepage's 404 page if any origin returns 404.
           # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-custom-error-pages
           CustomErrorResponses:

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -33,6 +33,7 @@ custom:
   webAppName: Tab2017
   searchAppName: SearchForACause
   graphQLAppName: TabGraphQL
+  # We assume the domain is *not* prefixed by "www".
   cloudfrontDomainAlias: ${env:DEPLOYMENT_WEB_APP_CLOUDFRONT_DOMAIN_ALIAS}
   SSLCertificateARN: ${env:SSL_CERTIFICATE_ARN}
   websiteOrigin: ${env:DEPLOYMENT_LANDING_PAGE_DOMAIN}
@@ -168,6 +169,7 @@ resources:
           # DefaultRootObject: index.html
           Aliases:
             - ${self:custom.cloudfrontDomainAlias}
+            - www.${self:custom.cloudfrontDomainAlias} # for a www redirect
           # Show the homepage's 404 page if any origin returns 404.
           # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/HTTPStatusCodes.html#HTTPStatusCodes-custom-error-pages
           CustomErrorResponses:


### PR DESCRIPTION
Use new ACM certificate for *.gladly.io.

**Note:** We still do not support `www.` subdomain redirect to non-www. To do this right and support HTTPS, we'd likely need separate CloudFront distributions. An alternative is to only redirect non-HTTPS `www` using an S3 distribution, like we do currently for https://gladly.io.