### PR TITLE
Set up v2 search endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,8 +155,8 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_NAME=dev-search.gladly.io
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
-  - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=985 # Important: create an alias for this function. See serverless-lambda-edge.yml.
-  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1097 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1221 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_LANDING_PAGE_DOMAIN=dev-tab-website.s3-website-us-west-2.amazonaws.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
-  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1221 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1230 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_LANDING_PAGE_DOMAIN=dev-tab-website.s3-website-us-west-2.amazonaws.com

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -4,6 +4,7 @@
   "description": "Tab for a Cause.",
   "private": true,
   "dependencies": {
+    "accept-language-parser": "^1.5.0",
     "aws-sdk": "^2.814.0",
     "firebase-admin": "^7.3.0",
     "lodash": "^4.17.21",

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -94,6 +94,8 @@ custom:
 package:
   exclude:
     - node_modules/**
+  include:
+    - node_modules/lodash/**
 
 # We are using a custom role (building on the default Serverless role)
 # so that we can add edgelambda.amazonaws.com as a trust provider.

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -96,6 +96,7 @@ package:
     - node_modules/**
   include:
     - node_modules/lodash/**
+    - node_modules/accept-language-parser/**
 
 # We are using a custom role (building on the default Serverless role)
 # so that we can add edgelambda.amazonaws.com as a trust provider.

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -88,13 +88,15 @@ custom:
     automatic: true
     number: 5
 
+# Only include the build.
 # Don't include any dependencies by default. CloudFront-triggered Lambdas
 # have stricter package size limitations.
 # https://www.serverless.com/framework/docs/providers/aws/guide/packaging/
 package:
   exclude:
-    - node_modules/**
+    - ./**
   include:
+    - build/**
     - node_modules/lodash/**
     - node_modules/accept-language-parser/**
 

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -13,7 +13,7 @@ frameworkVersion: ">=1.12.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   region: us-east-1
   stage: ${env:SLS_STAGE, self:custom.stageDefault}
   role: gladlyLambdaEdgeRole

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -8,7 +8,7 @@ const path = require('path')
 // Examples of Lambda@Edge functions:
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-examples.html#lambda-examples-general-examples
 // CloudFront event object:
-// https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-cloudfront
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
 exports.handler = (event, context, callback) => {
   // If the cookie "tabV4OptIn" is set, change the origin to
   // the Tab V4 origin hosted on Vercel.

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -2,7 +2,6 @@
 
 import { clone } from 'lodash/lang'
 import { setWith } from 'lodash/object'
-import querystring from 'querystring'
 import {
   getMockCloudFrontEventObject,
   getMockLambdaContext,

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -137,6 +137,17 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     expect(response.headers.location[0].value).toEqual(MOCK_V2_SEARCH_URL)
   })
 
+  it('uses the v2 API if the URI has a trailing slash', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, '/search/v2/')
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(MOCK_V2_SEARCH_URL)
+  })
+
   it('sets the query string value if the "q" value is defined', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -1,22 +1,42 @@
 /* eslint-env jest */
 
+import { clone } from 'lodash/lang'
+import { setWith } from 'lodash/object'
+import querystring from 'querystring'
 import {
   getMockCloudFrontEventObject,
   getMockLambdaContext,
 } from '../../utils/lambda-arg-utils'
+import searchURLByRegion from '../searchURLByRegion'
+
+jest.mock('../searchURLByRegion')
 
 const callback = jest.fn()
+const MOCK_V2_SEARCH_URL =
+  'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001'
+
+beforeEach(() => {
+  searchURLByRegion.mockReturnValue(MOCK_V2_SEARCH_URL)
+})
 
 afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('search app Lambda@Edge function on viewer-request', () => {
+const searchV1Path = '/search/'
+const searchV2Path = '/search/v2'
+const setEventURI = (event, uri) => {
+  // Like `set` but immutable:
+  // https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
+  return setWith(clone(event), 'Records[0].cf.request.uri', uri, clone)
+}
+
+describe('v1: search app Lambda@Edge function on viewer-request', () => {
   it('redirects with a 307 redirect', () => {
     expect.assertions(2)
     const { handler } = require('../search-app-lambda-edge')
-    const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/search/'
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV1Path)
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
@@ -27,8 +47,8 @@ describe('search app Lambda@Edge function on viewer-request', () => {
   it('redirects an empty search to Google without a query string', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
-    const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/search/'
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV1Path)
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
@@ -40,8 +60,8 @@ describe('search app Lambda@Edge function on viewer-request', () => {
   it('sets the query string value if the "q" value is defined', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
-    const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/search/'
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV1Path)
     event.Records[0].cf.request.querystring = 'q=pizza'
     const context = getMockLambdaContext()
     handler(event, context, callback)
@@ -54,22 +74,22 @@ describe('search app Lambda@Edge function on viewer-request', () => {
   it('sets the query string value if the "q" value is defined with a space character', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
-    const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/search/'
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV1Path)
     event.Records[0].cf.request.querystring = 'q=pizza+palace'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
     expect(response.headers.location[0].value).toEqual(
-      'https://www.google.com/search?q=pizza%20palace'
+      'https://www.google.com/search?q=pizza+palace'
     )
   })
 
   it('sets the query string value if the "q" value is defined with a special character', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
-    const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/search/'
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV1Path)
     event.Records[0].cf.request.querystring = 'q=pizza🍕'
     const context = getMockLambdaContext()
     handler(event, context, callback)
@@ -82,14 +102,95 @@ describe('search app Lambda@Edge function on viewer-request', () => {
   it('only sets the "q" query string value, ignoring other URL params', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
-    const event = getMockCloudFrontEventObject()
-    event.Records[0].cf.request.uri = '/search/'
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV1Path)
     event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
     expect(response.headers.location[0].value).toEqual(
       'https://www.google.com/search?q=pizza'
+    )
+  })
+})
+
+describe('v2: search app Lambda@Edge function on viewer-request', () => {
+  it('redirects with a 307 redirect', () => {
+    expect.assertions(2)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.status).toEqual('307')
+    expect(response.statusDescription).toEqual('Found')
+  })
+
+  it('redirects an empty search to Yahoo without a query string', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(MOCK_V2_SEARCH_URL)
+  })
+
+  it('sets the query string value if the "q" value is defined', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'q=pizza'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
+    )
+  })
+
+  it('sets the query string value if the "q" value is defined with a space character', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'q=pizza+palace'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza+palace'
+    )
+  })
+
+  it('sets the query string value if the "q" value is defined with a special character', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'q=pizza🍕'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza%F0%9F%8D%95'
+    )
+  })
+
+  it('only sets the "q" query string value, ignoring other URL params', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
     )
   })
 })

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -235,7 +235,6 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
     const context = getMockLambdaContext()
     handler(event, context, callback)
-    const response = callback.mock.calls[0][1]
     expect(searchURLByRegion).toHaveBeenCalledWith('MX', 'es')
   })
 })

--- a/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
@@ -5,10 +5,88 @@ afterEach(() => {
 const US_SEARCH_URL = 'https://search.yahoo.com'
 const urlPath = '/yhs/search?hspart=gladly&hsimp=yhs-001'
 
+const getExpectedURL = baseURL => baseURL + urlPath
+
 describe('searchURLByRegion', () => {
   it('returns the US base URL when no arguments are provided', () => {
     expect.assertions(1)
     const searchURLByRegion = require('../searchURLByRegion').default
-    expect(searchURLByRegion()).toEqual(US_SEARCH_URL + urlPath)
+    expect(searchURLByRegion()).toEqual(getExpectedURL(US_SEARCH_URL))
+  })
+
+  it('returns the US base URL when an empty string country code is provided (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('')).toEqual(getExpectedURL(US_SEARCH_URL))
+  })
+
+  it('returns the US base URL when an unsupported country code is provided (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('not-a-real-code')).toEqual(
+      getExpectedURL(US_SEARCH_URL)
+    )
+  })
+
+  it('returns the Argentina base URL when the country code is AR (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('AR')).toEqual(
+      getExpectedURL('https://ar.search.yahoo.com')
+    )
+  })
+
+  it('returns the Argentina base URL when the country code is lowercase ar (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('ar')).toEqual(
+      getExpectedURL('https://ar.search.yahoo.com')
+    )
+  })
+
+  it('returns the Australia base URL when the country code is AU (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('AU')).toEqual(
+      getExpectedURL('https://au.search.yahoo.com')
+    )
+  })
+
+  it('returns the Germany base URL when the country code is DE (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('DE')).toEqual(
+      getExpectedURL('https://de.search.yahoo.com')
+    )
+  })
+
+  it('returns the Spain base URL when the country code is ES (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('ES')).toEqual(
+      getExpectedURL('https://es.search.yahoo.com')
+    )
+  })
+
+  it('returns the Hong Kong base URL when the country code is HK (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('HK')).toEqual(
+      getExpectedURL('https://hk.search.yahoo.com')
+    )
+  })
+
+  it('returns the United Kingdom base URL when the country code is UK (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('UK')).toEqual(
+      getExpectedURL('https://uk.search.yahoo.com')
+    )
+  })
+
+  it('returns the United States base URL when the country code is US (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('US')).toEqual(getExpectedURL(US_SEARCH_URL))
   })
 })

--- a/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
@@ -107,4 +107,98 @@ describe('searchURLByRegion', () => {
       getExpectedURL('https://ch.search.yahoo.com')
     )
   })
+
+  it('returns the Canada (English) base URL when the country code is CA and has an English-preferred accept-language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'en-GB,en-US;q=0.9,fr-CA;q=0.7,en;q=0.8'
+    expect(searchURLByRegion('CA', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://ca.search.yahoo.com')
+    )
+  })
+
+  it('returns the Canada (French) base URL when the country code is CA and has an French-preferred accept-language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'es,fr;q=0.8,it;q=0.2'
+    expect(searchURLByRegion('CA', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://cf.search.yahoo.com')
+    )
+  })
+
+  it('returns the Canada (English) base URL when the country code is CA and has an English language, even if French is preferred', () => {
+    // This test is for a limitation of our language parser.
+    // https://github.com/opentable/accept-language-parser#parserpicksupportedlangugagesarray-acceptlanguageheader-options--
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'fr-FR,en;q=0.8'
+    expect(searchURLByRegion('CA', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://ca.search.yahoo.com')
+    )
+  })
+
+  it('returns the Canada (English) base URL when the country code is CA and the accept-language header has no matches', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'it,de;q=0.9'
+    expect(searchURLByRegion('CA', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://ca.search.yahoo.com')
+    )
+  })
+
+  it('returns the Switzerland (German) base URL when the country code is CH and has an German-preferred accept-language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'de,it;q=0.4'
+    expect(searchURLByRegion('CH', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://ch.search.yahoo.com')
+    )
+  })
+
+  it('returns the Switzerland (French) base URL when the country code is CH and has an French-preferred accept-language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'fr,en;q=0.8'
+    expect(searchURLByRegion('CH', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://chfr.search.yahoo.com')
+    )
+  })
+
+  it('returns the Switzerland (Italian) base URL when the country code is CH and has an Italian-preferred accept-language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'es,it;q=0.4,en;q=0.1'
+    expect(searchURLByRegion('CH', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://chit.search.yahoo.com')
+    )
+  })
+
+  it('returns the Switzerland (German) base URL when the country code is CH and the accept-language header has no matches', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'es,es-MX'
+    expect(searchURLByRegion('CH', acceptLanguageVal)).toEqual(
+      getExpectedURL('https://ch.search.yahoo.com')
+    )
+  })
+
+  it('returns an Espanol base URL if there is no country match and Spanish is an accepted language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'es,es-MX'
+    const UNSUPPORTED_COUNTRY_CODE = 'CU'
+    expect(
+      searchURLByRegion(UNSUPPORTED_COUNTRY_CODE, acceptLanguageVal)
+    ).toEqual(getExpectedURL('https://espanol.search.yahoo.com'))
+  })
+
+  it('returns the default base URL if there is no country match and Spanish is *not* an accepted language', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    const acceptLanguageVal = 'fr,it'
+    const UNSUPPORTED_COUNTRY_CODE = 'CU'
+    expect(
+      searchURLByRegion(UNSUPPORTED_COUNTRY_CODE, acceptLanguageVal)
+    ).toEqual(getExpectedURL('https://search.yahoo.com'))
+  })
 })

--- a/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
@@ -1,0 +1,14 @@
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const US_SEARCH_URL = 'https://search.yahoo.com'
+const urlPath = '/yhs/search?hspart=gladly&hsimp=yhs-001'
+
+describe('searchURLByRegion', () => {
+  it('returns the US base URL when no arguments are provided', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion()).toEqual(US_SEARCH_URL + urlPath)
+  })
+})

--- a/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/searchURLByRegion.test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 afterEach(() => {
   jest.clearAllMocks()
 })
@@ -88,5 +90,21 @@ describe('searchURLByRegion', () => {
     expect.assertions(1)
     const searchURLByRegion = require('../searchURLByRegion').default
     expect(searchURLByRegion('US')).toEqual(getExpectedURL(US_SEARCH_URL))
+  })
+
+  it('returns the Canada (English) base URL when the country code is CA (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('CA')).toEqual(
+      getExpectedURL('https://ca.search.yahoo.com')
+    )
+  })
+
+  it('returns the Switzerland (German) base URL when the country code is CH (no accept-language header)', () => {
+    expect.assertions(1)
+    const searchURLByRegion = require('../searchURLByRegion').default
+    expect(searchURLByRegion('CH')).toEqual(
+      getExpectedURL('https://ch.search.yahoo.com')
+    )
   })
 })

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -14,7 +14,7 @@ exports.handler = (event, context, callback) => {
   const params = new URLSearchParams(request.querystring.toLowerCase())
   const searchQueryVal = params.get(SFAC_QUERY_QS_KEY)
 
-  // Map our search URL onto another search provider's URL.
+  // Get the redirect destination URL.
   let searchBaseURL
   let searchProviderQueryKey
   if (get(event, 'Records[0].cf.request.uri', '').startsWith('/search/v2')) {

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -27,6 +27,12 @@ exports.handler = (event, context, callback) => {
     const countryHeader = get(headers, 'cloudfront-viewer-country.value')
     const acceptLanguageHeader = get(headers, 'accept-language.value')
     searchBaseURL = searchURLByRegion(countryHeader, acceptLanguageHeader)
+
+    // Debugging.
+    // TODO: remove
+    console.log('headers', headers)
+    console.log('countryHeader', countryHeader)
+    console.log('acceptLanguageHeader', acceptLanguageHeader)
   } else {
     // For v1, use Google for search results.
     searchProviderQueryKey = 'q'

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -10,6 +10,10 @@ const querystring = require('querystring')
 exports.handler = (event, context, callback) => {
   const request = event.Records[0].cf.request
 
+  // Needs access to headers:
+  // * Accept-Language
+  // * CloudFront-Viewer-Country
+
   // Map our search URL onto another search provider's URL.
   const SFAC_QUERY_QS_KEY = 'q'
   const SEARCH_PROVIDER_URL = 'https://www.google.com/search'

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -9,7 +9,7 @@ import searchURLByRegion from './searchURLByRegion'
 // CloudFront event object:
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
 exports.handler = (event, context, callback) => {
-  const request = event.Records[0].cf.request
+  const request = get(event, 'Records[0].cf.request')
   const SFAC_QUERY_QS_KEY = 'q'
   const params = new URLSearchParams(request.querystring.toLowerCase())
   const searchQueryVal = params.get(SFAC_QUERY_QS_KEY)
@@ -23,16 +23,10 @@ exports.handler = (event, context, callback) => {
     // Yahoo localization needs access to headers:
     // * Accept-Language
     // * CloudFront-Viewer-Country
-    const headers = get(request, 'Records[0].cf.request.headers', {})
-    const countryHeader = get(headers, 'cloudfront-viewer-country.value')
-    const acceptLanguageHeader = get(headers, 'accept-language.value')
+    const headers = get(request, 'headers', {})
+    const countryHeader = get(headers, 'cloudfront-viewer-country[0].value')
+    const acceptLanguageHeader = get(headers, 'accept-language[0].value')
     searchBaseURL = searchURLByRegion(countryHeader, acceptLanguageHeader)
-
-    // Debugging.
-    // TODO: remove
-    console.log('headers', headers)
-    console.log('countryHeader', countryHeader)
-    console.log('acceptLanguageHeader', acceptLanguageHeader)
   } else {
     // For v1, use Google for search results.
     searchProviderQueryKey = 'q'

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -9,13 +9,20 @@ const querystring = require('querystring')
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
 exports.handler = (event, context, callback) => {
   const request = event.Records[0].cf.request
+  const SFAC_QUERY_QS_KEY = 'q'
 
-  // Needs access to headers:
+  // Map our search URL onto another search provider's URL.
+
+  // TODO: if request path starts with /search/v2, use Yahoo partner.
+  // For v2, use Yahoo for search results.
+  // Yahoo localization needs access to headers:
   // * Accept-Language
   // * CloudFront-Viewer-Country
 
-  // Map our search URL onto another search provider's URL.
-  const SFAC_QUERY_QS_KEY = 'q'
+  // const SEARCH_PROVIDER_URL = 'TODO'
+  // const SEARCH_PROVIDER_QS_KEY = 'p'
+
+  // For v1, use Google for search results.
   const SEARCH_PROVIDER_URL = 'https://www.google.com/search'
   const SEARCH_PROVIDER_QS_KEY = 'q'
   const params = querystring.parse(request.querystring.toLowerCase())

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -6,7 +6,7 @@ const querystring = require('querystring')
 // Examples of Lambda@Edge functions:
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-examples.html#lambda-examples-general-examples
 // CloudFront event object:
-// https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-cloudfront
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
 exports.handler = (event, context, callback) => {
   const request = event.Records[0].cf.request
 

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -15,11 +15,12 @@ exports.handler = (event, context, callback) => {
   const searchQueryVal = params.get(SFAC_QUERY_QS_KEY)
 
   // Map our search URL onto another search provider's URL.
-  // For v2, use Yahoo for search results.
   let searchBaseURL
   let searchProviderQueryKey
   if (get(event, 'Records[0].cf.request.uri', '').startsWith('/search/v2')) {
+    // For v2, use Yahoo for search results.
     searchProviderQueryKey = 'p'
+
     // Yahoo localization needs access to headers:
     // * Accept-Language
     // * CloudFront-Viewer-Country

--- a/lambda/src/search-app-lambda-edge/searchURLByRegion.js
+++ b/lambda/src/search-app-lambda-edge/searchURLByRegion.js
@@ -1,0 +1,121 @@
+// The URL path, which is unaffected by country/language.
+// Add a "p" URL parameter value with search terms.
+const urlPath = '/yhs/search?hspart=gladly&hsimp=yhs-001'
+
+// The base URL is determined by country and language.
+// Here, keys are ISO 3166-1 alpha-2 codes:
+// https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+// Special cases (language) are listed outside of this object.
+const baseURLMap = {
+  // Argentina
+  RA: 'https://ar.search.yahoo.com',
+  // Austria
+  AT: 'https://at.search.yahoo.com',
+  // Australia
+  AU: 'https://au.search.yahoo.com',
+  // Brazil
+  BR: 'https://br.search.yahoo.com',
+  // Chile
+  CL: 'https://cl.search.yahoo.com',
+  // Colombia
+  CO: 'https://co.search.yahoo.com',
+  // Germany
+  DE: 'https://de.search.yahoo.com',
+  // Denmark
+  DK: 'https://dk.search.yahoo.com',
+  // Spain
+  ES: 'https://es.search.yahoo.com',
+  // Finland
+  FI: 'https://fi.search.yahoo.com',
+  // France
+  FR: 'https://fr.search.yahoo.com',
+  // Hong Kong
+  HK: 'https://hk.search.yahoo.com',
+  // Indonesia
+  RI: 'https://id.search.yahoo.com',
+  // India
+  IN: 'https://in.search.yahoo.com',
+  // Italy
+  IT: 'https://it.search.yahoo.com',
+  // Mexico
+  MX: 'https://mx.search.yahoo.com',
+  // Malaysia
+  MY: 'https://malaysia.search.yahoo.com',
+  // Netherlands
+  NL: 'https://nl.search.yahoo.com',
+  // Norway
+  NO: 'https://no.search.yahoo.com',
+  // New Zealand
+  NZ: 'https://nz.search.yahoo.com',
+  // Peru
+  PE: 'https://pe.search.yahoo.com',
+  // Philippines
+  PH: 'https://ph.search.yahoo.com',
+  // Sweden
+  SE: 'https://se.search.yahoo.com',
+  // Singapore
+  SG: 'https://sg.search.yahoo.com',
+  // Thailand
+  TH: 'https://th.search.yahoo.com',
+  // Taiwan
+  TW: 'https://tw.search.yahoo.com',
+  // United Kingdom
+  UK: 'https://uk.search.yahoo.com',
+  // United States
+  US: 'https://search.yahoo.com',
+  // Venezuela
+  VE: 'https://ve.search.yahoo.com',
+  // Viet Nam
+  VN: 'https://vn.search.yahoo.com',
+}
+
+// Country code: CA
+const canadaBaseURLs = {
+  // Canada - English
+  en: 'https://ca.search.yahoo.com',
+  // Canada - French
+  fr: 'https://cf.search.yahoo.com',
+}
+
+// Country code: CH
+const switzerlandBaseURLs = {
+  // Switzerland - German
+  de: 'https://ch.search.yahoo.com',
+  // Switzerland - French
+  fr: 'https://chfr.search.yahoo.com',
+  // Switzerland - Italian
+  it: 'https://chit.search.yahoo.com',
+}
+
+// Language code: es
+const espanolBaseURL = 'https://espanol.search.yahoo.com'
+
+/**
+ * Returns the search URL based on a user's country and language.
+ * Here, we select based on the country from which the request originated,
+ * using the Accept-Language header value for more information where needed
+ * and/or supported.
+ * @param {String|undefined} countryCode - An ISO 3166-1 alpha-2 code:
+ *   https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+ * @param {String|undefined} acceptLanguageHeader - The value of the
+ *   request's Accept-Language header:
+ *   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language#specification
+ *   The official list of possible values are here:
+ *   https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry
+ *   FYI, a registry tool:
+ *   https://github.com/mattcg/language-subtag-registry
+ * @return {Boolean} Whether the new URL is for another app
+ */
+const searchURLByRegion = (countryCode, acceptLanguageHeader) => {
+  const US_COUNTRY_CODE = 'US'
+  const FALLBACK_BASE_URL = baseURLMap[US_COUNTRY_CODE]
+  let baseURL
+
+  // TODO
+  if (!baseURL) {
+    baseURL = FALLBACK_BASE_URL
+  }
+  return `${baseURL}${urlPath}`
+}
+
+export default searchURLByRegion

--- a/lambda/src/search-app-lambda-edge/searchURLByRegion.js
+++ b/lambda/src/search-app-lambda-edge/searchURLByRegion.js
@@ -8,7 +8,7 @@ const urlPath = '/yhs/search?hspart=gladly&hsimp=yhs-001'
 // Special cases (language) are listed outside of this object.
 const baseURLMap = {
   // Argentina
-  RA: 'https://ar.search.yahoo.com',
+  AR: 'https://ar.search.yahoo.com',
   // Austria
   AT: 'https://at.search.yahoo.com',
   // Australia
@@ -69,7 +69,7 @@ const baseURLMap = {
   VN: 'https://vn.search.yahoo.com',
 }
 
-// Country code: CA
+const CANADA_COUNTRY_CODE = 'CA'
 const canadaBaseURLs = {
   // Canada - English
   en: 'https://ca.search.yahoo.com',
@@ -77,7 +77,7 @@ const canadaBaseURLs = {
   fr: 'https://cf.search.yahoo.com',
 }
 
-// Country code: CH
+const SWITZERLAND_COUNTRY_CODE = 'CH'
 const switzerlandBaseURLs = {
   // Switzerland - German
   de: 'https://ch.search.yahoo.com',
@@ -106,13 +106,16 @@ const espanolBaseURL = 'https://espanol.search.yahoo.com'
  *   https://github.com/mattcg/language-subtag-registry
  * @return {Boolean} Whether the new URL is for another app
  */
-const searchURLByRegion = (countryCode, acceptLanguageHeader) => {
+const searchURLByRegion = (countryCode = '', acceptLanguageHeader = '') => {
   const US_COUNTRY_CODE = 'US'
   const FALLBACK_BASE_URL = baseURLMap[US_COUNTRY_CODE]
-  let baseURL
+  const countryCodeCaps = countryCode.toUpperCase()
 
   // TODO
-  if (!baseURL) {
+  let baseURL
+  if (baseURLMap[countryCodeCaps]) {
+    baseURL = baseURLMap[countryCodeCaps]
+  } else {
     baseURL = FALLBACK_BASE_URL
   }
   return `${baseURL}${urlPath}`

--- a/lambda/src/search-app-lambda-edge/searchURLByRegion.js
+++ b/lambda/src/search-app-lambda-edge/searchURLByRegion.js
@@ -111,12 +111,30 @@ const searchURLByRegion = (countryCode = '', acceptLanguageHeader = '') => {
   const FALLBACK_BASE_URL = baseURLMap[US_COUNTRY_CODE]
   const countryCodeCaps = countryCode.toUpperCase()
 
-  // TODO
   let baseURL
+
+  // Use the country-specific search page if one exists.
   if (baseURLMap[countryCodeCaps]) {
     baseURL = baseURLMap[countryCodeCaps]
+  } else if (countryCodeCaps === CANADA_COUNTRY_CODE) {
+    // Handle Canada special case.
+    // TODO: select the best language based on the header
+    const language = 'en'
+    baseURL = canadaBaseURLs[language]
+  } else if (countryCodeCaps === SWITZERLAND_COUNTRY_CODE) {
+    // Handle Switzerland special case.
+    // TODO: select the best language based on the header
+    const language = 'de'
+    baseURL = switzerlandBaseURLs[language]
   } else {
-    baseURL = FALLBACK_BASE_URL
+    // TODO
+    const spanishLanguage = false
+    // If accept-language contains Spanish, return the Espanol URL.
+    if (spanishLanguage) {
+      baseURL = espanolBaseURL
+    } else {
+      baseURL = FALLBACK_BASE_URL
+    }
   }
   return `${baseURL}${urlPath}`
 }

--- a/lambda/src/utils/lambda-arg-utils.js
+++ b/lambda/src/utils/lambda-arg-utils.js
@@ -12,7 +12,7 @@ export const getMockLambdaContext = () => ({
 })
 
 // CloudFront event object:
-// https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-cloudfront
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-viewer-request
 export const getMockCloudFrontEventObject = () => ({
   Records: [
     {
@@ -35,6 +35,18 @@ export const getMockCloudFrontEventObject = () => ({
               {
                 key: 'User-Agent',
                 value: 'curl/7.51.0',
+              },
+            ],
+            'accept-language': [
+              {
+                key: 'Accept-Language',
+                value: 'en-GB',
+              },
+            ],
+            'cloudfront-viewer-country': [
+              {
+                key: 'CloudFront-Viewer-Country',
+                value: 'UK',
               },
             ],
           },

--- a/lambda/yarn.lock
+++ b/lambda/yarn.lock
@@ -1492,6 +1492,11 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
+accept-language-parser@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.5.0.tgz#8877c54040a8dcb59e0a07d9c1fde42298334791"
+  integrity sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E=
+
 accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -318,9 +318,14 @@ resources:
                 - OPTIONS
               TargetOriginId: ${self:custom.searchAppName}
               ForwardedValues:
-                QueryString: false
+                # Required to forward search query.
+                QueryString: true
                 Cookies:
                   Forward: none
+                Headers:
+                  # Required to forward the user to a localized SERP.
+                  - Accept-Language
+                  - CloudFront-Viewer-Country
               Compress: true
               ViewerProtocolPolicy: redirect-to-https
               LambdaFunctionAssociations:

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -329,7 +329,12 @@ resources:
               Compress: true
               ViewerProtocolPolicy: redirect-to-https
               LambdaFunctionAssociations:
-                - EventType: viewer-request
+                # We can't use viewer-request with CloudFront-Viewer-Country.
+                # "CloudFront adds the CloudFront-Viewer-Country header after the viewer
+                # request event. To use this example, you must create a trigger for the
+                # origin request event."
+                # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-examples.html#lambda-examples-redirect-based-on-country
+                - EventType: origin-request
                   LambdaFunctionARN: ${self:custom.searchAppLambdaEdgeFunctionARN}
             # GraphQL
             - PathPattern: 'graphql*'


### PR DESCRIPTION
Redirect search requests from `/search/v2/` to a localized Yahoo search engine results page.