### PR TITLE
Disable Upstash-backed Group Impact feature

### DIFF
--- a/graphql/database/base/RedisModel.js
+++ b/graphql/database/base/RedisModel.js
@@ -1,167 +1,107 @@
-// eslint-disable-next-line import/no-unresolved
-import { Redis } from '@upstash/redis/with-fetch'
 import Model from './Model'
-import config from '../../config'
 import {
-  DatabaseConditionalCheckFailedException,
   DatabaseItemDoesNotExistException,
   FieldDoesNotExistException,
   UnauthorizedQueryException,
 } from '../../utils/exceptions'
-import types from '../fieldTypes'
 
+// Upstash/Redis-backed models are disabled.
+//
+// Every method below is a no-op so that (a) no new keys are written to Upstash
+// and (b) callers that still try to read from a RedisModel get a
+// "not found" response they already know how to handle
+// (DatabaseItemDoesNotExistException is caught by the Group Impact helpers and
+// by Model.getOrNull, which returns null).
+//
+// Leaving the models and their subclasses in place means the feature can be
+// re-enabled later by restoring the real Upstash-backed implementation of this
+// file (see git history).
 class RedisModel extends Model {
+  // Intentionally unused; no real client is instantiated while Upstash is
+  // disabled. Kept so legacy callers referencing this symbol don't break.
   static getClient() {
-    const client = new Redis({
-      url: config.UPSTASH_REDIS_REST_URL,
-      token: config.UPSTASH_REDIS_REST_TOKEN,
-    })
-
-    return client
+    return null
   }
 
-  static async getInternal(key) {
-    const redisClient = this.getClient()
-    const redisKey = this.getRedisKey(key)
-    const item = await redisClient.hgetall(redisKey)
-    if (item === null) {
-      throw new DatabaseItemDoesNotExistException()
-    }
-
-    return this.postProcessObject(item)
+  // Read: always report "not found" so callers' existing not-found handling
+  // (try/catch on DatabaseItemDoesNotExistException, or Model.getOrNull)
+  // kicks in and the caller degrades to null / default data.
+  static async getInternal() {
+    throw new DatabaseItemDoesNotExistException()
   }
 
+  // Batched read: same semantics as getInternal for every requested key.
   static async getBatchInternal(keys) {
-    const items = keys.map((key) => this.getInternal(key))
+    const items = keys.map(() => this.getInternal())
     return Promise.all(items)
   }
 
-  static async createInternal(item, overwrite = false) {
-    const redisClient = this.getClient()
-    const redisKey = this.getRedisKey(item[this.hashKey])
-    if (!overwrite) {
-      const existingEntry = await redisClient.hgetall(redisKey)
-      if (existingEntry !== null) {
-        throw new DatabaseConditionalCheckFailedException()
-      }
-    }
-
-    const result = await redisClient
-      .multi()
-      .hset(redisKey, item)
-      .hgetall(redisKey)
-      .exec()
-    return this.postProcessObject(result.slice(-1)[0])
+  // Write: silently accept the item without persisting it. Returned value
+  // mirrors what callers expect (wrapped via postProcessObject) so downstream
+  // code that reads fields off the result does not crash.
+  static async createInternal(item) {
+    return this.postProcessObject(item)
   }
 
+  // Write: silently accept the update. See createInternal for why we return
+  // a postProcessObject-wrapped value.
   static async updateInternal(item) {
-    const redisClient = this.getClient()
-    const redisKey = this.getRedisKey(item[this.hashKey])
-    const existingEntry = await redisClient.hgetall(redisKey)
-    if (existingEntry === null) {
-      throw new DatabaseItemDoesNotExistException()
-    }
-
-    const result = await redisClient
-      .multi()
-      .hset(redisKey, item)
-      .hgetall(redisKey)
-      .exec()
-    return this.postProcessObject(result.slice(-1)[0])
+    return this.postProcessObject(item)
   }
 
+  // Write (single field): preserve authz + schema checks so any callers that
+  // rely on those exceptions still see consistent behavior, but do not
+  // persist anything.
   static async updateField(userContext, id, field, value) {
     if (!this.isQueryAuthorized(userContext, 'update', id)) {
       throw new UnauthorizedQueryException()
     }
-
     if (this.schema[field] === undefined) {
       throw new FieldDoesNotExistException()
     }
-
-    const redisKey = this.getRedisKey(id)
-    const redisClient = this.getClient()
-    const result = await redisClient.hget(redisKey, field)
-
-    if (result === null) {
-      throw new DatabaseItemDoesNotExistException()
-    }
-
-    const obj = {}
-    obj[field] = value
-    await redisClient.hset(redisKey, obj)
     return this.validateAndConvertField(field, value)
   }
 
-  static async updateIntegerFieldBy(userContext, id, field, increment) {
+  // Write (integer increment): preserve authz + schema checks for
+  // consistency; no persistence.
+  static async updateIntegerFieldBy(userContext, id, field) {
     if (!this.isQueryAuthorized(userContext, 'update', id)) {
       throw new UnauthorizedQueryException()
     }
-
-    if (types.number().integer().validate(increment).error) {
-      throw new Error('Increment amount should be an integer')
-    }
-
     if (this.schema[field] === undefined) {
       throw new FieldDoesNotExistException()
     }
-
-    const redisKey = this.getRedisKey(id)
-    const redisClient = this.getClient()
-    const result = await redisClient.hget(redisKey, field)
-
-    if (result === null) {
-      throw new DatabaseItemDoesNotExistException()
-    }
-
-    if (types.number().integer().validate(result).error) {
-      throw new Error('Field to update should be an integer')
-    }
-
-    await redisClient.hincrby(redisKey, field, increment)
-    const resultingValue = await redisClient.hget(redisKey, field)
-    return this.validateAndConvertField(field, resultingValue)
+    return 0
   }
 
+  // Read (single field): report "not found" so callers fall back to their
+  // missing-field handling.
   static async getField(userContext, id, field) {
-    const redisClient = this.getClient()
     if (!this.isQueryAuthorized(userContext, 'get', id)) {
       throw new UnauthorizedQueryException()
     }
-
     if (this.schema[field] === undefined) {
       throw new FieldDoesNotExistException()
     }
-
-    const redisKey = this.getRedisKey(id)
-    const result = await redisClient.hget(redisKey, field)
-    if (result === null) {
-      throw new DatabaseItemDoesNotExistException()
-    }
-
-    return this.validateAndConvertField(field, result)
+    throw new DatabaseItemDoesNotExistException()
   }
 
-  static async delete(key) {
-    const redisClient = this.getClient()
-    const redisKey = this.getRedisKey(key)
-    const item = await redisClient.del(redisKey)
-
-    if (item === 0) {
-      throw new DatabaseItemDoesNotExistException()
-    }
+  // Delete: no-op. With nothing written to Upstash there is nothing to delete.
+  static async delete() {
+    // no-op
   }
 
-  // Wraps the object in the expected format for Model.js.
+  // Wraps the object in the expected { attrs } shape so callers reading the
+  // return value of create/update/get keep working.
   static async postProcessObject(dataPromise) {
-    const rawObject = await dataPromise
+    const rawObject = (await dataPromise) || {}
     return {
       attrs: this.validateAndConvertObject(rawObject),
     }
   }
 
-  // Validates each field on an object. Also makes sure that
-  // objects are cast to their correct types.
+  // Validates each field on an object. Also casts values to their declared
+  // schema types.
   static validateAndConvertObject(rawObject) {
     const objectToReturn = Object.assign({}, rawObject)
     Object.keys(objectToReturn).forEach((field) => {
@@ -173,18 +113,20 @@ class RedisModel extends Model {
     return objectToReturn
   }
 
+  // Validates/casts a single field value against its schema.
   static validateAndConvertField(field, fieldValue) {
     if (this.schema[field]) {
       const validateResult = this.schema[field].validate(fieldValue, {
         convert: true,
       })
-      // todo: @jedtan Implement Solution here for RedisModels
-      // https://github.com/hapijs/joi/issues/1442
       return validateResult.value
     }
     return fieldValue
   }
 
+  // Kept for test utilities that still reference the Upstash key format
+  // (e.g., cleanup helpers that call client.del(getRedisKey(...))). They will
+  // no longer be used against real Upstash but we keep the shape stable.
   static getRedisKey(hashKey) {
     return `${this.name}_${hashKey}`
   }

--- a/graphql/database/base/__tests__/RedisModel-queries.test.js
+++ b/graphql/database/base/__tests__/RedisModel-queries.test.js
@@ -55,7 +55,9 @@ afterEach(async () => {
   await client.del(ExampleRedisModel.getRedisKey(testId))
 })
 
-describe('RedisModel queries', () => {
+// RedisModel is a no-op while Upstash is disabled; the live-client queries
+// this suite exercised are no longer meaningful.
+describe.skip('RedisModel queries', () => {
   it('RedisModel does not implement getAll', async () => {
     setModelPermissions(ExampleRedisModel, {
       getAll: () => true,

--- a/graphql/database/groupImpact/GroupImpactLeaderboard.js
+++ b/graphql/database/groupImpact/GroupImpactLeaderboard.js
@@ -1,146 +1,39 @@
-// eslint-disable-next-line import/no-unresolved
-import { Redis } from '@upstash/redis/with-fetch'
 import { CAUSE_GROUP_IMPACT_LEADERBOARD } from '../constants'
-import config from '../../config'
-import UserModel from '../users/UserModel'
-import UserGroupImpactMetricModel from './UserGroupImpactMetricModel'
-import {
-  GROUP_IMPACT_OVERRIDE,
-  getPermissionsOverride,
-} from '../../utils/permissions-overrides'
 
-const groupImpactOverride = getPermissionsOverride(GROUP_IMPACT_OVERRIDE)
-
+// Upstash-backed Group Impact leaderboard is disabled.
+//
+// All reads return an empty leaderboard and all writes are no-ops so no new
+// keys (CauseGroupImpactLeaderboard_*) are created in Upstash. The class
+// interface is preserved so callers compile and run unchanged.
 class GroupImpactLeaderboard {
+  // Name is preserved for any external code / logs that read it.
   static get name() {
     return CAUSE_GROUP_IMPACT_LEADERBOARD
   }
 
+  // Intentionally unused; no real Upstash client is instantiated while the
+  // leaderboard is disabled.
   static getClient() {
-    const client = new Redis({
-      url: config.UPSTASH_REDIS_REST_URL,
-      token: config.UPSTASH_REDIS_REST_TOKEN,
-    })
-
-    return client
+    return null
   }
 
-  static async add(groupImpactId, userId, contribution) {
-    const redisClient = this.getClient()
-    const redisKey = this.getRedisKey(groupImpactId)
-
-    return redisClient.zadd(redisKey, { member: userId, score: contribution })
+  // Write: adds a user's contribution to the leaderboard sorted set. Disabled
+  // so nothing is persisted.
+  static async add() {
+    // no-op
   }
 
-  static async getLeaderboardForUser(userGroupImpactMetricId, userId) {
-    // This will fail if redis does not have data.
-    try {
-      const userGroupImpactMetricModel = await UserGroupImpactMetricModel.get(
-        groupImpactOverride,
-        userGroupImpactMetricId
-      )
-
-      const redisClient = this.getClient()
-      const redisKey = this.getRedisKey(
-        userGroupImpactMetricModel.groupImpactMetricId
-      )
-
-      // Get Top 3 users
-      const topUsers = await redisClient.zrange(redisKey, 0, 2, { rev: true })
-      // Get user's position
-      const currentPosition = await redisClient.zrevrank(redisKey, userId)
-
-      let nextUsers = []
-      let userPositions = []
-
-      // Get users around user
-
-      if (currentPosition < 3) {
-        // If user in top 3, just get next 3 users
-        nextUsers = await redisClient.zrange(redisKey, 3, 5, { rev: true })
-        for (let i = 0; i < nextUsers.length + topUsers.length; i += 1) {
-          userPositions.push(i + 1)
-        }
-      } else {
-        const lowerBound = Math.max(3, currentPosition - 1)
-        nextUsers = await redisClient.zrange(
-          redisKey,
-          lowerBound,
-          lowerBound + 2,
-          { rev: true }
-        )
-        if (nextUsers.length === 1) {
-          userPositions = [1, 2, 3, lowerBound + 1]
-        } else if (nextUsers.length === 2) {
-          userPositions = [1, 2, 3, lowerBound + 1, lowerBound + 2]
-        } else if (nextUsers.length === 3)
-          userPositions = [
-            1,
-            2,
-            3,
-            lowerBound + 1,
-            lowerBound + 2,
-            lowerBound + 3,
-          ]
-      }
-
-      const potentialUsers = [...topUsers, ...nextUsers]
-      // Safety check to ensure we don't fetch duplicate users
-      const [dedupedUsers, dedupedUserPositions] = this.removeDuplicates(
-        potentialUsers,
-        userPositions
-      )
-      const userModels = await UserModel.getBatchInOrder(
-        groupImpactOverride,
-        dedupedUsers
-      )
-      const userGroupImpactModels = await this.fetchGroupImpactMetricModels(
-        userModels
-      )
-
-      return dedupedUserPositions
-        .map((element, index) => ({
-          user: userModels[index],
-          position: element,
-          userGroupImpactMetric: userGroupImpactModels[index],
-        }))
-        .filter((elem) => elem.user && elem.userGroupImpactMetric)
-    } catch (e) {
-      return []
-    }
+  // Read: returns the leaderboard entries surrounding a given user. With the
+  // leaderboard disabled we return an empty list; the GraphQL resolver and
+  // frontend already handle the empty-list case.
+  static async getLeaderboardForUser() {
+    return []
   }
 
-  static async fetchGroupImpactMetricModels(userModels) {
-    const userGroupImpactMetricIds = userModels
-      .filter((element) => element) // TODO(spicer): figure out why some elements are undefined
-      .map((User) => User.userGroupImpactMetricId)
-
-    return UserGroupImpactMetricModel.getBatch(
-      groupImpactOverride,
-      userGroupImpactMetricIds
-    )
-  }
-
+  // Preserved so test utilities that reference the Upstash key format still
+  // resolve. Not used against real Upstash anymore.
   static getRedisKey(hashKey) {
     return `${this.name}_${hashKey}`
-  }
-
-  static removeDuplicates(listA, listB) {
-    const seen = {}
-    const deduplicatedListA = []
-    const deduplicatedListB = []
-
-    for (let i = 0; i < listA.length; i += 1) {
-      const currentItem = listA[i]
-
-      if (!seen[currentItem]) {
-        deduplicatedListA.push(currentItem)
-        deduplicatedListB.push(listB[i])
-        seen[currentItem] = true
-      }
-    }
-
-    return [deduplicatedListA, deduplicatedListB]
   }
 }
 

--- a/graphql/database/groupImpact/__tests__/GroupImpactLeaderboard.test.js
+++ b/graphql/database/groupImpact/__tests__/GroupImpactLeaderboard.test.js
@@ -18,7 +18,8 @@ afterEach(async () => {
   client.clear()
 })
 
-describe('GroupImpactLeaderboard entity', () => {
+// Group Impact (Upstash-backed) is disabled; this suite is skipped.
+describe.skip('GroupImpactLeaderboard entity', () => {
   it('Add inserts into redis client', async () => {
     const val = 5
     GroupImpactLeaderboard.add('key', 'entity', val)

--- a/graphql/database/groupImpact/__tests__/getCauseImpactMetricCount.test.js
+++ b/graphql/database/groupImpact/__tests__/getCauseImpactMetricCount.test.js
@@ -25,7 +25,8 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('getCauseImpactMetricCount', () => {
+// Group Impact (Upstash-backed) is disabled; this suite is skipped.
+describe.skip('getCauseImpactMetricCount', () => {
   it('returns null if fetching group impact metric returns null', async () => {
     expect.assertions(1)
     getGroupImpactMetricForCause.mockResolvedValue(null)

--- a/graphql/database/groupImpact/__tests__/getGroupImpactMetricForCause.test.js
+++ b/graphql/database/groupImpact/__tests__/getGroupImpactMetricForCause.test.js
@@ -32,7 +32,8 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('getGroupImpactMetricForCause', () => {
+// Group Impact (Upstash-backed) is disabled; this suite is skipped.
+describe.skip('getGroupImpactMetricForCause', () => {
   it('throws if fetching CauseGroupImpactMetric has unexpected error', async () => {
     expect.assertions(1)
     CauseGroupImpactMetricModel.get.mockImplementation(() => {

--- a/graphql/database/groupImpact/__tests__/incrementCauseImpactMetricCount.test.js
+++ b/graphql/database/groupImpact/__tests__/incrementCauseImpactMetricCount.test.js
@@ -44,7 +44,8 @@ afterEach(async () => {
   )
 })
 
-describe('incrementCauseImpactMetricCount tests', () => {
+// Group Impact (Upstash-backed) is disabled; this suite is skipped.
+describe.skip('incrementCauseImpactMetricCount tests', () => {
   it('updates count if exists', async () => {
     await CauseImpactMetricCountModel.create(groupImpactOverride, {
       id: `${causeId}_${impactMetricId}`,

--- a/graphql/database/groupImpact/__tests__/updateGroupImpactMetric.test.js
+++ b/graphql/database/groupImpact/__tests__/updateGroupImpactMetric.test.js
@@ -67,7 +67,8 @@ afterEach(async () => {
   await client.del(GroupImpactMetricModel.getRedisKey(mockTestNanoId))
 })
 
-describe('updateGroupImpactMetric tests', () => {
+// Group Impact (Upstash-backed) is disabled; this suite is skipped.
+describe.skip('updateGroupImpactMetric tests', () => {
   it('creates correct instances of CauseGroupImpactMetricModel, GroupImpactMetricModel if both do not exist (tab)', async () => {
     await updateGroupImpactMetric(userContext, causeId, 'tab')
     const joinEntity = await CauseGroupImpactMetricModel.get(

--- a/graphql/database/groupImpact/__tests__/updateUserGroupImpactMetric.test.js
+++ b/graphql/database/groupImpact/__tests__/updateUserGroupImpactMetric.test.js
@@ -60,7 +60,8 @@ const getGroupImpactMetric = () => ({
   dateStarted: moment.utc().toISOString(),
 })
 
-describe('updateUserGroupImpactMetric tests', () => {
+// Group Impact (Upstash-backed) is disabled; this suite is skipped.
+describe.skip('updateUserGroupImpactMetric tests', () => {
   it('creates correct instances of UserGroupImpactMetricModel if both do not exist', async () => {
     const user = getMockUserInstance()
     const groupImpactMetric = getGroupImpactMetric()

--- a/graphql/database/users/__tests__/logSearch.test.js
+++ b/graphql/database/users/__tests__/logSearch.test.js
@@ -151,7 +151,8 @@ describe('logSearch', () => {
     )
   })
 
-  test('it updates group impact if applicable', async () => {
+  // Group Impact (Upstash-backed) is disabled; this assertion no longer applies.
+  test.skip('it updates group impact if applicable', async () => {
     expect.assertions(2)
 
     const userId = userContext.id

--- a/graphql/database/users/__tests__/logTab.test.js
+++ b/graphql/database/users/__tests__/logTab.test.js
@@ -1219,7 +1219,8 @@ describe('campaign: estimating money raised', () => {
     await expect(logTab(userContext, userId)).rejects.toEqual(mockErr)
   })
 
-  describe('correctly updates group impact if applicable', () => {
+  // Group Impact (Upstash-backed) is disabled; these assertions no longer apply.
+  describe.skip('correctly updates group impact if applicable', () => {
     it('does nothing if user is not part of a cause', async () => {
       expect.assertions(3)
       const userId = userContext.id

--- a/graphql/database/users/__tests__/rewardReferringUser.test.js
+++ b/graphql/database/users/__tests__/rewardReferringUser.test.js
@@ -232,7 +232,9 @@ describe('rewardReferringUser', () => {
     expect(updateUserGroupImpactMetric).not.toHaveBeenCalled()
   })
 
-  it.only('updates user group impact metric if group impact metric', async () => {
+  // Group Impact (Upstash-backed) is disabled; this assertion no longer applies.
+  // Note: removing the lingering `.only` here re-enables the rest of the suite.
+  it.skip('updates user group impact metric if group impact metric', async () => {
     expect.assertions(1)
 
     const userContext = getMockUserContext()

--- a/graphql/database/users/logSearch.js
+++ b/graphql/database/users/logSearch.js
@@ -8,10 +8,8 @@ import getUserSearchEngine from './getUserSearchEngine'
 import getSearchEngine from '../search/getSearchEngine'
 import getCause from '../cause/getCause'
 import { DatabaseItemDoesNotExistException } from '../../utils/exceptions'
-import getCauseByUser from '../cause/getCauseByUser'
-import { CAUSE_IMPACT_TYPES } from '../constants'
-import updateGroupImpactMetric from '../groupImpact/updateGroupImpactMetric'
-import updateUserGroupImpactMetric from '../groupImpact/updateUserGroupImpactMetric'
+// Group Impact (Upstash-backed) is disabled. Imports removed so logSearch no
+// longer triggers Upstash reads/writes. See PR that disabled Group Impact.
 
 // const PRODUCTION_STAGE = 'prod'
 
@@ -71,27 +69,7 @@ const logSearchKnownUser = async (userContext, userId, searchData) => {
     throw e
   }
 
-  if (user.v4BetaEnabled) {
-    const cause = await getCauseByUser(userContext, userId)
-
-    if (
-      cause &&
-      (cause.impactType === CAUSE_IMPACT_TYPES.group ||
-        cause.impactType === CAUSE_IMPACT_TYPES.individual_and_group)
-    ) {
-      const groupImpactMetric = await updateGroupImpactMetric(
-        userContext,
-        cause.id,
-        'search'
-      )
-      await updateUserGroupImpactMetric(
-        userContext,
-        user,
-        groupImpactMetric,
-        'search'
-      )
-    }
-  }
+  // Group Impact tracking disabled (Upstash-backed).
 
   // Update the user's counter for max searches in a day.
   // If this is the user's first search today, reset the counter

--- a/graphql/database/users/logTab.js
+++ b/graphql/database/users/logTab.js
@@ -17,10 +17,8 @@ import { getEstimatedMoneyRaisedPerTab } from '../globals/globals'
 import getCurrentUserMission from '../missions/getCurrentUserMission'
 import completeMission from '../missions/completeMission'
 import logger from '../../utils/logger'
-import getCauseByUser from '../cause/getCauseByUser'
-import { CAUSE_IMPACT_TYPES } from '../constants'
-import updateGroupImpactMetric from '../groupImpact/updateGroupImpactMetric'
-import updateUserGroupImpactMetric from '../groupImpact/updateUserGroupImpactMetric'
+// Group Impact (Upstash-backed) is disabled. Imports removed so logTab no
+// longer triggers Upstash reads/writes. See PR that disabled Group Impact.
 
 // const PRODUCTION_STAGE = 'prod'
 
@@ -231,26 +229,7 @@ const logTab = async (userContext, userId, tabId = null, isV4 = true) => {
     }
   }
 
-  if (user.v4BetaEnabled) {
-    const cause = await getCauseByUser(userContext, userId)
-    if (
-      cause &&
-      (cause.impactType === CAUSE_IMPACT_TYPES.group ||
-        cause.impactType === CAUSE_IMPACT_TYPES.individual_and_group)
-    ) {
-      const groupImpactMetric = await updateGroupImpactMetric(
-        userContext,
-        cause.id,
-        'tab'
-      )
-      await updateUserGroupImpactMetric(
-        userContext,
-        user,
-        groupImpactMetric,
-        'tab'
-      )
-    }
-  }
+  // Group Impact tracking disabled (Upstash-backed).
 
   // TODO(spicer): Pull into a separate library.
   // Publish to Brandfluence SNS topic.

--- a/graphql/database/users/rewardReferringUser.js
+++ b/graphql/database/users/rewardReferringUser.js
@@ -14,8 +14,8 @@ import {
 import addVc from './addVc'
 import addUsersRecruited from './addUsersRecruited'
 import { DatabaseItemDoesNotExistException } from '../../utils/exceptions'
-import updateUserGroupImpactMetric from '../groupImpact/updateUserGroupImpactMetric'
-import getGroupImpactMetricForCause from '../groupImpact/getGroupImpactMetricForCause'
+// Group Impact (Upstash-backed) is disabled. Imports removed so this
+// function no longer triggers Upstash reads/writes.
 
 const override = getPermissionsOverride(REWARD_REFERRER_OVERRIDE)
 
@@ -130,21 +130,7 @@ const rewardReferringUser = async (userContext, userId) => {
   try {
     await addVc(override, referringUserId, USER_REFERRAL_VC_REWARD)
     await addUsersRecruited(referringUserId, 1)
-    const referringUser = await UserModel.get(override, referringUserId)
-    if (referringUser.v4BetaEnabled) {
-      const groupImpactMetric = await getGroupImpactMetricForCause(
-        userContext,
-        referringUser.causeId
-      )
-      if (groupImpactMetric) {
-        await updateUserGroupImpactMetric(
-          userContext,
-          referringUser,
-          groupImpactMetric,
-          'referral'
-        )
-      }
-    }
+    // Group Impact tracking disabled (Upstash-backed).
   } catch (e) {
     throw e
   }


### PR DESCRIPTION
## Summary

Disables every read and write to Upstash so the keys there can be deleted without the backend re-creating them. All Upstash usage in this codebase is the Group Impact feature, which the frontend no longer uses.

- Removed the `updateGroupImpactMetric` / `updateUserGroupImpactMetric` / `getGroupImpactMetricForCause` call sites in `logTab`, `logSearch`, and `rewardReferringUser` so the hot paths never touch Upstash.
- Short-circuited `RedisModel` so every read throws `DatabaseItemDoesNotExistException` (callers already handle this via try/catch or `getOrNull`) and every write is a no-op returning an empty wrapped object. No Upstash client is instantiated.
- Short-circuited `GroupImpactLeaderboard` so `add()` is a no-op and `getLeaderboardForUser()` returns `[]` (the GraphQL resolver already handles the empty-list case).
- Skipped the Group Impact test suites that exercise Upstash / the real `RedisModel` client, plus the group-impact assertions inside `logTab` / `logSearch` / `rewardReferringUser` tests. Removing the lingering `it.only` in `rewardReferringUser` re-enables the rest of that suite.

## What's preserved

- GraphQL schema types, resolvers, and all model files — so the feature can be re-enabled later by restoring `RedisModel.js` and `GroupImpactLeaderboard.js` to their previous implementations (see git history).
- `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` env vars in `.env`, `.travis.yml`, `config.js`.

## Behavior after merge

- No new keys written to Upstash under any prefix (`GroupImpactMetric_*`, `CauseGroupImpactMetric_*`, `CauseImpactMetricCount_*`, `UserGroupImpactMetric_*`, `CauseGroupImpactLeaderboard_*`).
- GraphQL fields `userGroupImpactMetric`, `leaderboard`, `groupImpactMetric`, `groupImpactMetricCount` resolve to `null` / `[]`.
- Safe to delete all Upstash keys after this deploys — nothing will recreate them.

## Out of scope

- `graphql/utils/redis.js` / `redis/src/handler.js` (the campaign `REDIS_SERVICE_ENDPOINT`-based self-hosted Redis). Not Upstash, not touched here.

## Test plan

- [ ] CI passes — `yarn run graphql:test` should show the Group Impact suites as skipped, everything else green.
- [ ] Deploy to dev and confirm the Upstash dashboard shows no new writes after a tab/search/referral.
- [ ] Delete Upstash keys (dev first, then prod).
- [ ] Confirm frontend still renders without the Group Impact fields and no errors surface in the GraphQL logs.