### PR TITLE
Removed pattern matching when building lambda

### DIFF
--- a/lambda/package.json
+++ b/lambda/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "start": "nodemon -e js,json,yml --exec \"babel-node\" ./server.js",
-    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy -v && cp serverless-lambda-edge.yml serverless.yml && serverless deploy --verbose ",
+    "deploy": "yarn run build && cp serverless-lambda.yml serverless.yml && serverless deploy --verbose && cp serverless-lambda-edge.yml serverless.yml && serverless deploy --verbose ",
     "build": "rm -rf ./build && npm run build:transpile",
     "build:transpile": "babel-node ./scripts/build.js",
     "test": "npm-run-all -s lint test:run test:codecov",

--- a/lambda/serverless-lambda-edge.yml
+++ b/lambda/serverless-lambda-edge.yml
@@ -106,18 +106,6 @@ custom:
     dev: dev-SearchRequest
     prod: SearchRequest
 
-# Don't include any dependencies by default. CloudFront-triggered Lambdas
-# have stricter package size limitations.
-# https://www.serverless.com/framework/docs/providers/aws/guide/packaging/
-package:
-  patterns:
-    - '!./**'
-    - build/**
-    - node_modules/@aws-sdk/**
-    - node_modules/accept-language-parser/**
-    - node_modules/cookie/**
-    - node_modules/lodash/**
-
 # We are using a custom role (building on the default Serverless role)
 # so that we can add edgelambda.amazonaws.com as a trust provider.
 # Custom IAM roles:


### PR DESCRIPTION
Lambda use to have a 25meg limit. It recently has been updated to 50megs. This makes it so we no longer have to limit our build size. We were having issues where all dependencies where not uploading.