### PR TITLE
Add Kagi as search engine option

### DIFF
--- a/dynamodb/fixtures/WidgetsData.json
+++ b/dynamodb/fixtures/WidgetsData.json
@@ -19,7 +19,7 @@
         "field": "engine",
         "type": "choices",
         "display": "Search engine",
-        "choices": ["Google", "Bing", "DuckDuckGo", "Ecosia"],
+        "choices": ["Google", "Bing", "DuckDuckGo", "Ecosia", "Kagi"],
         "defaultValue": "Google"
       }
     ],

--- a/graphql/database/search/searchEngineData.js
+++ b/graphql/database/search/searchEngineData.js
@@ -52,6 +52,14 @@ export const searchEngineData = [
     isCharitable: false,
     inputPrompt: 'Search Yahoo',
   },
+  {
+    name: 'Kagi',
+    id: 'Kagi',
+    searchUrl: 'https://kagi.com/search?q={searchTerms}',
+    rank: 6,
+    isCharitable: false,
+    inputPrompt: 'Search Kagi',
+  },
 ]
 
 export const VALID_SEARCH_ENGINES = searchEngineData.map((data) => data.id)

--- a/graphql/integration-tests/fixtures/Widgets.json
+++ b/graphql/integration-tests/fixtures/Widgets.json
@@ -17,7 +17,7 @@
         "field": "engine",
         "type": "choices",
         "display": "Search engine",
-        "choices": ["Google", "Bing", "DuckDuckGo", "Ecosia"],
+        "choices": ["Google", "Bing", "DuckDuckGo", "Ecosia", "Kagi"],
         "defaultValue": "Google"
       }
     ]

--- a/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsComponent.test.js
+++ b/web/src/js/components/Settings/Widgets/__tests__/WidgetsSettingsComponent.test.js
@@ -74,7 +74,7 @@ const getMockYahooDemoProps = () => ({
             name: 'Search',
             type: 'search',
             settings:
-              '[{"field":"engine","type":"choices","choices":["Google","Bing","DuckDuckGo","Ecosia"],"defaultValue":"Google","display":"Search engine"}]',
+              '[{"field":"engine","type":"choices","choices":["Google","Bing","DuckDuckGo","Ecosia", "Kagi"],"defaultValue":"Google","display":"Search engine"}]',
           },
         },
       ],
@@ -90,7 +90,7 @@ const getMockYahooDemoProps = () => ({
             name: 'Search',
             enabled: true,
             settings:
-              '[{"field":"engine","type":"choices","choices":["Google","Bing","DuckDuckGo","Ecosia"],"defaultValue":"Google","display":"Search engine"}]',
+              '[{"field":"engine","type":"choices","choices":["Google","Bing","DuckDuckGo","Ecosia","Kagi"],"defaultValue":"Google","display":"Search engine"}]',
           },
         },
       ],

--- a/web/src/js/components/Widget/Widgets/Search/Search.js
+++ b/web/src/js/components/Widget/Widgets/Search/Search.js
@@ -124,6 +124,8 @@ class Search extends React.Component {
         return 'https://www.ecosia.org/search?q='
       case 'Yahoo':
         return 'https://search.yahoo.com/search;?q='
+      case 'Kagi':
+        return 'https://kagi.com/search?q='
       default:
         return 'https://www.google.com/search?q='
     }

--- a/web/src/js/components/Widget/Widgets/Search/__tests__/Search.test.js
+++ b/web/src/js/components/Widget/Widgets/Search/__tests__/Search.test.js
@@ -35,7 +35,7 @@ function getMockProps() {
       data: JSON.stringify({}),
       settings: JSON.stringify([
         {
-          choices: ['Google', 'Bing', 'DuckDuckGo', 'Ecosia'],
+          choices: ['Google', 'Bing', 'DuckDuckGo', 'Ecosia', 'Kagi'],
           defaultValue: 'Google',
           display: 'Search engine',
           field: 'engine',
@@ -61,7 +61,7 @@ function getMockYahooProps() {
       data: JSON.stringify({}),
       settings: JSON.stringify([
         {
-          choices: ['Yahoo', 'Bing', 'DuckDuckGo', 'Ecosia'],
+          choices: ['Yahoo', 'Bing', 'DuckDuckGo', 'Ecosia', 'Kagi'],
           defaultValue: 'Yahoo',
           display: 'Search engine',
           field: 'engine',


### PR DESCRIPTION
## Summary

- Added Kagi string to search choices in the widget files for DynamoDB and GraphQL as well as some `web` tests
- Added Kagi metadata to the GraphQL `searchEngineData` file and the `getSearchApi()` function on the `Search` class

## Links

- [Kagi docs on search URL](https://help.kagi.com/kagi/getting-started/setting-default.html#custom_use)

## Notes

- I was able to run `yarn run test:run` successfully on `web`
- It's my first contribution here so let me know if I'm missing any relevant details or context