### PR TITLE
TFAC-891: Enabling SFAC, Yahoo as Search Engines

### DIFF
--- a/graphql/database/constants.js
+++ b/graphql/database/constants.js
@@ -46,7 +46,6 @@ export const GENERAL_EMAIL_INVITE_TEMPLATE_ID =
 // 14 tabs for 1 treat * 36 treats for 1 session = 504 tabs for 1 cat mission
 export const TAB_GOAL_FOR_TRAINING_SESSION = 504
 
-export const VALID_SEARCH_ENGINES = ['Ecosia', 'DuckDuckGo', 'Google', 'Bing']
 export const DEFAULT_SEARCH_ENGINE = 'Google'
 
 // For getUserSearchEngine

--- a/graphql/database/search/__tests__/searchEngines.test.js
+++ b/graphql/database/search/__tests__/searchEngines.test.js
@@ -2,12 +2,8 @@
 
 jest.mock('../searchEngineData', () => {
   const module = {
-    // Can spy on getters:
-    // https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype
-    __esModule: true,
-    get default() {
-      return jest.requireActual('../searchEngineData').default
-    },
+    searchEngineData: jest.requireActual('../searchEngineData')
+      .searchEngineData,
   }
   return module
 })
@@ -39,11 +35,14 @@ describe('searchEngines', () => {
   })
 
   it('throws if provided data fails SearchEngineModel schema validation', () => {
-    const dataModule = require('../searchEngineData')
-    jest.spyOn(dataModule, 'default', 'get').mockImplementation(() => {
-      const realData = jest.requireActual('../searchEngineData').default
+    jest.mock('../searchEngineData', () => {
+      const realData = jest.requireActual('../searchEngineData')
+        .searchEngineData
       delete realData[0].name
-      return realData
+      const module = {
+        searchEngineData: realData,
+      }
+      return module
     })
     expect(() => require('../searchEngines').default).toThrow(
       'child "name" fails because ["name" is required]'

--- a/graphql/database/search/searchEngineData.js
+++ b/graphql/database/search/searchEngineData.js
@@ -1,12 +1,12 @@
-const data = [
-  /* {
+export const searchEngineData = [
+  {
     name: 'Search for a Cause',
     id: 'SearchForACause',
     searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
     rank: 0,
     isCharitable: true,
     inputPrompt: 'Search for a Cause',
-  }, */
+  },
   {
     name: 'Google',
     id: 'Google',
@@ -39,14 +39,14 @@ const data = [
     isCharitable: false,
     inputPrompt: 'Search Bing',
   },
-  /* {
+  {
     name: 'Yahoo',
     id: 'Yahoo',
     searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
     rank: 5,
     isCharitable: false,
     inputPrompt: 'Search Yahoo',
-  }, */
+  },
 ]
 
-export default data
+export const VALID_SEARCH_ENGINES = searchEngineData.map(data => data.id)

--- a/graphql/database/search/searchEngines.js
+++ b/graphql/database/search/searchEngines.js
@@ -1,8 +1,8 @@
 import Joi from 'joi'
 import SearchEngineModel from './SearchEngineModel'
-import searchEngines from './searchEngineData'
+import { searchEngineData } from './searchEngineData'
 
-const searchEngineModels = searchEngines.map(
+const searchEngineModels = searchEngineData.map(
   engineData => new SearchEngineModel(engineData)
 )
 

--- a/graphql/database/users/UserModel.js
+++ b/graphql/database/users/UserModel.js
@@ -7,7 +7,6 @@ import {
   USER,
   USER_BACKGROUND_OPTION_DAILY,
   BACKGROUND_IMAGE_LEGACY_CATEGORY,
-  VALID_SEARCH_ENGINES,
 } from '../constants'
 import { permissionAuthorizers } from '../../utils/authorization-helpers'
 import config from '../../config'
@@ -16,6 +15,7 @@ import {
   DatabaseItemDoesNotExistException,
   UserDoesNotExistException,
 } from '../../utils/exceptions'
+import { VALID_SEARCH_ENGINES } from '../search/searchEngineData'
 
 const mediaRoot = config.MEDIA_ENDPOINT
 
@@ -398,7 +398,7 @@ class User extends BaseModel {
         )
         .default(self.fieldDefaults.yahooPaidSearchRewardOptIn),
       yahooSearchSwitchPrompt: types.object({
-        hasSeenPrompt: types
+        hasRespondedToPrompt: types
           .boolean()
           .description(
             'whether or not the user has seen the yahoo search switch prompt'

--- a/graphql/database/users/UserSearchLogModel.js
+++ b/graphql/database/users/UserSearchLogModel.js
@@ -1,8 +1,9 @@
 import BaseModel from '../base/BaseModel'
 import types from '../fieldTypes'
 import tableNames from '../tables'
-import { USER_SEARCH_LOG, VALID_SEARCH_ENGINES } from '../constants'
+import { USER_SEARCH_LOG } from '../constants'
 import { permissionAuthorizers } from '../../utils/authorization-helpers'
+import { VALID_SEARCH_ENGINES } from '../search/searchEngineData'
 
 /*
  * @extends BaseModel

--- a/graphql/database/users/UserSearchSettingsLogModel.js
+++ b/graphql/database/users/UserSearchSettingsLogModel.js
@@ -2,8 +2,9 @@ import moment from 'moment'
 import BaseModel from '../base/BaseModel'
 import types from '../fieldTypes'
 import tableNames from '../tables'
-import { USER_SEARCH_SETTINGS_LOG, VALID_SEARCH_ENGINES } from '../constants'
+import { USER_SEARCH_SETTINGS_LOG } from '../constants'
 import { permissionAuthorizers } from '../../utils/authorization-helpers'
+import { VALID_SEARCH_ENGINES } from '../search/searchEngineData'
 
 /*
  * @extends BaseModel

--- a/graphql/database/users/UserSwitchSearchPromptLogModel.js
+++ b/graphql/database/users/UserSwitchSearchPromptLogModel.js
@@ -2,11 +2,9 @@ import moment from 'moment'
 import BaseModel from '../base/BaseModel'
 import types from '../fieldTypes'
 import tableNames from '../tables'
-import {
-  USER_SWITCH_SEARCH_PROMPT_LOG,
-  VALID_SEARCH_ENGINES,
-} from '../constants'
+import { USER_SWITCH_SEARCH_PROMPT_LOG } from '../constants'
 import { permissionAuthorizers } from '../../utils/authorization-helpers'
+import { VALID_SEARCH_ENGINES } from '../search/searchEngineData'
 
 /*
  * @extends BaseModel

--- a/graphql/database/users/__tests__/createSearchEnginePromptLog.test.js
+++ b/graphql/database/users/__tests__/createSearchEnginePromptLog.test.js
@@ -30,7 +30,7 @@ const mockReturn = {
 }
 describe('createSearchEnginePromptLog tests', () => {
   it('creates new UserSwitchSearchPromptLogModel', async () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const createSearchEnginePromptLog = require('../createSearchEnginePromptLog')
       .default
     // Mock creation query
@@ -39,7 +39,9 @@ describe('createSearchEnginePromptLog tests', () => {
     })
     const UserSwitchSearchPromptLogModel = require('../UserSwitchSearchPromptLogModel')
       .default
+    const UserModel = require('../../users/UserModel').default
     const createQuery = jest.spyOn(UserSwitchSearchPromptLogModel, 'create')
+    const userUpdateQuery = jest.spyOn(UserModel, 'update')
     const result = await createSearchEnginePromptLog(
       userContext,
       user.id,
@@ -55,6 +57,45 @@ describe('createSearchEnginePromptLog tests', () => {
       updated: '2017-05-19T13:59:46.000Z',
     })
     expect(result).toEqual({ success: true })
+    expect(userUpdateQuery).not.toHaveBeenCalled()
+  })
+
+  it('creates new UserSwitchSearchPromptLogModel and updates User if SearchForACause', async () => {
+    expect.assertions(3)
+    const createSearchEnginePromptLog = require('../createSearchEnginePromptLog')
+      .default
+    // Mock creation query
+    setMockDBResponse(DatabaseOperation.CREATE, {
+      Attributes: mockReturn,
+    })
+    const UserSwitchSearchPromptLogModel = require('../UserSwitchSearchPromptLogModel')
+      .default
+    const UserModel = require('../../users/UserModel').default
+    const createQuery = jest.spyOn(UserSwitchSearchPromptLogModel, 'create')
+    const userUpdateQuery = jest.spyOn(UserModel, 'update')
+    const result = await createSearchEnginePromptLog(
+      userContext,
+      user.id,
+      'SearchForACause',
+      switched
+    )
+    expect(createQuery).toHaveBeenCalledWith(userContext, {
+      userId: userContext.id,
+      searchEnginePrompted: testEngine,
+      switched,
+      timestamp: '2017-05-19T13:59:46.000Z',
+      created: '2017-05-19T13:59:46.000Z',
+      updated: '2017-05-19T13:59:46.000Z',
+    })
+    expect(result).toEqual({ success: true })
+    expect(userUpdateQuery).toHaveBeenCalledWith(userContext, {
+      id: userContext.id,
+      yahooSearchSwitchPrompt: {
+        hasRespondedToPrompt: true,
+        timestamp: '2017-05-19T13:59:46.000Z',
+      },
+      updated: '2017-05-19T13:59:46.000Z',
+    })
   })
 
   it('throws if invalid search engine for new UserSwitchSearchPromptLogModel', async () => {

--- a/graphql/database/users/createSearchEnginePromptLog.js
+++ b/graphql/database/users/createSearchEnginePromptLog.js
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import UserSwitchSearchPromptLogModel from './UserSwitchSearchPromptLogModel'
+import UserModel from './UserModel'
 /**
  * @param {Object} userContext - The user context.
  * @param {string} userId - The user's Id
@@ -16,6 +17,15 @@ export default async (userContext, userId, searchEnginePrompted, switched) => {
       switched,
       timestamp: moment.utc().toISOString(),
     })
+    if (searchEnginePrompted === 'SearchForACause') {
+      await UserModel.update(userContext, {
+        id: userId,
+        yahooSearchSwitchPrompt: {
+          hasRespondedToPrompt: true,
+          timestamp: moment.utc().toISOString(),
+        },
+      })
+    }
   } catch (e) {
     throw e
   }


### PR DESCRIPTION
This will enable both engines. I also shoehorned some logic into the CreateSearchEnginePromptLogMutation to correctly update UserModel.