### PR TITLE
[TFAC-1035] Improve reporting dimensions for search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ env:
   - TEST_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - TEST_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - TEST_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1451 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  # TODO: update after deploy
   - TEST_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1451 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - TEST_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=test-tab2017-media.gladly.io
   - TEST_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=test-tab2017-media.gladly.io
@@ -156,7 +157,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
-  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1230 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1233 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_LANDING_PAGE_DOMAIN=dev-tab-website.s3-website-us-west-2.amazonaws.com
@@ -226,6 +227,7 @@ env:
   # https://github.com/stereobooster/react-snap/issues/157
   - PROD_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - PROD_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=562 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  # TODO: update after deploy
   - PROD_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=562 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - PROD_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=prod-tab2017-media.gladly.io
   - PROD_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=prod-tab2017-media.gladly.io

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -745,6 +745,10 @@ const userType = new GraphQLObjectType({
       description: 'feature values for this specific user',
       resolve: (user, args, context) => getUserFeatures(context.user, user),
     },
+
+    // FIXME: need a SearchEnginePersonalizedType.
+    // Currently:
+    // RelayResponseNormalizer: Invalid record. The record contains two instances of the same id.
     searchEngine: {
       type: SearchEngineType,
       description: 'the User’s search engine',

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -998,7 +998,7 @@ const CauseType = new GraphQLObjectType({
   interfaces: [nodeInterface],
 })
 
-const searchEngineFields = {
+const searchEngineSharedFields = {
   engineId: {
     type: new GraphQLNonNull(GraphQLString),
     description: "Engine's id",
@@ -1007,14 +1007,6 @@ const searchEngineFields = {
   name: {
     type: new GraphQLNonNull(GraphQLString),
     description: `Name of the Search Engine`,
-  },
-  searchUrl: {
-    deprecationReason:
-      'Use "searchUrlPersonalized" instead, which might customize search URLs toprovide aggregated analytics (e.g., search revenue by cause)',
-
-    type: new GraphQLNonNull(GraphQLString),
-    description:
-      'Deprecated. A search destination URL, with a {searchTerms} placeholder for the client to replace',
   },
   rank: {
     type: new GraphQLNonNull(GraphQLInt),
@@ -1033,8 +1025,13 @@ const SearchEngineType = new GraphQLObjectType({
   name: SEARCH_ENGINE,
   description: 'all important data for a search engine.',
   fields: () => ({
-    ...searchEngineFields,
+    ...searchEngineSharedFields,
     id: globalIdField(SEARCH_ENGINE),
+    searchUrl: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        'A search destination URL, with a {searchTerms} placeholder for the client to replace. Use `user.searchEngine` if the user is authenticated.',
+    },
   }),
   interfaces: [nodeInterface],
 })
@@ -1043,7 +1040,7 @@ const SearchEnginePersonalizedType = new GraphQLObjectType({
   description:
     'SearchEngineType extended with fields potentially personalized to the user',
   fields: () => ({
-    ...searchEngineFields,
+    ...searchEngineSharedFields,
     searchUrlPersonalized: {
       type: new GraphQLNonNull(GraphQLString),
       description:

--- a/graphql/database/constants.js
+++ b/graphql/database/constants.js
@@ -25,6 +25,7 @@ export const USER_SWITCH_SEARCH_PROMPT_LOG = 'UserSwitchSearchPromptLog'
 export const USER_SEARCH_SETTINGS_LOG = 'UserSearchSettingsLog'
 export const USER_EXPERIMENT = 'UserExperiment'
 export const SEARCH_ENGINE = 'SearchEngine'
+export const SEARCH_ENGINE_PERSONALIZED = 'SearchEnginePersonalized'
 export const FEATURE = 'Feature'
 // Model field values
 export const USER_BACKGROUND_OPTION_DAILY = 'daily'

--- a/graphql/database/search/SearchEngineModel.js
+++ b/graphql/database/search/SearchEngineModel.js
@@ -31,10 +31,14 @@ class SearchEngine extends BaseModel {
         .required(),
       searchUrl: types
         .string()
-        .description(
-          `query string to redirect the user to after using the search bar`
-        )
+        .description(`a search destination URL`)
         .required(),
+      // must constructed in business logic
+      searchUrlPersonalized: types
+        .string()
+        .description(
+          `a search destination URL, potentially customized to the user`
+        ),
       rank: types
         .number()
         .description(`what order to display the search engine in a list`),
@@ -53,6 +57,15 @@ class SearchEngine extends BaseModel {
 
   static get fieldDefaults() {
     return {}
+  }
+
+  static get fieldDeserializers() {
+    return {
+      // Default to setting "searchUrlPersonalized" to the same value as
+      // "searchUrl" to ensure it's always defined. Let business logic
+      // overwrite it as needed.
+      searchUrlPersonalized: (_, searchEngineObj) => searchEngineObj.searchUrl,
+    }
   }
 }
 

--- a/graphql/database/search/__tests__/SearchEngineModel.test.js
+++ b/graphql/database/search/__tests__/SearchEngineModel.test.js
@@ -42,6 +42,7 @@ describe('SearchEngineModel', () => {
       name: 'Search For A Cause',
       id: 'SearchForACause',
       searchUrl: 'http://tab.gladly.io/search/v2?q=',
+      searchUrlPersonalized: 'http://tab.gladly.io/search/v2?q=',
       rank: 0,
       isCharitable: true,
       inputPrompt: 'Search For a Cause',

--- a/graphql/database/search/searchEngineData.js
+++ b/graphql/database/search/searchEngineData.js
@@ -3,14 +3,8 @@ export const searchEngineData = [
     name: 'Search for a Cause',
     id: 'SearchForACause',
 
-    // These placeholders should be filled in server-side:
-    //   {source}, {causeId}, and {referrerId}.
     // The {searchTerms} placeholder should be filled in client-side.
-    // TODO: if we have an internal search endpoint that is user-aware,
-    //   we should use it to populate the values required for analytics.
-    //   Then, we don't need to forward them in the search URL here.
-    searchUrl:
-      'http://tab.gladly.io/search/v2?q={searchTerms}&src={source}&c={causeId}&r={referrerId}',
+    searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
     rank: 0,
     isCharitable: true,
     inputPrompt: 'Search for a Cause',
@@ -50,8 +44,7 @@ export const searchEngineData = [
   {
     name: 'Yahoo',
     id: 'Yahoo',
-    searchUrl:
-      'http://tab.gladly.io/search/v2?q={searchTerms}&src={source}&c={causeId}&r={referrerId}',
+    searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
     rank: 5,
     isCharitable: false,
     inputPrompt: 'Search Yahoo',

--- a/graphql/database/search/searchEngineData.js
+++ b/graphql/database/search/searchEngineData.js
@@ -4,7 +4,7 @@ export const searchEngineData = [
     id: 'SearchForACause',
 
     // The {searchTerms} placeholder should be filled in client-side.
-    searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
+    searchUrl: 'https://tab.gladly.io/search/v2?q={searchTerms}',
     rank: 0,
     isCharitable: true,
     inputPrompt: 'Search for a Cause',
@@ -44,7 +44,7 @@ export const searchEngineData = [
   {
     name: 'Yahoo',
     id: 'Yahoo',
-    searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
+    searchUrl: 'https://tab.gladly.io/search/v2?q={searchTerms}',
     rank: 5,
     isCharitable: false,
     inputPrompt: 'Search Yahoo',

--- a/graphql/database/search/searchEngineData.js
+++ b/graphql/database/search/searchEngineData.js
@@ -2,7 +2,15 @@ export const searchEngineData = [
   {
     name: 'Search for a Cause',
     id: 'SearchForACause',
-    searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
+
+    // These placeholders should be filled in server-side:
+    //   {source}, {causeId}, and {referrerId}.
+    // The {searchTerms} placeholder should be filled in client-side.
+    // TODO: if we have an internal search endpoint that is user-aware,
+    //   we should use it to populate the values required for analytics.
+    //   Then, we don't need to forward them in the search URL here.
+    searchUrl:
+      'http://tab.gladly.io/search/v2?q={searchTerms}&src={source}&c={causeId}&r={referrerId}',
     rank: 0,
     isCharitable: true,
     inputPrompt: 'Search for a Cause',
@@ -42,7 +50,8 @@ export const searchEngineData = [
   {
     name: 'Yahoo',
     id: 'Yahoo',
-    searchUrl: 'http://tab.gladly.io/search/v2?q={searchTerms}',
+    searchUrl:
+      'http://tab.gladly.io/search/v2?q={searchTerms}&src={source}&c={causeId}&r={referrerId}',
     rank: 5,
     isCharitable: false,
     inputPrompt: 'Search Yahoo',

--- a/graphql/database/users/__tests__/getUserSearchEngine.test.js
+++ b/graphql/database/users/__tests__/getUserSearchEngine.test.js
@@ -140,7 +140,7 @@ describe('getUserSearchEngine', () => {
     expect(result).toEqual(await getSearchEngine('DuckDuckGo'))
   })
 
-  it('SFAC engine: returns the expected search URL', async () => {
+  it('SFAC engine: returns the expected *unpersonalized* search URL', async () => {
     expect.assertions(1)
     const searchEngine = 'SearchForACause'
     const mockUser = {
@@ -149,11 +149,11 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrl).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
+      'http://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
-  it('SFAC engine: adds a "src" URL parameter', async () => {
+  it('SFAC engine: returns the expected search URL', async () => {
     expect.assertions(1)
     const searchEngine = 'SearchForACause'
     const mockUser = {
@@ -161,11 +161,24 @@ describe('getUserSearchEngine', () => {
       searchEngine,
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    expect(result.searchUrlPersonalized).toEqual(
+      'http://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
+    )
+  })
+
+  it('SFAC engine (personalized): adds a "src" URL parameter', async () => {
+    expect.assertions(1)
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('src')).toEqual('tab')
   })
 
-  it('SFAC engine: adds a "c" URL parameter when the user is supporting a cause', async () => {
+  it('SFAC engine (personalized): adds a "c" URL parameter when the user is supporting a cause', async () => {
     expect.assertions(1)
     const searchEngine = 'SearchForACause'
     const mockUser = {
@@ -175,11 +188,11 @@ describe('getUserSearchEngine', () => {
       causeId: 'abc123',
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('c')).toEqual('abc123')
   })
 
-  it('SFAC engine: does not add a "c" URL parameter when the user is not using v4', async () => {
+  it('SFAC engine (personalized): does not add a "c" URL parameter when the user is not using v4', async () => {
     expect.assertions(1)
     const searchEngine = 'SearchForACause'
     const mockUser = {
@@ -189,11 +202,11 @@ describe('getUserSearchEngine', () => {
       causeId: 'abc123',
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('c')).toBeNull()
   })
 
-  it('SFAC engine: adds a "r" URL parameter when the user has a referring ID', async () => {
+  it('SFAC engine (personalized): adds a "r" URL parameter when the user has a referring ID', async () => {
     expect.assertions(1)
     jest.spyOn(ReferralDataModel, 'get').mockResolvedValueOnce({
       userId: 'abc123',
@@ -206,11 +219,11 @@ describe('getUserSearchEngine', () => {
       searchEngine,
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('r')).toEqual('998877')
   })
 
-  it('SFAC engine: still returns a search URL if adding reporting parameters fails', async () => {
+  it('SFAC engine (personalized): still returns a search URL if adding reporting parameters fails', async () => {
     expect.assertions(1)
     jest
       .spyOn(ReferralDataModel, 'get')
@@ -221,12 +234,12 @@ describe('getUserSearchEngine', () => {
       searchEngine,
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    expect(result.searchUrl).toEqual(
+    expect(result.searchUrlPersonalized).toEqual(
       'http://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
-  it('SFAC engine: logs an error if adding reporting parameters fails', async () => {
+  it('SFAC engine (personalized): logs an error if adding reporting parameters fails (', async () => {
     expect.assertions(1)
     jest
       .spyOn(ReferralDataModel, 'get')
@@ -240,7 +253,7 @@ describe('getUserSearchEngine', () => {
     expect(logger.error).toHaveBeenCalledWith(new Error('Uh oh!'))
   })
 
-  it('SFAC engine: does not log an error if the ReferralDataModel item does not exist', async () => {
+  it('SFAC engine (personalized): does not log an error if the ReferralDataModel item does not exist', async () => {
     expect.assertions(1)
     jest
       .spyOn(ReferralDataModel, 'get')
@@ -254,7 +267,7 @@ describe('getUserSearchEngine', () => {
     expect(logger.error).not.toHaveBeenCalled()
   })
 
-  it('Yahoo engine: returns the expected search URL', async () => {
+  it('Yahoo engine: returns the expected search URL (unpersonalized)', async () => {
     expect.assertions(1)
     const searchEngine = 'Yahoo'
     const mockUser = {
@@ -263,11 +276,11 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrl).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
+      'http://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
-  it('Yahoo engine: adds a "src" URL parameter', async () => {
+  it('Yahoo engine (personalized): returns the expected search URL', async () => {
     expect.assertions(1)
     const searchEngine = 'Yahoo'
     const mockUser = {
@@ -275,11 +288,24 @@ describe('getUserSearchEngine', () => {
       searchEngine,
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    expect(result.searchUrlPersonalized).toEqual(
+      'http://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
+    )
+  })
+
+  it('Yahoo engine (personalized): adds a "src" URL parameter', async () => {
+    expect.assertions(1)
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('src')).toEqual('tab')
   })
 
-  it('Yahoo engine: adds a "c" URL parameter when the user is supporting a cause', async () => {
+  it('Yahoo engine (personalized): adds a "c" URL parameter when the user is supporting a cause', async () => {
     expect.assertions(1)
     const searchEngine = 'Yahoo'
     const mockUser = {
@@ -289,11 +315,11 @@ describe('getUserSearchEngine', () => {
       causeId: 'abc123',
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('c')).toEqual('abc123')
   })
 
-  it('Yahoo engine: does not add a "c" URL parameter when the user is not using v4', async () => {
+  it('Yahoo engine (personalized): does not add a "c" URL parameter when the user is not using v4', async () => {
     expect.assertions(1)
     const searchEngine = 'Yahoo'
     const mockUser = {
@@ -303,11 +329,11 @@ describe('getUserSearchEngine', () => {
       causeId: 'abc123',
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('c')).toBeNull()
   })
 
-  it('Yahoo engine: adds a "r" URL parameter when the user has a referring ID', async () => {
+  it('Yahoo engine (personalized): adds a "r" URL parameter when the user has a referring ID', async () => {
     expect.assertions(1)
     jest.spyOn(ReferralDataModel, 'get').mockResolvedValueOnce({
       userId: 'abc123',
@@ -320,11 +346,11 @@ describe('getUserSearchEngine', () => {
       searchEngine,
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('r')).toEqual('998877')
   })
 
-  it('Yahoo engine: still returns a search URL if adding reporting parameters fails', async () => {
+  it('Yahoo engine (personalized): still returns a search URL if adding reporting parameters fails', async () => {
     expect.assertions(1)
     jest
       .spyOn(ReferralDataModel, 'get')
@@ -335,12 +361,12 @@ describe('getUserSearchEngine', () => {
       searchEngine,
     }
     const result = await getUserSearchEngine(userContext, mockUser)
-    expect(result.searchUrl).toEqual(
+    expect(result.searchUrlPersonalized).toEqual(
       'http://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
-  it('Yahoo engine: logs an error if adding reporting parameters fails', async () => {
+  it('Yahoo engine (personalized): logs an error if adding reporting parameters fails', async () => {
     expect.assertions(1)
     jest
       .spyOn(ReferralDataModel, 'get')
@@ -374,7 +400,7 @@ describe('getUserSearchEngine', () => {
     )
   })
 
-  it('Google engine: does not add "src", "c", or "r" URL parameter values', async () => {
+  it('Google engine (personalized): does not add "src", "c", or "r" URL parameter values', async () => {
     expect.assertions(3)
     const searchEngine = 'Google'
     const mockUser = {
@@ -389,7 +415,7 @@ describe('getUserSearchEngine', () => {
       referringChannel: '998877',
     })
     const result = await getUserSearchEngine(userContext, mockUser)
-    const url = new URL(result.searchUrl)
+    const url = new URL(result.searchUrlPersonalized)
     expect(url.searchParams.get('src')).toBeNull()
     expect(url.searchParams.get('c')).toBeNull()
     expect(url.searchParams.get('r')).toBeNull()

--- a/graphql/database/users/__tests__/getUserSearchEngine.test.js
+++ b/graphql/database/users/__tests__/getUserSearchEngine.test.js
@@ -149,7 +149,7 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrl).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}'
+      'https://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
@@ -162,7 +162,7 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrlPersonalized).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
+      'https://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
     )
   })
 
@@ -235,7 +235,7 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrlPersonalized).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}'
+      'https://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
@@ -276,7 +276,7 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrl).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}'
+      'https://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 
@@ -289,7 +289,7 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrlPersonalized).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
+      'https://tab.gladly.io/search/v2?q={searchTerms}&src=tab'
     )
   })
 
@@ -362,7 +362,7 @@ describe('getUserSearchEngine', () => {
     }
     const result = await getUserSearchEngine(userContext, mockUser)
     expect(result.searchUrlPersonalized).toEqual(
-      'http://tab.gladly.io/search/v2?q={searchTerms}'
+      'https://tab.gladly.io/search/v2?q={searchTerms}'
     )
   })
 

--- a/graphql/database/users/__tests__/getUserSearchEngine.test.js
+++ b/graphql/database/users/__tests__/getUserSearchEngine.test.js
@@ -14,12 +14,16 @@ import Feature from '../../experiments/FeatureModel'
 import { YAHOO_SEARCH_NEW_USERS } from '../../experiments/experimentConstants'
 import getSearchEngine from '../../search/getSearchEngine'
 import { DEFAULT_SEARCH_ENGINE, WIDGET_TYPE_SEARCH } from '../../constants'
+import ReferralDataModel from '../../referrals/ReferralDataModel'
+import logger from '../../../utils/logger'
 
 jest.mock('../../experiments/getUserFeature')
 jest.mock('../../databaseClient')
 jest.mock('../../globals/globals')
 jest.mock('../../cause/getCause')
 jest.mock('../../widgets/getWidgets')
+jest.mock('../../referrals/ReferralDataModel')
+jest.mock('../../../utils/logger')
 
 const userContext = getMockUserContext()
 const mockCurrentTime = '2017-06-22T01:13:28.000Z'
@@ -32,6 +36,11 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  jest.spyOn(ReferralDataModel, 'get').mockResolvedValue({
+    userId: 'abc123',
+    referringUser: null,
+    referringChannel: null,
+  })
 })
 const user = getMockUserInstance()
 
@@ -128,5 +137,200 @@ describe('getUserSearchEngine', () => {
 
     const result = await getUserSearchEngine(userContext, user)
     expect(result).toEqual(await getSearchEngine('DuckDuckGo'))
+  })
+
+  it('SFAC engine: adds a "src" URL parameter', async () => {
+    expect.assertions(1)
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('src')).toEqual('tab')
+  })
+
+  it('SFAC engine: adds a "c" URL parameter when the user is supporting a cause', async () => {
+    expect.assertions(1)
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+      v4BetaEnabled: true,
+      causeId: 'abc123',
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('c')).toEqual('abc123')
+  })
+
+  it('SFAC engine: does not add a "c" URL parameter when the user is not using v4', async () => {
+    expect.assertions(1)
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+      v4BetaEnabled: false,
+      causeId: 'abc123',
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('c')).toBeNull()
+  })
+
+  it('SFAC engine: adds a "r" URL parameter when the user has a referring ID', async () => {
+    expect.assertions(1)
+    jest.spyOn(ReferralDataModel, 'get').mockResolvedValueOnce({
+      userId: 'abc123',
+      referringUser: null,
+      referringChannel: '998877',
+    })
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('r')).toEqual('998877')
+  })
+
+  it('SFAC engine: still returns a search URL if adding reporting parameters fails', async () => {
+    expect.assertions(1)
+    jest
+      .spyOn(ReferralDataModel, 'get')
+      .mockRejectedValueOnce(new Error('Uh oh!'))
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    expect(result.searchUrl).toEqual(
+      'http://tab.gladly.io/search/v2?q={searchTerms}'
+    )
+  })
+
+  it('SFAC engine: logs an error if adding reporting parameters fails', async () => {
+    expect.assertions(1)
+    jest
+      .spyOn(ReferralDataModel, 'get')
+      .mockRejectedValueOnce(new Error('Uh oh!'))
+    const searchEngine = 'SearchForACause'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    await getUserSearchEngine(userContext, mockUser)
+    expect(logger.error).toHaveBeenCalledWith(new Error('Uh oh!'))
+  })
+
+  it('Yahoo engine: adds a "src" URL parameter', async () => {
+    expect.assertions(1)
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('src')).toEqual('tab')
+  })
+
+  it('Yahoo engine: adds a "c" URL parameter when the user is supporting a cause', async () => {
+    expect.assertions(1)
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+      v4BetaEnabled: true,
+      causeId: 'abc123',
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('c')).toEqual('abc123')
+  })
+
+  it('Yahoo engine: does not add a "c" URL parameter when the user is not using v4', async () => {
+    expect.assertions(1)
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+      v4BetaEnabled: false,
+      causeId: 'abc123',
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('c')).toBeNull()
+  })
+
+  it('Yahoo engine: adds a "r" URL parameter when the user has a referring ID', async () => {
+    expect.assertions(1)
+    jest.spyOn(ReferralDataModel, 'get').mockResolvedValueOnce({
+      userId: 'abc123',
+      referringUser: null,
+      referringChannel: '998877',
+    })
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('r')).toEqual('998877')
+  })
+
+  it('Yahoo engine: still returns a search URL if adding reporting parameters fails', async () => {
+    expect.assertions(1)
+    jest
+      .spyOn(ReferralDataModel, 'get')
+      .mockRejectedValueOnce(new Error('Uh oh!'))
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    const result = await getUserSearchEngine(userContext, mockUser)
+    expect(result.searchUrl).toEqual(
+      'http://tab.gladly.io/search/v2?q={searchTerms}'
+    )
+  })
+
+  it('Yahoo engine: logs an error if adding reporting parameters fails', async () => {
+    expect.assertions(1)
+    jest
+      .spyOn(ReferralDataModel, 'get')
+      .mockRejectedValueOnce(new Error('Uh oh!'))
+    const searchEngine = 'Yahoo'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+    }
+    await getUserSearchEngine(userContext, mockUser)
+    expect(logger.error).toHaveBeenCalledWith(new Error('Uh oh!'))
+  })
+
+  it('Google engine: does not add "src", "c", or "r" URL parameter values', async () => {
+    expect.assertions(3)
+    const searchEngine = 'Google'
+    const mockUser = {
+      ...getMockUserInstance(),
+      searchEngine,
+      v4BetaEnabled: true,
+      causeId: 'abc123',
+    }
+    jest.spyOn(ReferralDataModel, 'get').mockResolvedValueOnce({
+      userId: 'abc123',
+      referringUser: null,
+      referringChannel: '998877',
+    })
+    const result = await getUserSearchEngine(userContext, mockUser)
+    const url = new URL(result.searchUrl)
+    expect(url.searchParams.get('src')).toBeNull()
+    expect(url.searchParams.get('c')).toBeNull()
+    expect(url.searchParams.get('r')).toBeNull()
   })
 })

--- a/graphql/database/users/getUserSearchEngine.js
+++ b/graphql/database/users/getUserSearchEngine.js
@@ -5,6 +5,18 @@ import getSearchEngine from '../search/getSearchEngine'
 import { DatabaseItemDoesNotExistException } from '../../utils/exceptions'
 import getWidgets from '../widgets/getWidgets'
 
+// TODO: document & remove eslint-disable
+// eslint-disable-next-line no-unused-vars
+const generateSearchEngine = (searchEngineId, user) => {
+  const engineData = getSearchEngine(searchEngineId)
+  const personalizedSearchEngine = {
+    ...engineData,
+    // TODO: replace user-aware search URL parameter values:
+    //   &src={source}&c={causeId}&r={referrerId}
+  }
+  return personalizedSearchEngine
+}
+
 /**
  * Fetch the user's search engine by the following procedure:
  * 1. If set on the UserModel, return the value
@@ -19,7 +31,7 @@ import getWidgets from '../widgets/getWidgets'
 const getUserSearchEngine = async (userContext, user) => {
   // 1. If set on the UserModel, return the value
   if (user.searchEngine) {
-    return getSearchEngine(user.searchEngine)
+    return generateSearchEngine(user.searchEngine, user)
   }
 
   // 2. If unset, see if a search widget value is set and migrate it, then return that value
@@ -31,7 +43,7 @@ const getUserSearchEngine = async (userContext, user) => {
   if (maybeSearchWidget.length > 0) {
     const searchWidget = maybeSearchWidget[0]
     try {
-      return getSearchEngine(JSON.parse(searchWidget.config).engine)
+      return generateSearchEngine(JSON.parse(searchWidget.config).engine, user)
     } catch (e) {
       // Don't care if SearchEngine does not exist. This will happen if
       // the user has not explicitly set any search engine, or if a
@@ -49,11 +61,11 @@ const getUserSearchEngine = async (userContext, user) => {
     YAHOO_SEARCH_NEW_USERS
   )
   if (feature) {
-    return getSearchEngine(feature.variation)
+    return generateSearchEngine(feature.variation, user)
   }
 
   // 4. If still unset, return the default search engine
-  return getSearchEngine(DEFAULT_SEARCH_ENGINE)
+  return generateSearchEngine(DEFAULT_SEARCH_ENGINE, user)
 }
 
 export default getUserSearchEngine

--- a/graphql/database/users/getUserSearchEngine.js
+++ b/graphql/database/users/getUserSearchEngine.js
@@ -18,9 +18,12 @@ const searchEnginesToAddDimensions = ['SearchForACause', 'Yahoo']
  */
 const generateSearchEngine = async (userContext, user, searchEngineId) => {
   const engineData = getSearchEngine(searchEngineId)
-  let { searchUrl } = engineData
+  const { searchUrl } = engineData
 
-  // For SFAC & Yahoo, add dimensions for reporting.
+  let searchUrlPersonalized = searchUrl
+
+  // For SFAC & Yahoo, modify the personalized search URL to include
+  // dimensions used in aggregated analytics (e.g., search revenue by cause).
   try {
     if (searchEnginesToAddDimensions.indexOf(engineData.id) > -1) {
       const { causeId, v4BetaEnabled, id: userId } = user
@@ -43,18 +46,20 @@ const generateSearchEngine = async (userContext, user, searchEngineId) => {
       if (referringChannel) {
         url.searchParams.set('r', referringChannel)
       }
-      searchUrl = url.href
 
       // Setting search params will encode the {searchTerms} template.
       // We want to keep it unencoded for the client.
-      searchUrl = searchUrl.replace('%7BsearchTerms%7D', '{searchTerms}')
+      searchUrlPersonalized = url.href.replace(
+        '%7BsearchTerms%7D',
+        '{searchTerms}'
+      )
     }
   } catch (e) {
     logger.error(e)
   }
   const personalizedSearchEngine = {
     ...engineData,
-    searchUrl,
+    searchUrlPersonalized,
   }
   return personalizedSearchEngine
 }

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -205,12 +205,12 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     )
   })
 
-  it('only sets the "q" query string value, ignoring other URL params', () => {
+  it('only sets the "q" query string value, ignoring other unused URL params', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
     const event = setEventURI(defaultEvent, searchV2Path)
-    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&blah=foo'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
@@ -218,6 +218,21 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
       'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
     )
   })
+
+  // TODO
+  // it('sets the "type" string with an empty cause ID, source of search, and referral ID', () => {
+  //   expect.assertions(1)
+  //   const { handler } = require('../search-app-lambda-edge')
+  //   const defaultEvent = getMockCloudFrontEventObject()
+  //   const event = setEventURI(defaultEvent, searchV2Path)
+  //   event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
+  //   const context = getMockLambdaContext()
+  //   handler(event, context, callback)
+  //   const response = callback.mock.calls[0][1]
+  //   expect(response.headers.location[0].value).toEqual(
+  //     'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
+  //   )
+  // })
 
   it('passes the expected header values to `searchURLByRegion`', () => {
     expect.assertions(1)

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -118,7 +118,7 @@ describe('v1: search app Lambda@Edge function on viewer-request', () => {
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
     const event = setEventURI(defaultEvent, searchV1Path)
-    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
@@ -149,7 +149,9 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
-    expect(response.headers.location[0].value).toEqual(MOCK_V2_SEARCH_URL)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none'
+    )
   })
 
   it('uses the v2 API if the URI has a trailing slash', () => {
@@ -160,7 +162,9 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     const context = getMockLambdaContext()
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
-    expect(response.headers.location[0].value).toEqual(MOCK_V2_SEARCH_URL)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none'
+    )
   })
 
   it('sets the query string value if the "q" value is defined', () => {
@@ -173,7 +177,7 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
     expect(response.headers.location[0].value).toEqual(
-      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza'
     )
   })
 
@@ -187,7 +191,7 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
     expect(response.headers.location[0].value).toEqual(
-      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza+palace'
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza+palace'
     )
   })
 
@@ -201,7 +205,7 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
     expect(response.headers.location[0].value).toEqual(
-      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza%F0%9F%8D%95'
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza%F0%9F%8D%95'
     )
   })
 
@@ -215,24 +219,80 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     handler(event, context, callback)
     const response = callback.mock.calls[0][1]
     expect(response.headers.location[0].value).toEqual(
-      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza'
     )
   })
 
-  // TODO
-  // it('sets the "type" string with an empty cause ID, source of search, and referral ID', () => {
-  //   expect.assertions(1)
-  //   const { handler } = require('../search-app-lambda-edge')
-  //   const defaultEvent = getMockCloudFrontEventObject()
-  //   const event = setEventURI(defaultEvent, searchV2Path)
-  //   event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
-  //   const context = getMockLambdaContext()
-  //   handler(event, context, callback)
-  //   const response = callback.mock.calls[0][1]
-  //   expect(response.headers.location[0].value).toEqual(
-  //     'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&p=pizza'
-  //   )
-  // })
+  it('sets the "type" string with an empty cause ID, source of search, and referral ID', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with a source', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=tab'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_tab.c_none.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with a cause ID', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&c=abc123&q=pizza'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_abc123.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with a referral ID', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&r=2468&q=pizza'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_2468&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with all fields', () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring =
+      'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
+    const context = getMockLambdaContext()
+    handler(event, context, callback)
+    const response = callback.mock.calls[0][1]
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_ff.c_somecauseid.r_2468&p=pizza'
+    )
+  })
 
   it('passes the expected header values to `searchURLByRegion`', () => {
     expect.assertions(1)
@@ -247,7 +307,7 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
       'accept-language',
       'es'
     )
-    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=foo'
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
     const context = getMockLambdaContext()
     handler(event, context, callback)
     expect(searchURLByRegion).toHaveBeenCalledWith('MX', 'es')

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -29,10 +29,18 @@ exports.handler = (event, context, callback) => {
     const headers = get(request, 'headers', {})
     const countryHeader = get(headers, 'cloudfront-viewer-country[0].value')
     const acceptLanguageHeader = get(headers, 'accept-language[0].value')
-    searchBaseURL = searchURLByRegion(countryHeader, acceptLanguageHeader)
+    const yahooBaseURL = searchURLByRegion(countryHeader, acceptLanguageHeader)
 
-    // TODO: construct "type" param value from params: src, c, r
-    //   e.g.: type=src:tab,c:CA6A5C2uj,r:482
+    // Set the "type" parameter, a string used for reporting.
+    // We use unreserved characters for report readability/usability.
+    //   e.g.: type=src_tab.c_CA6A5C2uj.r_482
+    const searchSrc = params.get('src') || 'none'
+    const causeId = params.get('c') || 'none'
+    const referralId = params.get('r') || 'none'
+    const typeParamVal = `src_${searchSrc}.c_${causeId}.r_${referralId}`
+    const url = new URL(yahooBaseURL)
+    url.searchParams.set('type', typeParamVal)
+    searchBaseURL = url.href
   } else {
     // For v1, use Google for search results.
     searchProviderQueryKey = 'q'

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -32,7 +32,8 @@ exports.handler = (event, context, callback) => {
     const yahooBaseURL = searchURLByRegion(countryHeader, acceptLanguageHeader)
 
     // Set the "type" parameter, a string used for reporting.
-    // We use unreserved characters for report readability/usability.
+    // We use unreserved characters for report readability/usability, and
+    // Yahoo does not allow using hyphens.
     //   e.g.: type=src_tab.c_CA6A5C2uj.r_482
     const searchSrc = params.get('src') || 'none'
     const causeId = params.get('c') || 'none'

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -35,13 +35,18 @@ exports.handler = (event, context, callback) => {
     // We use unreserved characters for report readability/usability, and
     // Yahoo does not allow using hyphens.
     //   e.g.: type=src_tab.c_CA6A5C2uj.r_482
-    const searchSrc = params.get('src') || 'none'
-    const causeId = params.get('c') || 'none'
-    const referralId = params.get('r') || 'none'
-    const typeParamVal = `src_${searchSrc}.c_${causeId}.r_${referralId}`
-    const url = new URL(yahooBaseURL)
-    url.searchParams.set('type', typeParamVal)
-    searchBaseURL = url.href
+    try {
+      const searchSrc = params.get('src') || 'none'
+      const causeId = params.get('c') || 'none'
+      const referralId = params.get('r') || 'none'
+      const typeParamVal = `src_${searchSrc}.c_${causeId}.r_${referralId}`
+      const url = new URL(yahooBaseURL)
+      url.searchParams.set('type', typeParamVal)
+      searchBaseURL = url.href
+    } catch (e) {
+      console.error(e)
+      searchBaseURL = yahooBaseURL
+    }
   } else {
     // For v1, use Google for search results.
     searchProviderQueryKey = 'q'

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -30,6 +30,9 @@ exports.handler = (event, context, callback) => {
     const countryHeader = get(headers, 'cloudfront-viewer-country[0].value')
     const acceptLanguageHeader = get(headers, 'accept-language[0].value')
     searchBaseURL = searchURLByRegion(countryHeader, acceptLanguageHeader)
+
+    // TODO: construct "type" param value from params: src, c, r
+    //   e.g.: type=src:tab,c:CA6A5C2uj,r:482
   } else {
     // For v1, use Google for search results.
     searchProviderQueryKey = 'q'

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -1054,11 +1054,6 @@ type SearchEngine implements Node {
   """Name of the Search Engine"""
   name: String!
 
-  """
-  Deprecated. A search destination URL, with a {searchTerms} placeholder for the client to replace
-  """
-  searchUrl: String! @deprecated(reason: "Use \"searchUrlPersonalized\" instead, which might customize search URLs toprovide aggregated analytics (e.g., search revenue by cause)")
-
   """what order to display the search engine in a list"""
   rank: Int!
 
@@ -1070,6 +1065,12 @@ type SearchEngine implements Node {
 
   """The ID of an object"""
   id: ID!
+
+  """
+  A search destination URL, with a {searchTerms} placeholder for the client to
+  replace. Use `user.searchEngine` if the user is authenticated.
+  """
+  searchUrl: String!
 }
 
 """A connection to a list of items."""
@@ -1099,11 +1100,6 @@ type SearchEnginePersonalized implements Node {
 
   """Name of the Search Engine"""
   name: String!
-
-  """
-  Deprecated. A search destination URL, with a {searchTerms} placeholder for the client to replace
-  """
-  searchUrl: String! @deprecated(reason: "Use \"searchUrlPersonalized\" instead, which might customize search URLs toprovide aggregated analytics (e.g., search revenue by cause)")
 
   """what order to display the search engine in a list"""
   rank: Int!

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -1048,17 +1048,16 @@ type RestartMissionPayload {
 
 """all important data for a search engine."""
 type SearchEngine implements Node {
-  """The ID of an object"""
-  id: ID!
-
   """Engine's id"""
   engineId: String!
 
   """Name of the Search Engine"""
   name: String!
 
-  """query string to redirect the user to after using the search bar"""
-  searchUrl: String!
+  """
+  Deprecated. A search destination URL, with a {searchTerms} placeholder for the client to replace
+  """
+  searchUrl: String! @deprecated(reason: "Use \"searchUrlPersonalized\" instead, which might customize search URLs toprovide aggregated analytics (e.g., search revenue by cause)")
 
   """what order to display the search engine in a list"""
   rank: Int!
@@ -1068,6 +1067,9 @@ type SearchEngine implements Node {
 
   """Display string to display in the search bar"""
   inputPrompt: String!
+
+  """The ID of an object"""
+  id: ID!
 }
 
 """A connection to a list of items."""
@@ -1086,6 +1088,41 @@ type SearchEngineEdge {
 
   """A cursor for use in pagination"""
   cursor: String!
+}
+
+"""
+SearchEngineType extended with fields potentially personalized to the user
+"""
+type SearchEnginePersonalized implements Node {
+  """Engine's id"""
+  engineId: String!
+
+  """Name of the Search Engine"""
+  name: String!
+
+  """
+  Deprecated. A search destination URL, with a {searchTerms} placeholder for the client to replace
+  """
+  searchUrl: String! @deprecated(reason: "Use \"searchUrlPersonalized\" instead, which might customize search URLs toprovide aggregated analytics (e.g., search revenue by cause)")
+
+  """what order to display the search engine in a list"""
+  rank: Int!
+
+  """Whether or not the user can earn extra impact with this Search Engine"""
+  isCharitable: Boolean!
+
+  """Display string to display in the search bar"""
+  inputPrompt: String!
+
+  """
+  Use this for the user's search behavior. A search destination URL, with a
+  {searchTerms} placeholder for the client to replace. The URL might be
+  personalized based on the user.
+  """
+  searchUrlPersonalized: String!
+
+  """The ID of an object"""
+  id: ID!
 }
 
 """Info about any rate-limiting for VC earned from search queries"""
@@ -1555,7 +1592,7 @@ type User implements Node {
   features: [Feature]!
 
   """the User’s search engine"""
-  searchEngine: SearchEngine
+  searchEngine: SearchEnginePersonalized
 
   """whether to show the yahoo search prompt"""
   showYahooPrompt: Boolean!


### PR DESCRIPTION
This PR tackles two distinct pieces:
* Provide a personalized Search for a Cause URL to improve analytics: add a `SearchEnginePersonalized` type that includes reporting dimensions in the `searchUrlPersonalized` field
* Update the search endpoint to forward Search for a Cause reporting dimensions in a URL parameter

This PR is a no-op when deployed until we:
* update the search Lambda@Edge version in a subsequent deployment
* update the client behavior: https://github.com/gladly-team/tab-web/pull/356