### PR TITLE
[TFAC-1023]: Test out a stronger "supporting" statement on the new tab page

### DIFF
--- a/graphql/data/schema.graphql
+++ b/graphql/data/schema.graphql
@@ -293,6 +293,9 @@ type Cause implements Node {
   """URL path for the landing page belonging to this cause"""
   landingPagePath: String!
 
+  """Phrase for the landing page belonging to this cause"""
+  landingPagePhrase: String!
+
   """Whether or not the current cause supports individual impact"""
   individualImpactEnabled: Boolean! @deprecated(reason: "Replaced by \"impactType\" field.")
 

--- a/graphql/data/schema.js
+++ b/graphql/data/schema.js
@@ -149,6 +149,7 @@ import getShouldShowSfacExtensionPrompt from '../database/users/getShouldShowSfa
 import getUserNotifications from '../database/users/getUserNotifications'
 import getSfacActivityState from '../database/users/getSfacActivityState'
 import getShouldShowSfacIcon from '../database/users/getShouldShowSfacIcon'
+import getLandingPagePhrase from '../database/users/getLandingPagePhrase'
 import {
   getImpactMetricById,
   getImpactMetricsByCharityId,
@@ -1105,6 +1106,11 @@ const CauseType = new GraphQLObjectType({
     landingPagePath: {
       type: new GraphQLNonNull(GraphQLString),
       description: `URL path for the landing page belonging to this cause`,
+    },
+    landingPagePhrase: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: `Phrase for the landing page belonging to this cause`,
+      resolve: (cause, _, context) => getLandingPagePhrase(context.user, cause),
     },
     individualImpactEnabled: {
       type: new GraphQLNonNull(GraphQLBoolean),

--- a/graphql/database/cause/CauseModel.js
+++ b/graphql/database/cause/CauseModel.js
@@ -182,12 +182,16 @@ class Cause extends DynamoDBModel {
         .string()
         .required()
         .description(
-          `the backgroundground Image Category to show by default for a cause`
+          `the background Image Category to show by default for a cause`
         ),
       landingPagePath: types
         .string()
         .required()
         .description(`URL path for the landing page belonging to this cause`),
+      landingPagePhrase: types
+        .string()
+        .required()
+        .description(`Phrase for the landing page belonging to this cause`),
       slug: types
         .string()
         .required()

--- a/graphql/database/cause/__tests__/CauseModel.test.js
+++ b/graphql/database/cause/__tests__/CauseModel.test.js
@@ -17,6 +17,7 @@ const getMockCauseObject = () => ({
   impactType: 'individual',
   impactVisits: 14,
   landingPagePath: '/cats/',
+  landingPagePhrase: 'This tab helps shelter cats',
   slug: 'cats',
   impact: {
     claimImpactSubtitle: 'paw',

--- a/graphql/database/cause/causes/blackEquity/causeData.js
+++ b/graphql/database/cause/causes/blackEquity/causeData.js
@@ -22,6 +22,7 @@ const data = {
   impactType: 'none',
   impactVisits: null,
   landingPagePath: '/black-equity/',
+  landingPagePhrase: 'This tab supports Black empowerment',
   slug: 'black-equity',
   onboarding: {
     steps: [

--- a/graphql/database/cause/causes/cats/causeData.js
+++ b/graphql/database/cause/causes/cats/causeData.js
@@ -31,6 +31,7 @@ const data = {
   impactType: 'individual',
   impactVisits: 14,
   landingPagePath: '/cats/',
+  landingPagePhrase: 'This tab helps shelter cats',
   slug: 'cats',
   impact: {
     claimImpactSubtitle,

--- a/graphql/database/cause/causes/endingHunger/causeData.js
+++ b/graphql/database/cause/causes/endingHunger/causeData.js
@@ -16,6 +16,7 @@ const data = {
   impactType: 'individual',
   impactVisits: 366,
   landingPagePath: '/ending-hunger/',
+  landingPagePhrase: 'This tab feeds the hungry',
   slug: 'ending-hunger',
   impact: {
     impactCounterText:

--- a/graphql/database/cause/causes/globalHealth/causeData.js
+++ b/graphql/database/cause/causes/globalHealth/causeData.js
@@ -16,6 +16,7 @@ const data = {
   impactType: 'individual',
   impactVisits: 131,
   landingPagePath: '/global-health/',
+  landingPagePhrase: 'This tab provides health care',
   slug: 'global-health',
   impact: {
     impactCounterText:

--- a/graphql/database/cause/causes/reproductiveHealthCauseData.js
+++ b/graphql/database/cause/causes/reproductiveHealthCauseData.js
@@ -16,6 +16,7 @@ const data = {
   impactType: 'none',
   impactVisits: null,
   landingPagePath: '/reproductive-health/',
+  landingPagePhrase: 'This tab helps Reproductive Health',
   slug: 'reproductive-health',
   onboarding: {
     steps: [

--- a/graphql/database/cause/causes/teamseas/causeData.js
+++ b/graphql/database/cause/causes/teamseas/causeData.js
@@ -30,6 +30,7 @@ const data = {
   impactType: 'individual',
   impactVisits: 10,
   landingPagePath: '/teamseas/',
+  landingPagePhrase: 'This tab protects the ocean',
   slug: 'teamseas',
   impact: {
     claimImpactSubtitle,

--- a/graphql/database/cause/causes/trees/causeData.js
+++ b/graphql/database/cause/causes/trees/causeData.js
@@ -16,6 +16,7 @@ const data = {
   impactType: 'individual',
   impactVisits: 196,
   landingPagePath: '/trees/',
+  landingPagePhrase: 'This tab plants trees',
   slug: 'trees',
   impact: {
     impactCounterText:

--- a/graphql/database/cause/causes/ukraine/causeData.js
+++ b/graphql/database/cause/causes/ukraine/causeData.js
@@ -16,6 +16,7 @@ const data = {
   impactType: 'individual',
   impactVisits: 13,
   landingPagePath: '/ukraine/',
+  landingPagePhrase: 'This tab supports Ukrainian families',
   slug: 'ukraine',
   impact: {
     impactCounterText:

--- a/graphql/database/experiments/experimentConstants.js
+++ b/graphql/database/experiments/experimentConstants.js
@@ -36,3 +36,6 @@ export const SFAC_EXTENSION_PROMPT_CUTOFF_UNIX_TIME = 1662494400000 // 20:00 UTC
 
 // Show third ad to v4 users
 export const V4_SHOW_THIRD_LOOKBACK_TIME = 1814400000 // 3 weeks
+
+// Test out stronger "supporting" statements : TFAC-1023
+export const V4_SUPPORTING_STATEMENTS = 'v4-supporting-statements'

--- a/graphql/database/experiments/features.js
+++ b/graphql/database/experiments/features.js
@@ -17,6 +17,7 @@ import {
   GLOBAL_HEALTH_GROUP_IMPACT,
   REDUCED_IMPACT_COST,
   NOTIF_SFAC_FEB_2023,
+  V4_SUPPORTING_STATEMENTS,
 } from './experimentConstants'
 
 const features = {
@@ -425,6 +426,43 @@ const features = {
         },
         force: true,
       },
+    ],
+  },
+  [V4_SUPPORTING_STATEMENTS]: {
+    defaultValue: 'Control',
+    rules: [
+      /* Begin internal overrides */
+      {
+        condition: {
+          env: {
+            $in: ['local', 'dev'],
+          },
+          [`internalExperimentOverrides.${V4_SUPPORTING_STATEMENTS}`]: {
+            $eq: 'Control',
+            $exists: true,
+          },
+        },
+        force: 'Control',
+      },
+      {
+        condition: {
+          env: {
+            $in: ['local', 'dev'],
+          },
+          [`internalExperimentOverrides.${V4_SUPPORTING_STATEMENTS}`]: {
+            $eq: 'Experiment',
+            $exists: true,
+          },
+        },
+        force: 'Experiment',
+      },
+      /* End internal overrides */
+      // {
+      //   variations: ['Control', 'Experiment'],
+      //   weights: [0.5, 0.5],
+      //   coverage: 1.0,
+      //   condition: {},
+      // },
     ],
   },
 }

--- a/graphql/database/test-utils.js
+++ b/graphql/database/test-utils.js
@@ -157,6 +157,8 @@ export const getMockCauseInstance = (attributes) => {
         charityId: 'abcdefghijklmnop',
         landingPagePath: '/test',
         impactVisits: 10,
+        name: 'cause name',
+        landingPagePhrase: 'test landing page phrase',
         impact: {
           impactCounterText: 'impactCounterText',
           claimImpactSubtitle: 'claimImpactSubtitle',

--- a/graphql/database/users/__tests__/getLandingPagePhrase.test.js
+++ b/graphql/database/users/__tests__/getLandingPagePhrase.test.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+
+import { V4_SUPPORTING_STATEMENTS } from '../../experiments/experimentConstants'
+
+import { getMockUserContext, getMockCauseInstance } from '../../test-utils'
+import getUserFeature from '../../experiments/getUserFeature'
+import Feature from '../../experiments/FeatureModel'
+
+jest.mock('../../experiments/getUserFeature')
+
+const cause = getMockCauseInstance()
+const userContext = getMockUserContext()
+
+describe('getLandingPagePhrase tests', () => {
+  it('returns control phrase', async () => {
+    expect.assertions(1)
+    const getLandingPagePhrase = require('../getLandingPagePhrase').default
+
+    getUserFeature.mockResolvedValueOnce(
+      new Feature({
+        featureName: V4_SUPPORTING_STATEMENTS,
+        variation: 'Control',
+      })
+    )
+
+    const result = await getLandingPagePhrase(userContext, cause)
+    expect(result).toEqual('Supporting: cause name')
+  })
+
+  it('returns experiment phrase', async () => {
+    expect.assertions(1)
+    const getLandingPagePhrase = require('../getLandingPagePhrase').default
+
+    getUserFeature.mockResolvedValueOnce(
+      new Feature({
+        featureName: V4_SUPPORTING_STATEMENTS,
+        variation: 'Experiment',
+      })
+    )
+
+    const result = await getLandingPagePhrase(userContext, cause)
+    expect(result).toEqual('test landing page phrase')
+  })
+})

--- a/graphql/database/users/getLandingPagePhrase.js
+++ b/graphql/database/users/getLandingPagePhrase.js
@@ -1,0 +1,19 @@
+import { V4_SUPPORTING_STATEMENTS } from '../experiments/experimentConstants'
+import getUserFeature from '../experiments/getUserFeature'
+import UserModel from './UserModel'
+
+const getLandingPagePhrase = async (userContext, cause) => {
+  const user = await UserModel.get(userContext, userContext.id)
+
+  const feature = await getUserFeature(
+    userContext,
+    user,
+    V4_SUPPORTING_STATEMENTS
+  )
+
+  return feature.variation === 'Experiment'
+    ? cause.landingPagePhrase
+    : `Supporting: ${cause.name}`
+}
+
+export default getLandingPagePhrase

--- a/web/data/schema.graphql
+++ b/web/data/schema.graphql
@@ -293,6 +293,9 @@ type Cause implements Node {
   """URL path for the landing page belonging to this cause"""
   landingPagePath: String!
 
+  """Phrase for the landing page belonging to this cause"""
+  landingPagePhrase: String!
+
   """Whether or not the current cause supports individual impact"""
   individualImpactEnabled: Boolean! @deprecated(reason: "Replaced by \"impactType\" field.")
 


### PR DESCRIPTION
We want to test a more direct statement on the tab v4 page “chip”:

Added the new field to cause, built out new experiment. 