### PR TITLE
Fixed small bug with 404 page showing up in shop auth flow

### DIFF
--- a/web/src/js/components/Shop/ShopComponent.js
+++ b/web/src/js/components/Shop/ShopComponent.js
@@ -69,10 +69,10 @@ const ShopComponent = ({ user, classes }) => {
     if (uri) {
       localStorageMgr.removeItem(STORAGE_REDIRECT_URI)
       goTo(uri + (user.userId ? `?uuid=${user.userId}` : ''))
-      return
+      return null
     } else {
       goTo('/newtab')
-      return
+      return null
     }
   }
 

--- a/web/src/js/components/Shop/__tests__/ShopComponent.test.js
+++ b/web/src/js/components/Shop/__tests__/ShopComponent.test.js
@@ -18,7 +18,7 @@ jest.mock('@material-ui/core/styles', () => {
 
 describe('Shop component', () => {
   it('redirect if user is logged and has a cause and no STORAGE_REDIRECT_URI', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
     const ShopComponent = require('js/components/Shop/ShopComponent').default
     const mockProps = {
       user: {
@@ -27,12 +27,13 @@ describe('Shop component', () => {
       },
       style: {},
     }
-    await shallow(<ShopComponent {...mockProps} />)
+    const wrapper = await shallow(<ShopComponent {...mockProps} />)
+    expect(wrapper).toBe(null)
     expect(goTo).toHaveBeenCalledWith('/newtab')
   })
 
   it('redirect if user is logged and has a cause and has STORAGE_REDIRECT_URI', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const localStorageMock = (() => {
       let store = {}
@@ -57,7 +58,8 @@ describe('Shop component', () => {
       },
       style: {},
     }
-    await shallow(<ShopComponent {...mockProps} />)
+    const wrapper = await shallow(<ShopComponent {...mockProps} />)
+    expect(wrapper).toBe(null)
     expect(goTo).toHaveBeenCalledWith('http://www.google.com?uuid=abc123')
   })
 })


### PR DESCRIPTION
There was an issue when we redirected the user out of the shop auth flow that a 404 page would show up. We needed to return null instead of nothing.