### PR TITLE
Fix #142: Turn off BSA and move to Raptive for everything

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -14,156 +14,28 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <!--
-      Ad Provider A/B Test: Raptive (90%) vs Buy/Sell Ads (10%)
+      Raptive Ad Provider - loads on newtab page
     -->
     <script>
       ;(function(w, d) {
-        // Check for URL parameter to set ad provider preference
-        function checkAndSetAdProviderFromURL() {
-          var BUCKET_KEY = 'tab_ad_provider_bucket_v2'
-
-          try {
-            // Parse URL parameters
-            var urlParams = new URLSearchParams(w.location.search)
-            var adsParam = urlParams.get('ads')
-
-            // If ads parameter is present and valid, update localStorage
-            if (adsParam === 'buysellads' || adsParam === 'raptive') {
-              localStorage.setItem(BUCKET_KEY, adsParam)
-              console.log('[Ad Provider] Set via URL parameter: ' + adsParam)
-            }
-          } catch (e) {
-            console.error('Failed to process URL parameter:', e)
-          }
-        }
-
-        // A/B Test: Determine which ad provider to use
-        function getAdProviderBucket() {
-          var BUCKET_KEY = 'tab_ad_provider_bucket_v2'
-          var bucket = null
-
-          try {
-            bucket = localStorage.getItem(BUCKET_KEY)
-          } catch (e) {
-            console.error('Failed to access localStorage:', e)
-          }
-
-          // To test Buy/Sell Ads via URL: ?ads=buysellads
-          // To test Raptive via URL: ?ads=raptive
-          // Or set via console:
-          // localStorage.setItem('tab_ad_provider_bucket', 'buysellads')
-          // localStorage.setItem('tab_ad_provider_bucket', 'raptive')
-          // Or clear: localStorage.removeItem('tab_ad_provider_bucket')
-          if (!bucket) {
-            // Generate random bucket (0-99)
-            // 0-49 (50%) = buysellads, 50-99 (50%) = raptive
-            var randomValue = Math.floor(Math.random() * 100)
-            bucket = randomValue < 50 ? 'buysellads' : 'raptive'
-
-            try {
-              localStorage.setItem(BUCKET_KEY, bucket)
-            } catch (e) {
-              console.error('Failed to save to localStorage:', e)
-              // Default to raptive if localStorage fails
-              bucket = 'raptive'
-            }
-          }
-
-          return bucket
-        }
-
-        // Function to send log to Better Stack
-        function sendBetterStackLog(adBucket) {
-          try {
-            var timestamp = new Date().toISOString()
-            var logData = {
-              dt: timestamp,
-              message: 'Ad bucket selected: ' + adBucket,
-              ad_bucket: adBucket,
-              page: 'newtab',
-            }
-
-            // Send the log request
-            var xhr = new XMLHttpRequest()
-            xhr.open(
-              'POST',
-              'https://s1506080.eu-nbg-2.betterstackdata.com',
-              true
-            )
-            xhr.setRequestHeader('Content-Type', 'application/json')
-            xhr.setRequestHeader(
-              'Authorization',
-              'Bearer WTPPGq3DeQX21uKuHhyTseMN'
-            )
-            xhr.send(JSON.stringify(logData))
-
-            console.log('[Better Stack] Logging ad bucket:', adBucket)
-          } catch (e) {
-            console.error('[Better Stack] Failed to send log:', e)
-          }
-        }
-
-        // Check if the current pathname is '/newtab/'
+        // Load Raptive ads on the newtab page
         if (w.location.pathname === '/newtab/') {
-          // Check URL parameters first to see if we need to update the ad provider
-          checkAndSetAdProviderFromURL()
-
-          var adBucket = getAdProviderBucket()
-          console.log(
-            '[Ad Provider] Current bucket:',
-            adBucket,
-            '| Testing mode - Use ?ads=buysellads or ?ads=raptive in URL to switch'
-          )
-
-          // Send log to Better Stack with 500ms delay to not block ads
-          setTimeout(function() {
-            sendBetterStackLog(adBucket)
-          }, 500)
-
-          if (adBucket === 'raptive') {
-            // Load Raptive Ads (90% of users)
-            w.adthrive = w.adthrive || {}
-            w.adthrive.cmd = w.adthrive.cmd || []
-            w.adthrive.plugin = 'adthrive-ads-manual'
-            w.adthrive.host = 'ads.adthrive.com'
-            var s = d.createElement('script')
-            s.async = true
-            s.referrerpolicy = 'no-referrer-when-downgrade'
-            s.src =
-              'https://' +
-              w.adthrive.host +
-              '/sites/655cd66352dfc71af0778a48/ads.min.js?referrer=' +
-              w.encodeURIComponent(w.location.href) +
-              '&cb=' +
-              (Math.floor(Math.random() * 100) + 1)
-            var n = d.getElementsByTagName('script')[0]
-            n.parentNode.insertBefore(s, n)
-          } else if (adBucket === 'buysellads') {
-            ;(function() {
-              var bsa_optimize = document.createElement('script')
-              bsa_optimize.type = 'text/javascript'
-              bsa_optimize.async = true
-              bsa_optimize.src =
-                'https://cdn4.buysellads.net/pub/gladly.js?' +
-                (new Date() - (new Date() % 600000))
-              ;(
-                document.getElementsByTagName('head')[0] ||
-                document.getElementsByTagName('body')[0]
-              ).appendChild(bsa_optimize)
-            })()
-
-            window.optimize = window.optimize || { queue: [] }
-
-            window.optimize.queue.push(() => {
-              window.optimize.customTargeting.push({
-                key: 'cause',
-                value: 'legacy',
-              })
-              window.optimize.pushAll()
-            })
-          }
-        } else {
-          console.log('Ads not loaded: not on newtab page')
+          w.adthrive = w.adthrive || {}
+          w.adthrive.cmd = w.adthrive.cmd || []
+          w.adthrive.plugin = 'adthrive-ads-manual'
+          w.adthrive.host = 'ads.adthrive.com'
+          var s = d.createElement('script')
+          s.async = true
+          s.referrerpolicy = 'no-referrer-when-downgrade'
+          s.src =
+            'https://' +
+            w.adthrive.host +
+            '/sites/655cd66352dfc71af0778a48/ads.min.js?referrer=' +
+            w.encodeURIComponent(w.location.href) +
+            '&cb=' +
+            (Math.floor(Math.random() * 100) + 1)
+          var n = d.getElementsByTagName('script')[0]
+          n.parentNode.insertBefore(s, n)
         }
       })(window, document)
     </script>

--- a/web/src/js/components/Dashboard/DashboardComponent.js
+++ b/web/src/js/components/Dashboard/DashboardComponent.js
@@ -216,46 +216,6 @@ class Dashboard extends React.Component {
       browser: detectSupportedBrowser(),
     })
     this.updateState()
-
-    // Initialize optimize for BuySellAds zones
-    this.initializeOptimize()
-  }
-
-  /**
-   * Initialize the optimize script for BuySellAds ad zones
-   * This pushes the zone IDs to the optimize queue for ad optimization
-   * Only runs when BuySellAds is the active ad provider
-   */
-  initializeOptimize() {
-    // Check if we're using BuySellAds as the ad provider
-    const BUCKET_KEY = 'tab_ad_provider_bucket'
-    let adProviderBucket = null
-
-    try {
-      adProviderBucket = localStorage.getItem(BUCKET_KEY)
-    } catch (e) {
-      console.error('Failed to access localStorage for ad provider check:', e)
-      return
-    }
-
-    // Only initialize optimize if we're using BuySellAds
-    if (adProviderBucket !== 'buysellads') {
-      console.log(
-        '[Ad Provider] Not using BuySellAds, skipping optimize initialization'
-      )
-      return
-    }
-
-    // // Ensure window.optimize exists
-    // window.optimize = window.optimize || { queue: [] }
-
-    // // Push both BSA zones to the optimize queue
-    // window.optimize.queue.push(function() {
-    //   window.optimize.push('bsa-zone_1754918740585-0_123456')
-    //   window.optimize.push('bsa-zone_1755538933410-5_123456')
-    // })
-
-    // console.log('[Ad Provider] Initialized optimize for BuySellAds zones')
   }
 
   componentWillReceiveProps(nextProps) {
@@ -1273,10 +1233,6 @@ class Dashboard extends React.Component {
               overflow: 'visible',
             }}
           >
-            <div id="bsa-zone_1754918740585-0_123456" />
-
-            <div id="bsa-zone_1755538933410-5_123456" />
-
             <div
               id="raptive-content-ad-1"
               style={{


### PR DESCRIPTION
## Summary
- Removed the BSA vs Raptive A/B test infrastructure from `index.html` — Raptive now loads directly for all `/newtab/` users without any bucket selection or localStorage-based split
- Removed BSA script loading (`cdn4.buysellads.net/pub/gladly.js`) and the associated `window.optimize` queue setup
- Removed Better Stack A/B test logging (XHR to `betterstackdata.com`) since the test is over
- Removed BSA zone divs (`bsa-zone_*`) from `DashboardComponent.js`
- Removed the `initializeOptimize()` method that was only used for BSA zones

## Notes
- **Login page ads** and **Pause for a Cause page ads** are not part of this codebase's current routing — those may need separate work or coordination with Raptive to set up their tags on those pages
- The Raptive ad loading script is already async and inserted at the top of `<head>` for fast loading

## Test plan
- [ ] Verify Raptive ads load on the new tab page
- [ ] Verify no BSA scripts are loaded (check network tab for `buysellads.net`)
- [ ] Verify no Better Stack A/B test logging requests are made
- [ ] Confirm `localStorage` key `tab_ad_provider_bucket_v2` is no longer being set for new users

Closes gladly-team/tab-v5#142