### PR TITLE
Add URL parameter support for ad provider selection

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -17,6 +17,25 @@
     <script>
         ;
         (function(w, d) {
+            // Check for URL parameter to set ad provider preference
+            function checkAndSetAdProviderFromURL() {
+                var BUCKET_KEY = 'tab_ad_provider_bucket'
+                
+                try {
+                    // Parse URL parameters
+                    var urlParams = new URLSearchParams(w.location.search)
+                    var adsParam = urlParams.get('ads')
+                    
+                    // If ads parameter is present and valid, update localStorage
+                    if (adsParam === 'buysellads' || adsParam === 'raptive') {
+                        localStorage.setItem(BUCKET_KEY, adsParam)
+                        console.log('[Ad Provider] Set via URL parameter: ' + adsParam)
+                    }
+                } catch (e) {
+                    console.error('Failed to process URL parameter:', e)
+                }
+            }
+            
             // A/B Test: Determine which ad provider to use
             function getAdProviderBucket() {
                 var BUCKET_KEY = 'tab_ad_provider_bucket'
@@ -29,9 +48,10 @@
                 }
 
                 // TESTING MODE: Always default to 'raptive' unless manually set
-                // To test Buy/Sell Ads, run in console:
+                // To test Buy/Sell Ads via URL: ?ads=buysellads
+                // To test Raptive via URL: ?ads=raptive
+                // Or set via console:
                 // localStorage.setItem('tab_ad_provider_bucket', 'buysellads')
-                // To switch back to Raptive:
                 // localStorage.setItem('tab_ad_provider_bucket', 'raptive')
                 // Or clear: localStorage.removeItem('tab_ad_provider_bucket')
                 if (!bucket) {
@@ -60,9 +80,12 @@
 
             // Check if the current pathname is '/newtab/'
             if (w.location.pathname === '/newtab/') {
+                // Check URL parameters first to see if we need to update the ad provider
+                checkAndSetAdProviderFromURL()
+                
                 var adBucket = getAdProviderBucket()
                 console.log('[Ad Provider] Current bucket:', adBucket, 
-                    '| Testing mode - Use localStorage.setItem("tab_ad_provider_bucket", "buysellads") to test Buy/Sell Ads')
+                    '| Testing mode - Use ?ads=buysellads or ?ads=raptive in URL to switch')
 
                 if (adBucket === 'raptive') {
                     // Load Raptive Ads (90% of users)


### PR DESCRIPTION
## Summary
Adds URL parameter support to easily switch between ad providers during testing phase.

## What's New
- **URL Parameter Support**: Can now use `?ads=buysellads` or `?ads=raptive` to set the ad provider
- **Automatic Persistence**: URL parameter updates localStorage for subsequent visits
- **Testing Mode Maintained**: Still defaults to Raptive unless explicitly overridden

## How It Works
1. When the page loads, it checks for an `ads` URL parameter
2. If present and valid (`buysellads` or `raptive`), it updates localStorage
3. The stored preference persists across page loads until changed or cleared

## Testing Instructions

### Via URL Parameters (New!)
- **Enable Buy/Sell Ads**: Visit `/newtab/?ads=buysellads`
- **Enable Raptive**: Visit `/newtab/?ads=raptive`
- The parameter only needs to be used once - preference is saved

### Via Console (Still Works)
```javascript
// Enable Buy/Sell Ads
localStorage.setItem('tab_ad_provider_bucket', 'buysellads')

// Enable Raptive
localStorage.setItem('tab_ad_provider_bucket', 'raptive')

// Clear preference (defaults to Raptive)
localStorage.removeItem('tab_ad_provider_bucket')
```

## Console Output
The page logs which provider is active:
```
[Ad Provider] Set via URL parameter: buysellads
[Ad Provider] Current bucket: buysellads | Testing mode - Use ?ads=buysellads or ?ads=raptive in URL to switch
```

## Important Notes
- Still in **testing mode** - production A/B test logic remains commented out
- Defaults to Raptive if no preference is set
- URL parameter method makes testing more convenient for non-technical users
- All existing functionality preserved

## Technical Changes
- Added `checkAndSetAdProviderFromURL()` function to parse URL parameters
- Updated console messages to reflect new URL parameter option
- Modified comments to include URL parameter instructions