### PR TITLE
Fixed issue where errors were being thrown on no causeId

### DIFF
--- a/graphql/database/cause/__tests__/getCauseByUser.test.js
+++ b/graphql/database/cause/__tests__/getCauseByUser.test.js
@@ -97,4 +97,99 @@ describe('getCauseByUser', () => {
       'The database does not contain an item with these keys.'
     )
   })
+
+  it('set user to a default cause if they are v4BetaEnabled and have no cause', async () => {
+    expect.assertions(1)
+    const userContext = getMockUserContext()
+    const userId = userContext.id
+    const mockUser = getMockUserInstance({
+      id: userId,
+      v4BetaEnabled: true,
+      causeId: 'no-cause',
+    })
+
+    const UserModel = require('../../users/UserModel').default
+    jest.spyOn(UserModel, 'get').mockResolvedValue(mockUser)
+    const userModelUpdate = jest.spyOn(UserModel, 'update').mockResolvedValue(
+      getMockUserInstance({
+        id: userId,
+        causeId: 'CA6A5C2uj',
+      })
+    )
+
+    const getCauseByUser = require('../getCauseByUser').default
+    await getCauseByUser(userContext, userId)
+
+    expect(userModelUpdate).toHaveBeenCalledWith(userContext, {
+      id: userId,
+      causeId: 'CA6A5C2uj',
+    })
+  })
+
+  it('does not update update cause if they are v4BetaEnabled is not true and have no cause', async () => {
+    expect.assertions(1)
+    const userContext = getMockUserContext()
+    const userId = userContext.id
+    const mockUser = getMockUserInstance({
+      id: userId,
+      v4BetaEnabled: false,
+      causeId: 'no-cause',
+    })
+
+    const UserModel = require('../../users/UserModel').default
+    jest.spyOn(UserModel, 'get').mockResolvedValue(mockUser)
+    const userModelUpdate = jest
+      .spyOn(UserModel, 'update')
+      .mockResolvedValue({})
+
+    const getCauseByUser = require('../getCauseByUser').default
+    await getCauseByUser(userContext, userId)
+
+    expect(userModelUpdate).not.toHaveBeenCalled()
+  })
+
+  it('does not update update cause if they are v4BetaEnabled is true but causeId is set to a cause id', async () => {
+    expect.assertions(1)
+    const userContext = getMockUserContext()
+    const userId = userContext.id
+    const mockUser = getMockUserInstance({
+      id: userId,
+      v4BetaEnabled: true,
+      causeId: 'CA6A5C2uj',
+    })
+
+    const UserModel = require('../../users/UserModel').default
+    jest.spyOn(UserModel, 'get').mockResolvedValue(mockUser)
+    const userModelUpdate = jest
+      .spyOn(UserModel, 'update')
+      .mockResolvedValue({})
+
+    const getCauseByUser = require('../getCauseByUser').default
+    await getCauseByUser(userContext, userId)
+
+    expect(userModelUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns null if the user has v4BetaEnabled set to false (legacy user) and cause is set to no-cause', async () => {
+    expect.assertions(2)
+    const userContext = getMockUserContext()
+    const userId = userContext.id
+    const mockUser = getMockUserInstance({
+      id: userId,
+      v4BetaEnabled: false,
+      causeId: 'no-cause',
+    })
+
+    const UserModel = require('../../users/UserModel').default
+    jest.spyOn(UserModel, 'get').mockResolvedValue(mockUser)
+    const userModelUpdate = jest
+      .spyOn(UserModel, 'update')
+      .mockResolvedValue({})
+
+    const getCauseByUser = require('../getCauseByUser').default
+    const rt = await getCauseByUser(userContext, userId)
+
+    expect(rt).toBe(null)
+    expect(userModelUpdate).not.toHaveBeenCalled()
+  })
 })

--- a/graphql/database/cause/getCauseByUser.js
+++ b/graphql/database/cause/getCauseByUser.js
@@ -13,11 +13,33 @@ const CATS_CAUSE_ID = 'CA6A5C2uj'
 
 const getCauseByUser = async (userContext, userId) => {
   let user = await UserModel.get(userContext, userId)
+
+  // TODO(spicer): I don't think we need this anymore but we should confirm
   if (user.causeId === DEPRECATED_CATS_CAUSE_ID) {
     user = await UserModel.update(userContext, {
       causeId: CATS_CAUSE_ID,
     })
   }
+
+  // This is a temporary fix for users who were created with v4BetaEnabled
+  // But never got their causeId set to a cause
+  if (
+    user.v4BetaEnabled &&
+    user.v4BetaEnabled === true &&
+    user.causeId === 'no-cause'
+  ) {
+    user = await UserModel.update(userContext, {
+      id: userId, // need to include this or we get permission denied
+      causeId: CATS_CAUSE_ID,
+    })
+  }
+
+  // If we still have no causeId this likely is a legacy user or
+  // someone is in the sign up process and the cause does not mater.
+  if (user.causeId === 'no-cause') {
+    return null
+  }
+
   return getCause(user.causeId)
 }
 


### PR DESCRIPTION
Fixed issue where errors were being thrown on no causeId. 

This issues was caused by removing the default of cats being the causeId. 

Now if a user is using v4 and does not have a causeId set it will add the cat's cause id to their profile. If they are a legacy user and not v4 we return null when cause is looked up.

TODO(spicer): make 'no-cause' a constant some where. Just did not know quickly where to put this.