### PR TITLE
Modify LogSearch mutation to support global userID

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -1950,8 +1950,15 @@ const createNewMissionMutation = mutationWithClientMutationId({
 const logSearchMutation = mutationWithClientMutationId({
   name: 'LogSearch',
   inputFields: {
-    // Note that this is the raw user ID (not the Relay global).
-    userId: { type: new GraphQLNonNull(GraphQLString) },
+    userIdGlobal: {
+      type: GraphQLString,
+      description: 'The user Relay global ID. Provide either this or `userId`.',
+    },
+    userId: {
+      type: GraphQLString,
+      description:
+        'The actual user ID (not the Relay global). Provide either this or `userIdGlobal`.',
+    },
     source: { type: GraphQLString },
   },
   outputFields: {
@@ -1960,8 +1967,13 @@ const logSearchMutation = mutationWithClientMutationId({
       resolve: user => user,
     },
   },
-  mutateAndGetPayload: ({ userId, ...additionalData }, context) =>
-    logSearch(context.user, userId, additionalData),
+  mutateAndGetPayload: (
+    { userId, userIdGlobal, ...additionalData },
+    context
+  ) => {
+    const userGlobalObj = fromGlobalId(userIdGlobal)
+    return logSearch(context.user, userId || userGlobalObj.id, additionalData)
+  },
 })
 
 /**

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -1971,7 +1971,7 @@ const logSearchMutation = mutationWithClientMutationId({
     { userId, userIdGlobal, ...additionalData },
     context
   ) => {
-    const userGlobalObj = fromGlobalId(userIdGlobal)
+    const userGlobalObj = userIdGlobal ? fromGlobalId(userIdGlobal) : {}
     return logSearch(context.user, userId || userGlobalObj.id, additionalData)
   },
 })

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -733,7 +733,13 @@ type LogReferralLinkClickPayload {
 }
 
 input LogSearchInput {
-  userId: String!
+  """The user Relay global ID. Provide either this or `userId`."""
+  userIdGlobal: String
+
+  """
+  The actual user ID (not the Relay global). Provide either this or `userIdGlobal`.
+  """
+  userId: String
   source: String
   clientMutationId: String
 }


### PR DESCRIPTION
The LogSearch mutation currently expects a plain user ID. This PR supports passing the user's Relay global ID.