### PR TITLE
Add a default backgroundColor so app doesn't error

### DIFF
--- a/web/src/js/components/Background/BackgroundColorPickerComponent.js
+++ b/web/src/js/components/Background/BackgroundColorPickerComponent.js
@@ -13,6 +13,7 @@ class BackgroundColorPicker extends React.Component {
 
     this.state = {
       selectedColor: '#000',
+      backgroundColor: '#000000'
     }
   }
 


### PR DESCRIPTION
This PR Is meant to partially address issue #573 . It only addresses the backgroundColor, not the backgroundImage error, as I wasn't sure what placeholder you would want to use (perhaps the `brokenImage`?) or if you would want to do any refactoring of this section of the codebase from classes to hooks.