### PR TITLE
Update edge function to support the new shop auth flow.

### DIFF
--- a/lambda/package.json
+++ b/lambda/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "start": "nodemon -e js,json,yml --exec \"babel-node\" ./server.js",
-    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v && cp serverless-lambda-edge.yml serverless.yml && serverless deploy -v ",
+    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v && cp serverless-lambda-edge.yml serverless.yml && serverless deploy --verbose ",
     "build": "rm -rf ./build && npm run build:transpile",
     "build:transpile": "babel-node ./scripts/build.js",
     "test": "npm-run-all -s lint test:run test:codecov",

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -7,8 +7,7 @@
 # Serverless also does not support customizing the yml filename,
 # so we just cp the file before deploying.
 # https://github.com/serverless/serverless/issues/4473
-service:
-  name: lambda-edge # Important: this must be unique in AWS Cloudformation!
+service: lambda-edge # Important: this must be unique in AWS Cloudformation!
 frameworkVersion: ">=3.24.1 <4.0.0"
 
 provider:

--- a/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
+++ b/lambda/src/newtab-app-lambda-edge/newtab-app-lambda-edge.js
@@ -32,6 +32,7 @@ exports.handler = (event, context, callback) => {
   // If this is an auth page, or an auth page resource with a referrer
   // from an auth page, always use the legacy Tab app until the auth
   // functionality in Tab v4 is complete.
+  // TEST SPICER
   const USE_LEGACY_APP_FOR_AUTH = true
 
   let showLegacyAuthPage = false


### PR DESCRIPTION
Just like auth with newtab/shop we need to make sure all requests go to legacy. This PR updates our cloudfront edge function to support this. 