### PR TITLE
Add a new v4 API path, /newtab/api

### DIFF
--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -205,6 +205,30 @@ resources:
                 Cookies:
                   Forward: none
               ViewerProtocolPolicy: redirect-to-https
+            # Next.js API on Vercel.
+            - PathPattern: 'newtab/api/*'
+              MinTTL: 0
+              DefaultTTL: 0
+              # Allow the origin to set long-lived caching on files.
+              MaxTTL: 63115200 # two years
+              AllowedMethods:
+                - HEAD
+                - DELETE
+                - POST
+                - GET
+                - OPTIONS
+                - PUT
+                - PATCH
+              TargetOriginId: nextjs-tab-web.now.sh
+              ForwardedValues:
+                # Cannot use '*', as that sends the Host header:
+                # https://stackoverflow.com/a/32825414 
+                Headers:
+                  - Authorization
+                QueryString: true
+                Cookies:
+                  Forward: all
+              ViewerProtocolPolicy: redirect-to-https
             # New tab app
             - PathPattern: 'newtab*'
               MinTTL: 0

--- a/web/src/js/navigation/navigation.js
+++ b/web/src/js/navigation/navigation.js
@@ -147,7 +147,7 @@ export const searchExternalHelpURL =
   'https://gladly.zendesk.com/hc/en-us/categories/360001779552-Search-for-a-Cause'
 
 // Tab V4 API
-export const tabV4BetaOptInURL = '/v4/api/beta-opt-in'
+export const tabV4BetaOptInURL = '/newtab/api/beta-opt-in'
 
 // Homepage
 

--- a/web/src/js/utils/__tests__/v4-beta-opt-in.test.js
+++ b/web/src/js/utils/__tests__/v4-beta-opt-in.test.js
@@ -15,7 +15,7 @@ describe('optIntoV4Beta', () => {
     expect.assertions(1)
     const optIntoV4Beta = require('js/utils/v4-beta-opt-in').default
     await optIntoV4Beta()
-    expect(fetch.mock.calls[0][0]).toEqual('/v4/api/beta-opt-in')
+    expect(fetch.mock.calls[0][0]).toEqual('/newtab/api/beta-opt-in')
   })
 
   it('calls with the expected data', async () => {
@@ -38,7 +38,7 @@ describe('optIntoV4Beta', () => {
     expect.assertions(1)
     const optIntoV4Beta = require('js/utils/v4-beta-opt-in').default
     await optIntoV4Beta()
-    expect(fetch.mock.calls[0][0]).toEqual('/v4/api/beta-opt-in')
+    expect(fetch.mock.calls[0][0]).toEqual('/newtab/api/beta-opt-in')
   })
 
   it('throws if the response is not 200', async () => {


### PR DESCRIPTION
This removes the need to rewrite /v4/api* requests in our Next.js app, freeing us to upgrade to a later version of Next.js.