### PR TITLE
TFAC-1047: call search request SNS topic from edge lambda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   # TODO: update
-  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1236 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1239 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_LANDING_PAGE_DOMAIN=dev-tab-website.s3-website-us-west-2.amazonaws.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ env:
   - TEST_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - TEST_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - TEST_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1451 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  # TODO: update after deploy
   - TEST_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1453 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - TEST_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=test-tab2017-media.gladly.io
   - TEST_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=test-tab2017-media.gladly.io
@@ -226,6 +227,7 @@ env:
   # https://github.com/stereobooster/react-snap/issues/157
   - PROD_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - PROD_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=562 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  # TODO: update after deploy
   - PROD_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=563 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - PROD_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=prod-tab2017-media.gladly.io
   - PROD_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=prod-tab2017-media.gladly.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   # TODO: update
-  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1233 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1236 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_LANDING_PAGE_DOMAIN=dev-tab-website.s3-website-us-west-2.amazonaws.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,6 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
-  # TODO: update
   - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1239 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ env:
   - DEV_DEPLOYMENT_SEARCH_APP_S3_BUCKET_PATH=/search
   - DEV_DEPLOYMENT_SEARCH_APP_PUBLIC_URL=/search/
   - DEV_DEPLOYMENT_WEB_APP_LAMBDA_EDGE_FUNCTION_VERSION=1227 # Important: create an alias for this function. See serverless-lambda-edge.yml.
+  # TODO: update
   - DEV_DEPLOYMENT_SEARCH_APP_LAMBDA_EDGE_FUNCTION_VERSION=1233 # Important: create an alias for this function. See serverless-lambda-edge.yml.
   - DEV_DEPLOYMENT_MEDIA_S3_BUCKET_NAME=dev-tab2017-media.gladly.io
   - DEV_DEPLOYMENT_MEDIA_CLOUDFRONT_DOMAIN_ALIAS=dev-tab2017-media.gladly.io

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -129,6 +129,8 @@ resources:
         # able to communicate with resources within your VPC.
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        # TODO: Give permission to publish to SNS SearchRequest topic
+        #   in any region. In test/dev stage, set to dev-SearchRequest topic.
         Policies:
           - PolicyName: gladly-${self:custom.stage}-lambda-execution-role
             PolicyDocument:

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -87,6 +87,10 @@ custom:
   prune:
     automatic: true
     number: 5
+  searchRequestSNSTopicName:
+    test: dev-SearchRequest
+    dev: dev-SearchRequest
+    prod: SearchRequest
 
 # Only include the build.
 # Don't include any dependencies by default. CloudFront-triggered Lambdas
@@ -129,8 +133,6 @@ resources:
         # able to communicate with resources within your VPC.
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-        # TODO: Give permission to publish to SNS SearchRequest topic
-        #   in any region. In test/dev stage, set to dev-SearchRequest topic.
         Policies:
           - PolicyName: gladly-${self:custom.stage}-lambda-execution-role
             PolicyDocument:
@@ -160,6 +162,23 @@ resources:
                        - ""
                        - - "arn:aws:s3:::"
                          - "Ref" : "ServerlessDeploymentBucket"
+          # Give permission to publish to the SNS SearchRequest topic in any
+          # region.
+          - PolicyName: gladly-${self:custom.stage}-search-request-log-role
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - sns:Publish
+                  Resource:
+                    - 'Fn::Join':
+                      - ':'
+                      -
+                        - 'arn:aws:sns:*' # allow in any region
+                        - Ref: 'AWS::AccountId'
+                        # SNS topic: SearchRequest or dev-SearchRequest
+                        - ${self:custom.searchRequestSNSTopicName}:${self:custom.stage}
 
 functions:
   # We manually reference the ARN of these Lambda@Edge functions in our

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -178,7 +178,7 @@ resources:
                         - 'arn:aws:sns:*' # allow in any region
                         - Ref: 'AWS::AccountId'
                         # SNS topic: SearchRequest or dev-SearchRequest
-                        - ${self:custom.searchRequestSNSTopicName}:${self:custom.stage}
+                        - ${self:custom.searchRequestSNSTopicName.${self:custom.stage}}
 
 functions:
   # We manually reference the ARN of these Lambda@Edge functions in our

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -291,6 +291,19 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     await handler(event)
     expect(searchURLByRegion).toHaveBeenCalledWith('MX', 'es')
   })
+
+  it('does not call SNS', async () => {
+    expect.assertions(2)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring =
+      'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
+    await handler(event)
+    const sns = new AWS.SNS()
+    expect(sns.publish).not.toHaveBeenCalled()
+    expect(sns.publish().promise).not.toHaveBeenCalled()
+  })
 })
 
 // Cloned and modified v2 tests, so we can just delete prior version tests

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -250,7 +250,7 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
       'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
-      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_ff.c_somecauseid.r_2468&p=pizza'
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_ff.c_someCauseId.r_2468&p=pizza'
     )
   })
 
@@ -413,7 +413,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
       'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
-      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_ff.c_somecauseid.r_2468&p=pizza'
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_ff.c_someCauseId.r_2468&p=pizza'
     )
   })
 

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -1,9 +1,18 @@
 /* eslint-env jest */
 
+import AWS from 'aws-sdk'
 import { clone } from 'lodash/lang'
 import { setWith } from 'lodash/object'
 import { getMockCloudFrontEventObject } from '../../utils/lambda-arg-utils'
 import searchURLByRegion from '../searchURLByRegion'
+
+jest.mock('aws-sdk', () => {
+  const mockSNS = {
+    publish: jest.fn().mockReturnThis(),
+    promise: jest.fn(),
+  }
+  return { SNS: jest.fn(() => mockSNS) }
+})
 
 jest.mock('../searchURLByRegion')
 
@@ -20,6 +29,7 @@ afterEach(() => {
 
 const searchV1Path = '/search/'
 const searchV2Path = '/search/v2'
+const searchV3Path = '/search/v3'
 const setEventURI = (event, uri) => {
   // Like `set` but immutable:
   // https://github.com/lodash/lodash/issues/1696#issuecomment-328335502
@@ -280,7 +290,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(2)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     const response = await handler(event)
     expect(response.status).toEqual('307')
     expect(response.statusDescription).toEqual('Found')
@@ -290,7 +300,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
       'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none'
@@ -312,7 +322,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'q=pizza'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -324,7 +334,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'q=pizza+palace'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -336,7 +346,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'q=pizza🍕'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -348,7 +358,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'hi=there&q=pizza&blah=foo'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -360,7 +370,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -372,7 +382,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=tab'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -384,7 +394,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'hi=there&c=abc123&q=pizza'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -396,7 +406,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring = 'hi=there&r=2468&q=pizza'
     const response = await handler(event)
     expect(response.headers.location[0].value).toEqual(
@@ -408,7 +418,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     expect.assertions(1)
     const { handler } = require('../search-app-lambda-edge')
     const defaultEvent = getMockCloudFrontEventObject()
-    const event = setEventURI(defaultEvent, searchV2Path)
+    const event = setEventURI(defaultEvent, searchV3Path)
     event.Records[0].cf.request.querystring =
       'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
     const response = await handler(event)
@@ -423,7 +433,7 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     const defaultEvent = getMockCloudFrontEventObject()
     const event = setHeader(
       setHeader(
-        setEventURI(defaultEvent, searchV2Path),
+        setEventURI(defaultEvent, searchV3Path),
         'cloudfront-viewer-country',
         'MX'
       ),
@@ -433,5 +443,41 @@ describe('v3: search app Lambda@Edge function on viewer-request', () => {
     event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
     await handler(event)
     expect(searchURLByRegion).toHaveBeenCalledWith('MX', 'es')
+  })
+
+  it('publishes to SNS once', async () => {
+    expect.assertions(2)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV3Path)
+    event.Records[0].cf.request.querystring =
+      'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
+    await handler(event)
+    const sns = new AWS.SNS()
+    expect(sns.publish).toHaveBeenCalledTimes(1)
+    expect(sns.publish().promise).toHaveBeenCalledTimes(1)
+  })
+
+  it('publishes to SNS with the expected message', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV3Path)
+    event.Records[0].cf.request.querystring =
+      'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
+    await handler(event)
+    const sns = new AWS.SNS()
+    const expectedMessage = JSON.stringify({
+      user: {
+        idToken: null,
+      },
+      data: {
+        src: 'ff',
+        engine: 'SearchForACause',
+        causeId: 'someCauseId',
+      },
+    })
+    const input = sns.publish.mock.calls[0][0]
+    expect(input.Message).toEqual(expectedMessage)
   })
 })

--- a/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
+++ b/lambda/src/search-app-lambda-edge/__tests__/search-app-lambda-edge.test.js
@@ -272,3 +272,166 @@ describe('v2: search app Lambda@Edge function on viewer-request', () => {
     expect(searchURLByRegion).toHaveBeenCalledWith('MX', 'es')
   })
 })
+
+// Cloned and modified v2 tests, so we can just delete prior version tests
+// when we no longer support the behavior.
+describe('v3: search app Lambda@Edge function on viewer-request', () => {
+  it('redirects with a 307 redirect', async () => {
+    expect.assertions(2)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    const response = await handler(event)
+    expect(response.status).toEqual('307')
+    expect(response.statusDescription).toEqual('Found')
+  })
+
+  it('redirects an empty search to Yahoo without a query string', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none'
+    )
+  })
+
+  it('uses the v2 API if the URI has a trailing slash', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, '/search/v2/')
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none'
+    )
+  })
+
+  it('sets the query string value if the "q" value is defined', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'q=pizza'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza'
+    )
+  })
+
+  it('sets the query string value if the "q" value is defined with a space character', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'q=pizza+palace'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza+palace'
+    )
+  })
+
+  it('sets the query string value if the "q" value is defined with a special character', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'q=pizza🍕'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza%F0%9F%8D%95'
+    )
+  })
+
+  it('only sets the "q" query string value, ignoring other unused URL params', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&blah=foo'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with an empty cause ID, source of search, and referral ID', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with a source', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza&src=tab'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_tab.c_none.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with a cause ID', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&c=abc123&q=pizza'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_abc123.r_none&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with a referral ID', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring = 'hi=there&r=2468&q=pizza'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_none.c_none.r_2468&p=pizza'
+    )
+  })
+
+  it('sets the "type" string with all fields', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setEventURI(defaultEvent, searchV2Path)
+    event.Records[0].cf.request.querystring =
+      'hi=there&r=2468&q=pizza&c=someCauseId&src=ff'
+    const response = await handler(event)
+    expect(response.headers.location[0].value).toEqual(
+      'https://search.yahoo.com/yhs/search?hspart=gladly&hsimp=yhs-001&type=src_ff.c_somecauseid.r_2468&p=pizza'
+    )
+  })
+
+  it('passes the expected header values to `searchURLByRegion`', async () => {
+    expect.assertions(1)
+    const { handler } = require('../search-app-lambda-edge')
+    const defaultEvent = getMockCloudFrontEventObject()
+    const event = setHeader(
+      setHeader(
+        setEventURI(defaultEvent, searchV2Path),
+        'cloudfront-viewer-country',
+        'MX'
+      ),
+      'accept-language',
+      'es'
+    )
+    event.Records[0].cf.request.querystring = 'hi=there&q=pizza'
+    await handler(event)
+    expect(searchURLByRegion).toHaveBeenCalledWith('MX', 'es')
+  })
+})

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -53,7 +53,8 @@ exports.handler = async event => {
   let searchSrc = null
   let causeId = null
 
-  // Get the function "version", which we use in manual QA.
+  // Get the function "version" from the endpoint, which we use to QA new
+  // functionality in production prior to rolling it out to users.
   const uri = get(event, 'Records[0].cf.request.uri', '')
   const defaultVersion = 1 // Bump this to "roll out" a new version
   let version

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -2,15 +2,37 @@
 // (but not `/search/api*`).
 /* eslint prefer-destructuring: 0 */
 
+import AWS from 'aws-sdk'
 import { get } from 'lodash/object'
 import searchURLByRegion from './searchURLByRegion'
+
+const PRODUCTION_STAGE = 'prod'
+
+const publishToSNS = async ({ stage, messageData }) => {
+  // Get the SNS topic ARN. Example:
+  //   "arn:aws:sns:eu-west-3:167811431063:dev-SearchRequest"
+  const awsRegion = process.env.AWS_REGION
+  const awsAccountId = '167811431063'
+  const snsTopicName = 'SearchRequest'
+  const snsTopicNamePrefix = stage === PRODUCTION_STAGE ? '' : 'dev-'
+  const snsTopicARN = `arn:aws:sns:${awsRegion}:${awsAccountId}:${snsTopicNamePrefix}${snsTopicName}`
+
+  // Publish.
+  const message = JSON.stringify(messageData)
+  const sns = new AWS.SNS()
+  const params = {
+    Message: message,
+    TopicArn: snsTopicARN,
+  }
+  await sns.publish(params).promise()
+}
 
 // Rewrites URIs from /search* to another search provider.
 // Examples of Lambda@Edge functions:
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-examples.html#lambda-examples-general-examples
 // CloudFront event object:
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
-exports.handler = (event, context, callback) => {
+exports.handler = async event => {
   const request = get(event, 'Records[0].cf.request')
   const SFAC_QUERY_QS_KEY = 'q'
   const params = new URLSearchParams(request.querystring.toLowerCase())
@@ -28,7 +50,22 @@ exports.handler = (event, context, callback) => {
   // Get the redirect destination URL.
   let searchBaseURL
   let searchProviderQueryKey
-  if (get(event, 'Records[0].cf.request.uri', '').startsWith('/search/v2')) {
+  let searchSrc = null
+  let causeId = null
+
+  // Get the function "version", which we use in manual QA.
+  const uri = get(event, 'Records[0].cf.request.uri', '')
+  const defaultVersion = 1 // Bump this to "roll out" a new version
+  let version
+  if (uri.startsWith('/search/v2')) {
+    version = 2
+  } else if (uri.startsWith('/search/v3')) {
+    version = 3
+  } else {
+    version = defaultVersion
+  }
+
+  if (version >= 2) {
     // For v2, use Yahoo for search results.
     searchProviderQueryKey = 'p'
 
@@ -45,10 +82,12 @@ exports.handler = (event, context, callback) => {
     // Yahoo does not allow using hyphens.
     //   e.g.: type=src_tab.c_CA6A5C2uj.r_482
     try {
-      const searchSrc = params.get('src') || 'none'
-      const causeId = params.get('c') || 'none'
-      const referralId = params.get('r') || 'none'
-      const typeParamVal = `src_${searchSrc}.c_${causeId}.r_${referralId}`
+      searchSrc = params.get('src') || null
+      causeId = params.get('c') || null
+      const referralId = params.get('r') || null
+      const NONE = 'none'
+      const typeParamVal = `src_${searchSrc || NONE}.c_${causeId ||
+        NONE}.r_${referralId || NONE}`
       const url = new URL(yahooBaseURL)
       url.searchParams.set('type', typeParamVal)
       searchBaseURL = url.href
@@ -71,6 +110,28 @@ exports.handler = (event, context, callback) => {
   }
   const redirectURL = baseURL.href
 
+  // Publish the search request event to SNS.
+  if (version >= 3) {
+    try {
+      const searchEngine = 'SearchForACause' // TODO: get from URL param later
+      const messageData = {
+        user: {
+          idToken: null, // TODO: get from cookie
+        },
+        data: {
+          src: searchSrc,
+          engine: searchEngine,
+          causeId,
+        },
+      }
+      await publishToSNS({ stage, messageData })
+    } catch (e) {
+      // TODO: add Sentry error logging.
+      // eslint-disable-next-line no-console
+      console.error(e)
+    }
+  }
+
   const response = {
     status: '307',
     statusDescription: 'Found',
@@ -89,5 +150,5 @@ exports.handler = (event, context, callback) => {
       ],
     },
   }
-  callback(null, response)
+  return response
 }

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -75,10 +75,12 @@ exports.handler = (event, context, callback) => {
     status: '307',
     statusDescription: 'Found',
     headers: {
-      'X-Tab-Debug-Stage': {
-        key: 'X-Tab-Debug-Stage',
-        value: stage,
-      },
+      'X-Tab-Debug-Stage': [
+        {
+          key: 'X-Tab-Debug-Stage',
+          value: stage,
+        },
+      ],
       location: [
         {
           key: 'Location',

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -35,7 +35,7 @@ const publishToSNS = async ({ stage, messageData }) => {
 exports.handler = async event => {
   const request = get(event, 'Records[0].cf.request')
   const SFAC_QUERY_QS_KEY = 'q'
-  const params = new URLSearchParams(request.querystring.toLowerCase())
+  const params = new URLSearchParams(request.querystring)
   const searchQueryVal = params.get(SFAC_QUERY_QS_KEY)
 
   // Get the deploy stage (ex: prod, dev, or test). We set the custom

--- a/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
+++ b/lambda/src/search-app-lambda-edge/search-app-lambda-edge.js
@@ -136,9 +136,9 @@ exports.handler = async event => {
     status: '307',
     statusDescription: 'Found',
     headers: {
-      'X-Tab-Debug-Stage': [
+      'x-tab-stage-debug': [
         {
-          key: 'X-Tab-Debug-Stage',
+          key: 'X-Tab-Stage-Debug',
           value: stage,
         },
       ],

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -322,9 +322,10 @@ resources:
                 - HEAD
                 - GET
                 - OPTIONS
-              # The origin isn't used for how we use this endpoint now, which
-              # is as a 307 redirect only. However, we do use the
-              # OriginCustomHeaders defined on the origin.
+              # The actual origin server isn't used currently because the
+              # associated Lambda@Edge function always returns a 307 redirect.
+              # However, we do rely on the OriginCustomHeaders defined on the
+              # origin.
               TargetOriginId: ${self:custom.searchAppName}
               ForwardedValues:
                 # Required to forward search query.

--- a/web/serverless.yml
+++ b/web/serverless.yml
@@ -132,6 +132,12 @@ resources:
                 # website endpoints:
                 # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginProtocolPolicy 
                 OriginProtocolPolicy: http-only
+              OriginCustomHeaders:
+                # We use custom headers as a workaround for the fact that
+                # Edge functions don't support environment variables. See:
+                # https://stackoverflow.com/a/58101487/1332513
+                - HeaderName: X-Tab-Stage
+                  HeaderValue: ${self:custom.stage}
             # GraphQL service.
             - DomainName: ${self:custom.graphQLProxyDomain}
               OriginPath: ${self:custom.graphQLProxyPath}
@@ -316,6 +322,9 @@ resources:
                 - HEAD
                 - GET
                 - OPTIONS
+              # The origin isn't used for how we use this endpoint now, which
+              # is as a 307 redirect only. However, we do use the
+              # OriginCustomHeaders defined on the origin.
               TargetOriginId: ${self:custom.searchAppName}
               ForwardedValues:
                 # Required to forward search query.


### PR DESCRIPTION
* For "version 3" of the search endpoint, call the SearchRequest SNS topic. Don't change this for existing production behavior for `/search/` or `/search/v2/`.
* Bug fix, affecting production search behavior: don't lowercase URL parameter values when passing dimensions to Yahoo. Doing so leads to bad cause IDs.
* For debugging: return an `X-Tab-Stage-Debug` response header that's the same as the `X-Tab-Stage` request header value. Remove this after manual QA in other deploy stages.