### PR TITLE
Backend: feature to show notification about user survey

### DIFF
--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -137,6 +137,7 @@ import {
 import getCampaign from '../database/globals/getCampaign'
 import getUserSearchEngine from '../database/users/getUserSearchEngine'
 import getShouldShowYahooPrompt from '../database/users/getShouldShowYahooPrompt'
+import getUserNotifications from '../database/users/getUserNotifications'
 
 class App {
   constructor(id) {
@@ -684,12 +685,8 @@ const userType = new GraphQLObjectType({
         )
       ),
       description: 'notifications for the v4 user to see',
-      resolve: () => {
-        if (process.env.SHOW_NOTIF_INTL_CAT_DAY_END_2021 === 'true') {
-          return [{ code: 'intlCatDayEnd2021' }]
-        }
-        return []
-      },
+      resolve: (user, args, context) =>
+        getUserNotifications(context.user, user),
     },
     searchesToday: {
       type: GraphQLInt,

--- a/graphql/database/experiments/__tests__/growthbookUtils.test.js
+++ b/graphql/database/experiments/__tests__/growthbookUtils.test.js
@@ -76,6 +76,7 @@ describe('growthbookUtils tests', () => {
       joined: user.joined,
       isTabTeamMember: showInternalOnly(user.email),
       internalExperimentOverrides: {},
+      tabs: 0,
     })
   })
 

--- a/graphql/database/experiments/features.js
+++ b/graphql/database/experiments/features.js
@@ -48,7 +48,8 @@ const features = {
             $gte: 10,
           },
         },
-        force: true,
+        // TODO: set to true when ready
+        force: false,
       },
     ],
   },

--- a/graphql/database/experiments/features.js
+++ b/graphql/database/experiments/features.js
@@ -43,6 +43,14 @@ const features = {
     defaultValue: false,
     rules: [
       {
+        // Show on dev for our team only.
+        condition: {
+          isTabTeamMember: true,
+          env: 'dev',
+        },
+        force: true,
+      },
+      {
         condition: {
           tabs: {
             $gte: 10,

--- a/graphql/database/experiments/features.js
+++ b/graphql/database/experiments/features.js
@@ -39,6 +39,19 @@ const features = {
       },
     ],
   },
+  'user-survey-2022-notification': {
+    defaultValue: false,
+    rules: [
+      {
+        condition: {
+          tabs: {
+            $gte: 10,
+          },
+        },
+        force: true,
+      },
+    ],
+  },
 }
 
 features[YAHOO_SEARCH_EXISTING_USERS] = {

--- a/graphql/database/experiments/getUserFeature.js
+++ b/graphql/database/experiments/getUserFeature.js
@@ -3,7 +3,7 @@ import {
   getConfiguredGrowthbook,
 } from './growthbookUtils'
 
-const getUserFeatures = async (userContext, user, featureName) => {
+const getUserFeature = async (userContext, user, featureName) => {
   const configuredGrowthbook = getConfiguredGrowthbook(user)
   const userFeature = await getAndLogFeatureForUser(
     userContext,
@@ -15,4 +15,4 @@ const getUserFeatures = async (userContext, user, featureName) => {
   return userFeature
 }
 
-export default getUserFeatures
+export default getUserFeature

--- a/graphql/database/experiments/growthbookUtils.js
+++ b/graphql/database/experiments/growthbookUtils.js
@@ -14,6 +14,7 @@ const validateAttributesObject = (userId, attributes) => {
     'v4BetaEnabled',
     'joined',
     'isTabTeamMember',
+    'tabs',
   ]
   requiredProperties.forEach(attribute => {
     if (attributes[attribute] === null || attributes[attribute] === undefined) {
@@ -33,6 +34,7 @@ export const getConfiguredGrowthbook = ({
   joined,
   email,
   internalExperimentOverrides = {},
+  tabs,
 }) => {
   const growthbook = new GrowthBook()
   growthbook.setFeatures(features)
@@ -44,6 +46,7 @@ export const getConfiguredGrowthbook = ({
     internalExperimentOverrides,
     env: process.env.GROWTHBOOK_ENV,
     isTabTeamMember: showInternalOnly(email),
+    tabs,
   }
   validateAttributesObject(userId, attributes)
   growthbook.setAttributes(attributes)

--- a/graphql/database/users/__tests__/getUserNotifications.test.js
+++ b/graphql/database/users/__tests__/getUserNotifications.test.js
@@ -3,9 +3,6 @@
 import getUserNotifications from '../getUserNotifications'
 import { getMockUserContext, getMockUserInstance } from '../../test-utils'
 
-jest.mock('../../databaseClient')
-jest.mock('../BackgroundImageModel')
-
 const userContext = getMockUserContext()
 const user = getMockUserInstance()
 

--- a/graphql/database/users/__tests__/getUserNotifications.test.js
+++ b/graphql/database/users/__tests__/getUserNotifications.test.js
@@ -3,8 +3,10 @@
 import getUserNotifications from '../getUserNotifications'
 import { getMockUserContext, getMockUserInstance } from '../../test-utils'
 import getUserFeature from '../../experiments/getUserFeature'
+import logger from '../../../utils/logger'
 
 jest.mock('../../experiments/getUserFeature')
+jest.mock('../../../utils/logger')
 
 const userContext = getMockUserContext()
 const user = getMockUserInstance()
@@ -28,5 +30,17 @@ describe('getUserNotifications', () => {
     })
     const notifications = await getUserNotifications(userContext, user)
     expect(notifications).toEqual([{ code: 'userSurvey2022' }])
+  })
+
+  it('logs an error and returns an empty array if something goes wrong', async () => {
+    expect.assertions(2)
+    getUserFeature.mockImplementationOnce(() => {
+      throw new Error('Something went wrong.')
+    })
+    const notifications = await getUserNotifications(userContext, user)
+    expect(logger.error).toHaveBeenCalledWith(
+      new Error('Something went wrong.')
+    )
+    expect(notifications).toEqual([])
   })
 })

--- a/graphql/database/users/__tests__/getUserNotifications.test.js
+++ b/graphql/database/users/__tests__/getUserNotifications.test.js
@@ -2,13 +2,30 @@
 
 import getUserNotifications from '../getUserNotifications'
 import { getMockUserContext, getMockUserInstance } from '../../test-utils'
+import getUserFeature from '../../experiments/getUserFeature'
+
+jest.mock('../../experiments/getUserFeature')
 
 const userContext = getMockUserContext()
 const user = getMockUserInstance()
 
 describe('getUserNotifications', () => {
-  it('returns the expected notifications data', async () => {
+  it('returns the expected notifications data (no user survey feature enabled)', async () => {
     expect.assertions(1)
+    getUserFeature.mockResolvedValue({
+      featureName: 'user-survey-2022-notification',
+      variation: false,
+    })
+    const notifications = await getUserNotifications(userContext, user)
+    expect(notifications).toEqual([])
+  })
+
+  it('returns the expected notifications data (user survey feature enabled)', async () => {
+    expect.assertions(1)
+    getUserFeature.mockResolvedValue({
+      featureName: 'user-survey-2022-notification',
+      variation: true,
+    })
     const notifications = await getUserNotifications(userContext, user)
     expect(notifications).toEqual([{ code: 'userSurvey2022' }])
   })

--- a/graphql/database/users/__tests__/getUserNotifications.test.js
+++ b/graphql/database/users/__tests__/getUserNotifications.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+
+import getUserNotifications from '../getUserNotifications'
+import { getMockUserContext, getMockUserInstance } from '../../test-utils'
+
+jest.mock('../../databaseClient')
+jest.mock('../BackgroundImageModel')
+
+const userContext = getMockUserContext()
+const user = getMockUserInstance()
+
+describe('getUserNotifications', () => {
+  it('returns the expected notifications data', async () => {
+    expect.assertions(1)
+    const notifications = await getUserNotifications(userContext, user)
+    expect(notifications).toEqual([{ code: 'userSurvey2022' }])
+  })
+})

--- a/graphql/database/users/getUserNotifications.js
+++ b/graphql/database/users/getUserNotifications.js
@@ -1,3 +1,5 @@
+import getUserFeature from '../experiments/getUserFeature'
+
 /**
  * Get data for notifications the user should see.
  * @param {object} userContext - The user authorizer object.
@@ -6,11 +8,15 @@
  *   array.
  */
 
-// TODO: remove lint disable
-// eslint-disable-next-line no-unused-vars
-const getUserNotifications = (userContext, user) => {
-  // TODO
-  return [{ code: 'userSurvey2022' }]
+const getUserNotifications = async (userContext, user) => {
+  const showUserSurvey2022Notif = await getUserFeature(
+    userContext,
+    user,
+    'user-survey-2022-notification'
+  )
+  return [
+    ...(showUserSurvey2022Notif.variation ? [{ code: 'userSurvey2022' }] : []),
+  ]
 }
 
 export default getUserNotifications

--- a/graphql/database/users/getUserNotifications.js
+++ b/graphql/database/users/getUserNotifications.js
@@ -1,0 +1,13 @@
+/**
+ * Get data for notifications the user should see.
+ * @param {object} userContext - The user authorizer object.
+ * @param {string} user - UserModel object.
+ * @return {Notifications[]} An array of notification data, or an empty
+ *   array.
+ */
+const getUserNotifications = (userContext, user) => {
+  // TODO
+  return [{ code: 'userSurvey2022' }]
+}
+
+export default getUserNotifications

--- a/graphql/database/users/getUserNotifications.js
+++ b/graphql/database/users/getUserNotifications.js
@@ -1,4 +1,5 @@
 import getUserFeature from '../experiments/getUserFeature'
+import logger from '../../utils/logger'
 
 /**
  * Get data for notifications the user should see.
@@ -9,14 +10,22 @@ import getUserFeature from '../experiments/getUserFeature'
  */
 
 const getUserNotifications = async (userContext, user) => {
-  const showUserSurvey2022Notif = await getUserFeature(
-    userContext,
-    user,
-    'user-survey-2022-notification'
-  )
-  return [
-    ...(showUserSurvey2022Notif.variation ? [{ code: 'userSurvey2022' }] : []),
-  ]
+  let notifications = []
+  try {
+    const showUserSurvey2022Notif = await getUserFeature(
+      userContext,
+      user,
+      'user-survey-2022-notification'
+    )
+    notifications = [
+      ...(showUserSurvey2022Notif.variation
+        ? [{ code: 'userSurvey2022' }]
+        : []),
+    ]
+  } catch (e) {
+    logger.error(e)
+  }
+  return notifications
 }
 
 export default getUserNotifications

--- a/graphql/database/users/getUserNotifications.js
+++ b/graphql/database/users/getUserNotifications.js
@@ -5,6 +5,9 @@
  * @return {Notifications[]} An array of notification data, or an empty
  *   array.
  */
+
+// TODO: remove lint disable
+// eslint-disable-next-line no-unused-vars
 const getUserNotifications = (userContext, user) => {
   // TODO
   return [{ code: 'userSurvey2022' }]


### PR DESCRIPTION
* This should not affect prod until the feature is enabled
* When the feature is enabled, return a notification from `user.notifications`, indicating to the client to show the 2022 user survey