### PR TITLE
TFAC-1121: launch experiment to show SFAC icon to existing users

### DIFF
--- a/graphql/database/experiments/experimentConstants.js
+++ b/graphql/database/experiments/experimentConstants.js
@@ -1,8 +1,8 @@
+export const COLLEGE_AMBASSADOR_2022_NOTIF = 'college-ambassador-2022-notif'
 export const MONEY_RAISED_EXCLAMATION_POINT_V2 =
   'money-raised-exclamation-point-v2'
+export const SFAC_EXTENSION_PROMPT = 'sfac-extension-prompt'
+export const SUPPORTING_CAUSE_CHIP = 'supporting-cause-chip'
 export const YAHOO_SEARCH_NEW_USERS = 'yahoo-search-new-users'
 export const YAHOO_SEARCH_NEW_USERS_V2 = 'yahoo-search-new-users-v2'
 export const YAHOO_SEARCH_EXISTING_USERS = 'yahoo-search-existing-users'
-export const SUPPORTING_CAUSE_CHIP = 'supporting-cause-chip'
-export const SFAC_EXTENSION_PROMPT = 'sfac-extension-prompt'
-export const COLLEGE_AMBASSADOR_2022_NOTIF = 'college-ambassador-2022-notif'

--- a/graphql/database/experiments/experimentConstants.js
+++ b/graphql/database/experiments/experimentConstants.js
@@ -1,6 +1,8 @@
 export const COLLEGE_AMBASSADOR_2022_NOTIF = 'college-ambassador-2022-notif'
 export const MONEY_RAISED_EXCLAMATION_POINT_V2 =
   'money-raised-exclamation-point-v2'
+export const SFAC_EXISTING_USER_ACTIVITY_ICON =
+  'sfac-existing-user-activity-icon'
 export const SFAC_EXTENSION_PROMPT = 'sfac-extension-prompt'
 export const SUPPORTING_CAUSE_CHIP = 'supporting-cause-chip'
 export const YAHOO_SEARCH_NEW_USERS = 'yahoo-search-new-users'

--- a/graphql/database/experiments/features.js
+++ b/graphql/database/experiments/features.js
@@ -4,6 +4,7 @@ import {
   YAHOO_SEARCH_NEW_USERS,
   YAHOO_SEARCH_NEW_USERS_V2,
   SUPPORTING_CAUSE_CHIP,
+  SFAC_EXISTING_USER_ACTIVITY_ICON,
   SFAC_EXTENSION_PROMPT,
   COLLEGE_AMBASSADOR_2022_NOTIF,
 } from './experimentConstants'
@@ -177,6 +178,51 @@ const features = {
           },
           v4BetaEnabled: {
             $eq: true,
+          },
+        },
+      },
+    ],
+  },
+  [SFAC_EXISTING_USER_ACTIVITY_ICON]: {
+    defaultValue: 'Control',
+    rules: [
+      /* Begin internal overrides */
+      {
+        condition: {
+          v4BetaEnabled: {
+            $eq: true,
+          },
+          [`internalExperimentOverrides.${SFAC_EXISTING_USER_ACTIVITY_ICON}`]: {
+            $eq: 'Control',
+            $exists: true,
+          },
+        },
+        force: 'Control',
+      },
+      {
+        condition: {
+          v4BetaEnabled: {
+            $eq: true,
+          },
+          [`internalExperimentOverrides.${SFAC_EXISTING_USER_ACTIVITY_ICON}`]: {
+            $eq: 'Icon',
+            $exists: true,
+          },
+        },
+        force: 'Icon',
+      },
+      /* End internal overrides */
+      {
+        variations: ['Control', 'Icon'],
+        weights: [0.5, 0.5],
+        coverage: 0.5,
+        condition: {
+          v4BetaEnabled: {
+            $eq: true,
+          },
+          joined: {
+            // Users who joined after this in the experiment for new users.
+            $lte: SFAC_EXTENSION_PROMPT_CUTOFF_UNIX_TIME,
           },
         },
       },

--- a/graphql/database/users/__tests__/getShouldShowSfacIcon.test.js
+++ b/graphql/database/users/__tests__/getShouldShowSfacIcon.test.js
@@ -17,12 +17,15 @@ describe('getShouldShowSfacIcon tests', () => {
     expect.assertions(1)
 
     const getUserFeature = require('../../experiments/getUserFeature').default
-    getUserFeature.mockResolvedValueOnce(
-      new Feature({
-        featureName: SFAC_EXTENSION_PROMPT,
-        variation: 'Notification',
-      })
-    )
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXTENSION_PROMPT) {
+        return new Feature({
+          featureName: SFAC_EXTENSION_PROMPT,
+          variation: 'Notification',
+        })
+      }
+      return new Feature()
+    })
 
     const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
     const result = await getShouldShowSfacIcon(userContext, user)
@@ -33,12 +36,15 @@ describe('getShouldShowSfacIcon tests', () => {
     expect.assertions(1)
 
     const getUserFeature = require('../../experiments/getUserFeature').default
-    getUserFeature.mockResolvedValueOnce(
-      new Feature({
-        featureName: SFAC_EXTENSION_PROMPT,
-        variation: 'Control',
-      })
-    )
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXTENSION_PROMPT) {
+        return new Feature({
+          featureName: SFAC_EXTENSION_PROMPT,
+          variation: 'Control',
+        })
+      }
+      return new Feature()
+    })
 
     const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
     const result = await getShouldShowSfacIcon(userContext, user)

--- a/graphql/database/users/__tests__/getShouldShowSfacIcon.test.js
+++ b/graphql/database/users/__tests__/getShouldShowSfacIcon.test.js
@@ -1,5 +1,8 @@
 /* eslint-env jest */
-import { SFAC_EXTENSION_PROMPT } from '../../experiments/experimentConstants'
+import {
+  SFAC_EXISTING_USER_ACTIVITY_ICON,
+  SFAC_EXTENSION_PROMPT,
+} from '../../experiments/experimentConstants'
 import { getMockUserInstance, getMockUserContext } from '../../test-utils'
 import Feature from '../../experiments/FeatureModel'
 
@@ -13,7 +16,7 @@ beforeEach(() => {
 })
 
 describe('getShouldShowSfacIcon tests', () => {
-  it('returns false if the user is in the experiment but it is not dev', async () => {
+  it('returns true if the user is in the treatment group for the "new user SFAC notification" experiment', async () => {
     expect.assertions(1)
 
     const getUserFeature = require('../../experiments/getUserFeature').default
@@ -32,7 +35,7 @@ describe('getShouldShowSfacIcon tests', () => {
     expect(result).toEqual(true)
   })
 
-  it('returns false if the user is in not the experiment but it is dev', async () => {
+  it('returns false if the user is in the control group for the "new user SFAC notification" experiment', async () => {
     expect.assertions(1)
 
     const getUserFeature = require('../../experiments/getUserFeature').default
@@ -49,5 +52,68 @@ describe('getShouldShowSfacIcon tests', () => {
     const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
     const result = await getShouldShowSfacIcon(userContext, user)
     expect(result).toEqual(false)
+  })
+
+  it('returns true if the user is in the treatment group for the "existing user activity icon" experiment', async () => {
+    expect.assertions(1)
+
+    const getUserFeature = require('../../experiments/getUserFeature').default
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXISTING_USER_ACTIVITY_ICON) {
+        return new Feature({
+          featureName: SFAC_EXISTING_USER_ACTIVITY_ICON,
+          variation: 'Icon',
+        })
+      }
+      return new Feature()
+    })
+
+    const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
+    const result = await getShouldShowSfacIcon(userContext, user)
+    expect(result).toEqual(true)
+  })
+
+  it('returns false if the user is in the control group for the "existing user activity icon" experiment', async () => {
+    expect.assertions(1)
+
+    const getUserFeature = require('../../experiments/getUserFeature').default
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXISTING_USER_ACTIVITY_ICON) {
+        return new Feature({
+          featureName: SFAC_EXISTING_USER_ACTIVITY_ICON,
+          variation: 'Control',
+        })
+      }
+      return new Feature()
+    })
+
+    const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
+    const result = await getShouldShowSfacIcon(userContext, user)
+    expect(result).toEqual(false)
+  })
+
+  it('returns true if the user is in the treatment group for the "new user SFAC notification" experiment but in the control group for the "existing user activity icon" experiment', async () => {
+    expect.assertions(1)
+
+    const getUserFeature = require('../../experiments/getUserFeature').default
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXTENSION_PROMPT) {
+        return new Feature({
+          featureName: SFAC_EXTENSION_PROMPT,
+          variation: 'Notification',
+        })
+      }
+      if (featureName === SFAC_EXISTING_USER_ACTIVITY_ICON) {
+        return new Feature({
+          featureName: SFAC_EXISTING_USER_ACTIVITY_ICON,
+          variation: 'Control',
+        })
+      }
+      return new Feature()
+    })
+
+    const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
+    const result = await getShouldShowSfacIcon(userContext, user)
+    expect(result).toEqual(true)
   })
 })

--- a/graphql/database/users/__tests__/getShouldShowSfacIcon.test.js
+++ b/graphql/database/users/__tests__/getShouldShowSfacIcon.test.js
@@ -116,4 +116,54 @@ describe('getShouldShowSfacIcon tests', () => {
     const result = await getShouldShowSfacIcon(userContext, user)
     expect(result).toEqual(true)
   })
+
+  it('returns true if the user is in the control group for the "new user SFAC notification" experiment but in the treatment group for the "existing user activity icon" experiment', async () => {
+    expect.assertions(1)
+
+    const getUserFeature = require('../../experiments/getUserFeature').default
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXTENSION_PROMPT) {
+        return new Feature({
+          featureName: SFAC_EXTENSION_PROMPT,
+          variation: 'Control',
+        })
+      }
+      if (featureName === SFAC_EXISTING_USER_ACTIVITY_ICON) {
+        return new Feature({
+          featureName: SFAC_EXISTING_USER_ACTIVITY_ICON,
+          variation: 'Icon',
+        })
+      }
+      return new Feature()
+    })
+
+    const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
+    const result = await getShouldShowSfacIcon(userContext, user)
+    expect(result).toEqual(true)
+  })
+
+  it('returns false if the user is in the control group for both experiments', async () => {
+    expect.assertions(1)
+
+    const getUserFeature = require('../../experiments/getUserFeature').default
+    getUserFeature.mockImplementation((_userContext, _user, featureName) => {
+      if (featureName === SFAC_EXTENSION_PROMPT) {
+        return new Feature({
+          featureName: SFAC_EXTENSION_PROMPT,
+          variation: 'Control',
+        })
+      }
+      if (featureName === SFAC_EXISTING_USER_ACTIVITY_ICON) {
+        return new Feature({
+          featureName: SFAC_EXISTING_USER_ACTIVITY_ICON,
+          variation: 'Control',
+        })
+      }
+      return new Feature()
+    })
+
+    const getShouldShowSfacIcon = require('../getShouldShowSfacIcon').default
+    const result = await getShouldShowSfacIcon(userContext, user)
+    expect(result).toEqual(false)
+  })
 })

--- a/graphql/database/users/getShouldShowSfacIcon.js
+++ b/graphql/database/users/getShouldShowSfacIcon.js
@@ -1,13 +1,24 @@
-import { SFAC_EXTENSION_PROMPT } from '../experiments/experimentConstants'
+import {
+  SFAC_EXISTING_USER_ACTIVITY_ICON,
+  SFAC_EXTENSION_PROMPT,
+} from '../experiments/experimentConstants'
 import getUserFeature from '../experiments/getUserFeature'
 
 const getShouldShowSfacIcon = async (userContext, user) => {
-  const showSfacExtensionFeature = await getUserFeature(
+  const newUserSFACNotifFeature = await getUserFeature(
     userContext,
     user,
     SFAC_EXTENSION_PROMPT
   )
-  return showSfacExtensionFeature.variation === 'Notification'
+  const existingUserSFACIconFeature = await getUserFeature(
+    userContext,
+    user,
+    SFAC_EXISTING_USER_ACTIVITY_ICON
+  )
+  return (
+    newUserSFACNotifFeature.variation === 'Notification' ||
+    existingUserSFACIconFeature.variation === 'Icon'
+  )
 }
 
 export default getShouldShowSfacIcon


### PR DESCRIPTION
Before deploying, merge https://github.com/gladly-team/tab-web/pull/378 and #1334.